### PR TITLE
Restructure repo and add docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# magic-combat
+# Magic Combat
+
+This project contains a very early skeleton for a small combat simulator inspired
+by trading card games such as *Magic: The Gathering*.
+
+At this stage only the module layout and a couple of stub classes exist. The
+actual combat logic is intentionally left unimplemented and will be developed in
+future iterations.
+
+## Repository layout
+
+```
+magic_combat/       Core package containing combat code
+magic_combat/creature.py     Basic ``CombatCreature`` dataclass
+magic_combat/simulator.py    ``CombatSimulator`` and ``CombatResult`` stubs
+```
+
+## Development
+
+1. Install the requirements
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Run the test suite
+
+```bash
+pytest
+```
+
+The current tests simply verify that the package can be imported and that the
+stubs are callable.

--- a/magic_combat/__init__.py
+++ b/magic_combat/__init__.py
@@ -1,0 +1,10 @@
+"""Core package for the Magic Combat simulator."""
+
+from .creature import CombatCreature
+from .simulator import CombatResult, CombatSimulator
+
+__all__ = [
+    "CombatCreature",
+    "CombatResult",
+    "CombatSimulator",
+]

--- a/magic_combat/creature.py
+++ b/magic_combat/creature.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+
+@dataclass
+class CombatCreature:
+    """Simplified representation of a creature during combat."""
+
+    name: str
+    power: int
+    toughness: int
+    first_strike: bool = False
+    double_strike: bool = False
+
+    def __str__(self) -> str:
+        return f"{self.name} ({self.power}/{self.toughness})"

--- a/magic_combat/simulator.py
+++ b/magic_combat/simulator.py
@@ -1,17 +1,25 @@
-from typing import List, Dict, Optional
-from dataclasses import dataclass
+"""Core simulation logic for the combat phase."""
 
-# Assume CombatCreature is already imported from above
+from dataclasses import dataclass
+from typing import Dict, List
+
+from .creature import CombatCreature
 
 @dataclass
 class CombatResult:
+    """Outcome of combat after resolution."""
+
     damage_to_players: Dict[str, int]
     creatures_destroyed: List[CombatCreature]
     lifegain: Dict[str, int]
 
 
 class CombatSimulator:
+    """High level orchestrator for combat resolution."""
+
     def __init__(self, attackers: List[CombatCreature], defenders: List[CombatCreature]):
+        """Store combatants taking part in the current combat phase."""
+
         self.attackers = attackers
         self.defenders = defenders
         self.all_creatures = attackers + defenders

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pytest
+pytest>=7.0

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+import sys
+
+# Ensure the package is importable when running tests from any location
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from magic_combat import CombatCreature, CombatResult, CombatSimulator
+
+
+def test_imports():
+    creature = CombatCreature(name="Goblin", power=1, toughness=1)
+    simulator = CombatSimulator([creature], [creature])
+    assert isinstance(simulator.attackers[0], CombatCreature)
+    assert simulator.all_creatures == [creature, creature]
+
+
+def test_combat_result_dataclass():
+    result = CombatResult(damage_to_players={"player": 0}, creatures_destroyed=[], lifegain={})
+    assert result.damage_to_players["player"] == 0
+


### PR DESCRIPTION
## Summary
- package the code under `magic_combat`
- create `CombatCreature` dataclass
- add simulator module with docstrings
- add minimal tests and gitignore
- expand README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855f7add438832abdbe16a2ae63e6d9