### PR TITLE
Expand tests for simulator

### DIFF
--- a/tests/test_creature_validation.py
+++ b/tests/test_creature_validation.py
@@ -25,3 +25,16 @@ def test_negative_minus1_counters_assignment():
     with pytest.raises(ValueError):
         creature.minus1_counters = -2
 
+
+def test_invalid_power_or_toughness():
+    """CR 107.1: Numbers like power and toughness can't be negative."""
+    with pytest.raises(ValueError):
+        CombatCreature(name="Oops", power=-1, toughness=1, controller="A")
+    with pytest.raises(ValueError):
+        CombatCreature(name="Oops", power=1, toughness=0, controller="A")
+
+
+def test_negative_damage_marked():
+    """CR 107.1: Damage values can't be negative."""
+    with pytest.raises(ValueError):
+        CombatCreature(name="Oops", power=1, toughness=1, controller="A", damage_marked=-1)

--- a/tests/test_extra_features.py
+++ b/tests/test_extra_features.py
@@ -1,0 +1,96 @@
+import pytest
+from pathlib import Path
+import sys
+
+# Ensure the package is importable when running tests from any location
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from magic_combat import (
+    CombatCreature,
+    DamageAssignmentStrategy,
+    MostCreaturesKilledStrategy,
+    CombatSimulator,
+)
+
+
+def test_string_representation():
+    """CR 109.2: A creature's power and toughness are written as `X/Y`."""
+    creature = CombatCreature(name="Bear", power=2, toughness=2, controller="A")
+    assert str(creature) == "Bear (2/2)"
+
+
+def test_effective_stats_with_counters():
+    """CR 122.1a: +1/+1 counters modify a creature's power and toughness."""
+    creature = CombatCreature(
+        name="Scute", power=1, toughness=1, controller="A", _plus1_counters=2, _minus1_counters=1
+    )
+    assert creature.effective_power() == 2
+    assert creature.effective_toughness() == 2
+
+
+def test_has_protection_from():
+    """CR 702.16b: Protection prevents effects from objects of that color."""
+    creature = CombatCreature(
+        name="Paladin", power=2, toughness=2, controller="A", protection_colors={"black"}
+    )
+    assert creature.has_protection_from("black")
+    assert not creature.has_protection_from("red")
+
+
+def test_destroyed_by_damage():
+    """CR 704.5g: A creature with lethal damage is destroyed."""
+    creature = CombatCreature(name="Goblin", power=2, toughness=2, controller="A")
+    creature.damage_marked = 3
+    assert creature.is_destroyed_by_damage()
+
+
+def test_damage_assignment_strategy_identity():
+    """CR 510.2: Damage assignment order matters only if multiple blockers are present."""
+    strat = DamageAssignmentStrategy()
+    a = CombatCreature("A", 2, 2, "A")
+    b1 = CombatCreature("B1", 1, 1, "B")
+    b2 = CombatCreature("B2", 1, 1, "B")
+    ordered = strat.order_blockers(a, [b1, b2])
+    assert ordered == [b1, b2]
+
+
+def test_most_creatures_killed_strategy_sorts():
+    """CR 510.2: Attackers may order blockers to maximize kills."""
+    strat = MostCreaturesKilledStrategy()
+    a = CombatCreature("A", 3, 3, "A")
+    b1 = CombatCreature("Wall", 0, 4, "B")
+    b2 = CombatCreature("Goblin", 1, 1, "B")
+    ordered = strat.order_blockers(a, [b1, b2])
+    assert ordered == [b2, b1]
+
+
+def test_plus1_minus1_counter_setters():
+    """CR 122.1a: Counters can increase or decrease stats."""
+    creature = CombatCreature(name="Bug", power=1, toughness=1, controller="A")
+    creature.plus1_counters = 1
+    creature.minus1_counters = 1
+    assert creature.plus1_counters == 1
+    assert creature.minus1_counters == 1
+    assert creature.effective_power() == 1
+    assert creature.effective_toughness() == 1
+
+
+def test_validate_blocking_unknown_attacker():
+    """CR 509.1a: A creature can block only a creature that's attacking it."""
+    attacker = CombatCreature("Attacker", 2, 2, "A")
+    blocker = CombatCreature("Blocker", 2, 2, "B")
+    blocker.blocking = attacker  # attacker not included in simulator attackers
+    sim = CombatSimulator([], [blocker])
+    with pytest.raises(ValueError):
+        sim.validate_blocking()
+
+
+def test_validate_blocking_inconsistent():
+    """CR 509.1b: Each blocker must be declared blocking a specific attacker."""
+    attacker = CombatCreature("Attacker", 2, 2, "A")
+    blocker = CombatCreature("Blocker", 2, 2, "B")
+    attacker.blocked_by.append(blocker)
+    # blocker.blocking not set -> inconsistent
+    sim = CombatSimulator([attacker], [blocker])
+    with pytest.raises(ValueError):
+        sim.validate_blocking()


### PR DESCRIPTION
## Summary
- add additional validation checks for CombatCreature
- test base and ordering damage strategies
- cover string representation and protection logic
- verify blocking validation errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685601ce49ac832aa07765995f709100