### PR TITLE
Implement blocking keyword abilities

### DIFF
--- a/magic_combat/creature.py
+++ b/magic_combat/creature.py
@@ -16,11 +16,14 @@ class CombatCreature:
     power: int
     toughness: int
     controller: str
+    colors: Set[Color] = field(default_factory=set)
+    artifact: bool = False
 
     # --- Combat Keywords ---
     flying: bool = False
     reach: bool = False
     menace: bool = False
+    fear: bool = False
     shadow: bool = False
     horsemanship: bool = False
     skulk: bool = False

--- a/magic_combat/simulator.py
+++ b/magic_combat/simulator.py
@@ -43,6 +43,32 @@ class CombatSimulator:
                 if blocker.blocking is not attacker:
                     raise ValueError("Inconsistent blocking assignments")
 
+        for attacker in self.attackers:
+            if attacker.unblockable and attacker.blocked_by:
+                raise ValueError("Unblockable creature was blocked")
+
+            if attacker.menace and 0 < len(attacker.blocked_by) < 2:
+                raise ValueError("Menace creature blocked by fewer than two")
+
+            for blocker in attacker.blocked_by:
+                if attacker.flying and not (blocker.flying or blocker.reach):
+                    raise ValueError("Non-flying/reach blocker blocking flyer")
+
+                if attacker.shadow and not blocker.shadow:
+                    raise ValueError("Non-shadow creature blocking shadow")
+
+                if attacker.horsemanship and not blocker.horsemanship:
+                    raise ValueError("Non-horsemanship creature blocking")
+
+                if attacker.skulk and blocker.effective_power() >= attacker.effective_power():
+                    raise ValueError("Skulk prevents block by higher power")
+
+                if attacker.fear and not (blocker.artifact or "black" in blocker.colors):
+                    raise ValueError("Fear creature blocked illegally")
+
+                if attacker.protection_colors & blocker.colors:
+                    raise ValueError("Attacker has protection from blocker's color")
+
     def apply_precombat_triggers(self):
         """Placeholder for future precombat trigger logic."""
         return

--- a/tests/test_blocking_keywords.py
+++ b/tests/test_blocking_keywords.py
@@ -1,0 +1,81 @@
+import pytest
+from pathlib import Path
+import sys
+
+# Ensure the package is importable when running tests from any location
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from magic_combat import CombatCreature, CombatSimulator
+
+
+def test_flying_requires_flying_or_reach():
+    """CR 702.9b: A creature with flying can be blocked only by creatures with flying or reach."""
+    attacker = CombatCreature("Hawk", 1, 1, "A", flying=True)
+    blocker = CombatCreature("Bear", 2, 2, "B")
+    attacker.blocked_by.append(blocker)
+    blocker.blocking = attacker
+    sim = CombatSimulator([attacker], [blocker])
+    with pytest.raises(ValueError):
+        sim.validate_blocking()
+
+
+def test_reach_allows_blocking_flying():
+    """CR 702.9c: Creatures with reach can block creatures with flying."""
+    attacker = CombatCreature("Hawk", 1, 1, "A", flying=True)
+    blocker = CombatCreature("Spider", 1, 2, "B", reach=True)
+    attacker.blocked_by.append(blocker)
+    blocker.blocking = attacker
+    sim = CombatSimulator([attacker], [blocker])
+    # Should not raise
+    sim.validate_blocking()
+
+
+def test_menace_requires_two_blockers():
+    """CR 702.110b: A creature with menace can't be blocked except by two or more creatures."""
+    attacker = CombatCreature("Ogre", 3, 3, "A", menace=True)
+    blocker = CombatCreature("Goblin", 1, 1, "B")
+    attacker.blocked_by.append(blocker)
+    blocker.blocking = attacker
+    sim = CombatSimulator([attacker], [blocker])
+    with pytest.raises(ValueError):
+        sim.validate_blocking()
+
+
+def test_menace_with_two_blockers_allowed():
+    """CR 702.110b allows blocking a menace creature with two blockers."""
+    attacker = CombatCreature("Ogre", 3, 3, "A", menace=True)
+    b1 = CombatCreature("Goblin1", 1, 1, "B")
+    b2 = CombatCreature("Goblin2", 1, 1, "B")
+    attacker.blocked_by.extend([b1, b2])
+    b1.blocking = attacker
+    b2.blocking = attacker
+    sim = CombatSimulator([attacker], [b1, b2])
+    sim.validate_blocking()
+
+
+def test_fear_blocking():
+    """CR 702.36b: Fear allows blocking only by artifact or black creatures."""
+    attacker = CombatCreature("Nightmare", 2, 2, "A", fear=True)
+    blocker = CombatCreature("Knight", 2, 2, "B", colors={"white"})
+    attacker.blocked_by.append(blocker)
+    blocker.blocking = attacker
+    sim = CombatSimulator([attacker], [blocker])
+    with pytest.raises(ValueError):
+        sim.validate_blocking()
+
+    black_blocker = CombatCreature("Shade", 1, 1, "B", colors={"black"})
+    attacker.blocked_by = [black_blocker]
+    black_blocker.blocking = attacker
+    sim = CombatSimulator([attacker], [black_blocker])
+    sim.validate_blocking()
+
+
+def test_protection_prevents_blocking():
+    """CR 702.16b: Protection from a color means it can't be blocked by creatures of that color."""
+    attacker = CombatCreature("Paladin", 2, 2, "A", protection_colors={"red"})
+    blocker = CombatCreature("Orc", 2, 2, "B", colors={"red"})
+    attacker.blocked_by.append(blocker)
+    blocker.blocking = attacker
+    sim = CombatSimulator([attacker], [blocker])
+    with pytest.raises(ValueError):
+        sim.validate_blocking()


### PR DESCRIPTION
## Summary
- support colors and artifact on `CombatCreature`
- add `fear` attribute
- enforce blocking restrictions for flying, menace, fear, skulk, and protection
- add comprehensive keyword ability tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68561f30da18832aa3c7696e05906cfc