### PR TITLE
Implement precombat stat abilities

### DIFF
--- a/magic_combat/creature.py
+++ b/magic_combat/creature.py
@@ -59,6 +59,10 @@ class CombatCreature:
     _plus1_counters: int = field(default=0, repr=False)
     _minus1_counters: int = field(default=0, repr=False)
 
+    # --- Temporary stat modifiers (until end of turn) ---
+    temp_power: int = field(default=0, repr=False)
+    temp_toughness: int = field(default=0, repr=False)
+
     def __post_init__(self) -> None:
         check_non_negative(self.power, "power")
         check_positive(self.toughness, "toughness")
@@ -70,11 +74,23 @@ class CombatCreature:
         return color in self.protection_colors
 
     def effective_power(self) -> int:
-        """Base power + +1/+1 counters - -1/-1 counters"""
-        return max(0, self.power + self.plus1_counters - self.minus1_counters)
+        """Base power, counters, and temporary modifiers."""
+        return max(
+            0,
+            self.power
+            + self.plus1_counters
+            - self.minus1_counters
+            + self.temp_power,
+        )
 
     def effective_toughness(self) -> int:
-        return max(0, self.toughness + self.plus1_counters - self.minus1_counters)
+        return max(
+            0,
+            self.toughness
+            + self.plus1_counters
+            - self.minus1_counters
+            + self.temp_toughness,
+        )
 
     def is_destroyed_by_damage(self) -> bool:
         """Check if marked damage is lethal, accounting for indestructibility"""
@@ -101,3 +117,8 @@ class CombatCreature:
     def minus1_counters(self, value: int) -> None:
         check_non_negative(value, "minus1 counters")
         self._minus1_counters = value
+
+    def reset_temporary_bonuses(self) -> None:
+        """Clear temporary power and toughness modifiers."""
+        self.temp_power = 0
+        self.temp_toughness = 0

--- a/magic_combat/simulator.py
+++ b/magic_combat/simulator.py
@@ -44,8 +44,70 @@ class CombatSimulator:
                     raise ValueError("Inconsistent blocking assignments")
 
     def apply_precombat_triggers(self):
-        """Placeholder for future precombat trigger logic."""
-        return
+        """Apply keyword abilities that modify stats before combat damage."""
+        # reset any temporary bonuses
+        for creature in self.all_creatures:
+            creature.reset_temporary_bonuses()
+
+        # group attackers by controller for exalted and training
+        attackers_by_controller: Dict[str, List[CombatCreature]] = {}
+        for atk in self.attackers:
+            attackers_by_controller.setdefault(atk.controller, []).append(atk)
+
+        # Exalted triggers
+        for controller, atks in attackers_by_controller.items():
+            if len(atks) == 1:
+                atk = atks[0]
+                exalted_total = atk.exalted_count
+                atk.temp_power += exalted_total
+                atk.temp_toughness += exalted_total
+
+        # Battle cry
+        for atk in self.attackers:
+            if atk.battle_cry_count:
+                for other in self.attackers:
+                    if other is not atk and other.controller == atk.controller:
+                        other.temp_power += atk.battle_cry_count
+
+        # Melee
+        num_opponents_attacked = 1 if self.attackers else 0
+        for atk in self.attackers:
+            if atk.melee and num_opponents_attacked:
+                atk.temp_power += num_opponents_attacked
+                atk.temp_toughness += num_opponents_attacked
+
+        # Training
+        for atk in self.attackers:
+            if atk.training:
+                if any(
+                    other.controller == atk.controller
+                    and other is not atk
+                    and other.effective_power() > atk.effective_power()
+                    for other in self.attackers
+                ):
+                    atk.plus1_counters += 1
+
+        # Bushido, Rampage, and Flanking
+        for attacker in self.attackers:
+            if attacker.blocked_by:
+                if attacker.bushido:
+                    attacker.temp_power += attacker.bushido
+                    attacker.temp_toughness += attacker.bushido
+                if attacker.rampage:
+                    extra = max(0, len(attacker.blocked_by) - 1)
+                    attacker.temp_power += attacker.rampage * extra
+                    attacker.temp_toughness += attacker.rampage * extra
+                if attacker.flanking:
+                    for blocker in attacker.blocked_by:
+                        if blocker.flanking == 0:
+                            blocker.temp_power -= attacker.flanking
+                            blocker.temp_toughness -= attacker.flanking
+
+        for blocker in self.defenders:
+            if blocker.blocking is not None:
+                if blocker.bushido:
+                    blocker.temp_power += blocker.bushido
+                    blocker.temp_toughness += blocker.bushido
 
     def resolve_first_strike_damage(self):
         """No first strike logic for vanilla combat."""


### PR DESCRIPTION
## Summary
- add temporary stat modifiers to `CombatCreature`
- implement precombat abilities in `CombatSimulator`
- test Bushido, Flanking, Exalted, Rampage, Battle Cry, Melee, and Training

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68561fa87670832a90c718652ed34ea1