### PR TITLE
Add basic vanilla combat simulation and tests

### DIFF
--- a/magic_combat/creature.py
+++ b/magic_combat/creature.py
@@ -54,8 +54,18 @@ class CombatCreature:
     damage_marked: int = 0
 
     # --- Counters ---
-    plus1_counters: int = 0
-    minus1_counters: int = 0
+    _plus1_counters: int = field(default=0, repr=False)
+    _minus1_counters: int = field(default=0, repr=False)
+
+    def __post_init__(self) -> None:
+        if self.power < 0:
+            raise ValueError("power cannot be negative")
+        if self.toughness <= 0:
+            raise ValueError("toughness must be positive")
+        if self._plus1_counters < 0 or self._minus1_counters < 0:
+            raise ValueError("counters cannot be negative")
+        if self.damage_marked < 0:
+            raise ValueError("damage_marked cannot be negative")
 
     def has_protection_from(self, color: Color) -> bool:
         return color in self.protection_colors
@@ -73,3 +83,24 @@ class CombatCreature:
 
     def __str__(self) -> str:
         return f"{self.name} ({self.power}/{self.toughness})"
+
+    # --- Counter properties with validation ---
+    @property
+    def plus1_counters(self) -> int:
+        return self._plus1_counters
+
+    @plus1_counters.setter
+    def plus1_counters(self, value: int) -> None:
+        if value < 0:
+            raise ValueError("plus1 counters cannot be negative")
+        self._plus1_counters = value
+
+    @property
+    def minus1_counters(self) -> int:
+        return self._minus1_counters
+
+    @minus1_counters.setter
+    def minus1_counters(self, value: int) -> None:
+        if value < 0:
+            raise ValueError("minus1 counters cannot be negative")
+        self._minus1_counters = value

--- a/magic_combat/simulator.py
+++ b/magic_combat/simulator.py
@@ -23,37 +23,57 @@ class CombatSimulator:
         self.attackers = attackers
         self.defenders = defenders
         self.all_creatures = attackers + defenders
+        self.player_damage: Dict[str, int] = {}
 
     def validate_blocking(self):
-        """Ensure blocking assignments are legal (e.g., flying, menace, skulk, etc.)"""
-        raise NotImplementedError("Blocking legality checks not yet implemented.")
+        """Ensure blocking assignments are legal for this simplified simulator."""
+        for attacker in self.attackers:
+            if len(attacker.blocked_by) > 1:
+                # TODO: allow double blocking in the future
+                raise ValueError("Multiple blockers are not supported yet")
+
+        for blocker in self.defenders:
+            if blocker.blocking is not None and blocker.blocking not in self.attackers:
+                raise ValueError("Blocker assigned to unknown attacker")
 
     def apply_precombat_triggers(self):
-        """Handle effects like Exalted, Battle Cry, Training, Melee, Bushido, Flanking, etc."""
-        raise NotImplementedError("Pre-combat triggers not yet implemented.")
+        """Placeholder for future precombat trigger logic."""
+        return
 
     def resolve_first_strike_damage(self):
-        """Assign and deal damage in the first strike step."""
-        raise NotImplementedError("First strike damage not yet implemented.")
+        """No first strike logic for vanilla combat."""
+        return
 
     def resolve_normal_combat_damage(self):
-        """Assign and deal damage in the normal damage step."""
-        raise NotImplementedError("Normal combat damage not yet implemented.")
+        """Assign and deal damage in the normal damage step for vanilla combat."""
+        for attacker in self.attackers:
+            if attacker.blocked_by:
+                blocker = attacker.blocked_by[0]
+                blocker.damage_marked += attacker.effective_power()
+                attacker.damage_marked += blocker.effective_power()
+            else:
+                defender = self.defenders[0].controller if self.defenders else "defender"
+                self.player_damage[defender] = self.player_damage.get(defender, 0) + attacker.effective_power()
 
     def check_lethal_damage(self):
-        """Evaluate which creatures die after damage, accounting for indestructible, -1/-1 counters, etc."""
-        raise NotImplementedError("Lethal damage evaluation not yet implemented.")
+        """Evaluate which creatures die after damage."""
+        self.dead_creatures = [c for c in self.all_creatures if c.is_destroyed_by_damage()]
 
     def apply_lifelink_and_combat_lifegain(self):
-        """Apply lifelink for any combat damage dealt."""
-        raise NotImplementedError("Lifelink/lifegain not yet implemented.")
+        """No lifelink implementation for vanilla combat."""
+        self.lifegain = {}
 
     def finalize(self) -> CombatResult:
         """Return the outcome of combat."""
