### PR TITLE
Add more vanilla combat tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,3 @@
 To run tests, use pytest
+
+When adding tests, include a docstring quoting a relevant passage from the Magic Comprehensive Rules that the test exercises.

--- a/tests/test_vanilla_combat.py
+++ b/tests/test_vanilla_combat.py
@@ -37,3 +37,81 @@ def test_double_block_not_supported():
     with pytest.raises(ValueError):
         sim.simulate()
 
+
+def test_unblocked_attacker_hits_player():
+    """CR 510.1c: An unblocked creature deals damage to the player it's attacking."""
+    attacker = CombatCreature("Bear", 2, 2, "A")
+    defender = CombatCreature("Dummy", 0, 1, "B")
+    sim = CombatSimulator([attacker], [defender])
+    result = sim.simulate()
+    assert result.damage_to_players["B"] == 2
+    assert result.creatures_destroyed == []
+
+
+def test_blocker_survives_nonlethal_damage():
+    """CR 704.5g: Creatures with damage less than toughness aren't destroyed."""
+    attacker = CombatCreature("Bear", 2, 2, "A")
+    blocker = CombatCreature("Wall", 1, 3, "B")
+    attacker.blocked_by.append(blocker)
+    blocker.blocking = attacker
+    sim = CombatSimulator([attacker], [blocker])
+    result = sim.simulate()
+    assert result.creatures_destroyed == []
+
+
+def test_attacker_survives_and_kills_blocker():
+    """CR 704.5g: A creature with lethal damage is destroyed."""
+    attacker = CombatCreature("Ogre", 3, 3, "A")
+    blocker = CombatCreature("Goblin", 2, 2, "B")
+    attacker.blocked_by.append(blocker)
+    blocker.blocking = attacker
+    sim = CombatSimulator([attacker], [blocker])
+    result = sim.simulate()
+    assert blocker in result.creatures_destroyed
+    assert attacker not in result.creatures_destroyed
+
+
+def test_zero_power_attacker_deals_no_damage():
+    """CR 120.3d: A creature with 0 power deals no combat damage."""
+    attacker = CombatCreature("Pacifist", 0, 2, "A")
+    defender = CombatCreature("Dummy", 0, 1, "B")
+    sim = CombatSimulator([attacker], [defender])
+    result = sim.simulate()
+    assert result.damage_to_players.get("B", 0) == 0
+    assert result.creatures_destroyed == []
+
+
+def test_indestructible_creature_survives_lethal_damage():
+    """CR 702.12b: Indestructible permanents aren't destroyed by lethal damage."""
+    attacker = CombatCreature("Giant", 5, 5, "A")
+    blocker = CombatCreature("Guardian", 2, 2, "B", indestructible=True)
+    attacker.blocked_by.append(blocker)
+    blocker.blocking = attacker
+    sim = CombatSimulator([attacker], [blocker])
+    result = sim.simulate()
+    assert attacker not in result.creatures_destroyed
+    assert blocker not in result.creatures_destroyed
+
+
+def test_first_strike_not_implemented():
+    """CR 702.7b: First strike would let a creature deal damage before others."""
+    attacker = CombatCreature("Swift", 2, 1, "A", first_strike=True)
+    blocker = CombatCreature("Grizzly", 2, 2, "B")
+    attacker.blocked_by.append(blocker)
+    blocker.blocking = attacker
+    sim = CombatSimulator([attacker], [blocker])
+    result = sim.simulate()
+    assert attacker in result.creatures_destroyed
+    assert blocker in result.creatures_destroyed
+
+
+def test_multiple_attackers_damage_added():
+    """CR 510.2: All combat damage is dealt simultaneously."""
+    a1 = CombatCreature("Goblin1", 2, 2, "A")
+    a2 = CombatCreature("Goblin2", 2, 2, "A")
+    defender = CombatCreature("Dummy", 0, 1, "B")
+    sim = CombatSimulator([a1, a2], [defender])
+    result = sim.simulate()
+    assert result.damage_to_players["B"] == 4
+    assert result.creatures_destroyed == []
+


### PR DESCRIPTION
## Summary
- expand the vanilla combat test suite with multiple scenarios
- require CR quotes for future tests in `AGENTS.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855ffe9a95c832a81688802c916c1d2