-        raise NotImplementedError("Final result aggregation not yet implemented.")
+        return CombatResult(
+            damage_to_players=self.player_damage,
+            creatures_destroyed=self.dead_creatures,
+            lifegain=self.lifegain,
+        )
 
     def simulate(self) -> CombatResult:
         """Run a full combat phase resolution and return the result."""
+        self.dead_creatures: List[CombatCreature] = []
         self.validate_blocking()
         self.apply_precombat_triggers()
 

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -1,0 +1,46 @@
+import random
+from pathlib import Path
+import sys
+
+# Ensure the package is importable when running tests from any location
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from magic_combat import CombatCreature, CombatSimulator
+
+
+def random_creature(name, controller):
+    return CombatCreature(name=name, power=random.randint(1, 5), toughness=random.randint(1, 5), controller=controller)
+
+
+def simulate_pair(a, b):
+    a.blocked_by.append(b)
+    b.blocking = a
+    sim = CombatSimulator([a], [b])
+    return sim.simulate()
+
+
+def test_combat_independence():
+    """CR 109.5: combat damage is assigned and dealt for each pair independently."""
+    random.seed(0)
+    for _ in range(10):
+        a1 = random_creature("a1", "A")
+        b1 = random_creature("b1", "B")
+        a2 = random_creature("a2", "A")
+        b2 = random_creature("b2", "B")
+
+        # combined simulation
+        a1.blocked_by.append(b1)
+        b1.blocking = a1
+        a2.blocked_by.append(b2)
+        b2.blocking = a2
+        combined = CombatSimulator([a1, a2], [b1, b2])
+        comb_res = combined.simulate()
+
+        res1 = simulate_pair(CombatCreature("a1", a1.power, a1.toughness, "A"),
+                             CombatCreature("b1", b1.power, b1.toughness, "B"))
+        res2 = simulate_pair(CombatCreature("a2", a2.power, a2.toughness, "A"),
+                             CombatCreature("b2", b2.power, b2.toughness, "B"))
+
+        expected = {c.name for c in res1.creatures_destroyed + res2.creatures_destroyed}
+        assert {c.name for c in comb_res.creatures_destroyed} == expected
+

--- a/tests/test_creature_validation.py
+++ b/tests/test_creature_validation.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import sys
+import pytest
+
+# Ensure the package is importable when running tests from any location
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from magic_combat import CombatCreature
+
+
+def test_negative_counters_init():
+    """CR 107.1: counters can't be negative."""
+    with pytest.raises(ValueError):
+        CombatCreature(name="Bad", power=1, toughness=1, controller="A", _plus1_counters=-1)
+
+
+def test_negative_counters_assignment():
+    creature = CombatCreature(name="Good", power=1, toughness=1, controller="A")
+    with pytest.raises(ValueError):
+        creature.plus1_counters = -3
+
+
+def test_negative_minus1_counters_assignment():
+    creature = CombatCreature(name="Good", power=1, toughness=1, controller="A")
+    with pytest.raises(ValueError):
+        creature.minus1_counters = -2
+

--- a/tests/test_vanilla_combat.py
+++ b/tests/test_vanilla_combat.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+import sys
+import pytest
+
+# Ensure the package is importable when running tests from any location
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from magic_combat import CombatCreature, CombatSimulator
+
+
+def setup_vanilla():
+    attacker = CombatCreature("Bear", 2, 2, "A")
+    blocker = CombatCreature("Piker", 3, 1, "B")
+    attacker.blocked_by.append(blocker)
+    blocker.blocking = attacker
+    return attacker, blocker
+
+
+def test_simple_trade():
+    """CR 510.2: combat damage is dealt simultaneously."""
+    a, b = setup_vanilla()
+    sim = CombatSimulator([a], [b])
+    result = sim.simulate()
+    assert a in result.creatures_destroyed
+    assert b in result.creatures_destroyed
+
+
+def test_double_block_not_supported():
+    """CR 509.1h: each creature can block a single attacker."""
+    a = CombatCreature("Bear", 2, 2, "A")
+    b1 = CombatCreature("Goblin", 1, 1, "B")
+    b2 = CombatCreature("Goblin2", 1, 1, "B")
+    a.blocked_by.extend([b1, b2])
+    b1.blocking = a
+    b2.blocking = a
+    sim = CombatSimulator([a], [b1, b2])
+    with pytest.raises(ValueError):
+        sim.simulate()
+


### PR DESCRIPTION
## Summary
- validate creature stats and counters
- implement a very small combat engine that can handle single blockers
- disallow double blocking for now
- add tests for counter validation and vanilla combat
- generate random combat scenarios to ensure pairwise independence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855fd761274832a9b0db24a0d13d7ac