### PR TITLE
Add interaction tests

### DIFF
--- a/magic_combat/simulator.py
+++ b/magic_combat/simulator.py
@@ -60,7 +60,7 @@ class CombatSimulator:
                 if attacker.horsemanship and not blocker.horsemanship:
                     raise ValueError("Non-horsemanship creature blocking")
 
-                if attacker.skulk and blocker.effective_power() >= attacker.effective_power():
+                if attacker.skulk and blocker.effective_power() > attacker.effective_power():
                     raise ValueError("Skulk prevents block by higher power")
 
                 if attacker.fear and not (blocker.artifact or "black" in blocker.colors):

--- a/tests/test_edge_interactions.py
+++ b/tests/test_edge_interactions.py
@@ -1,0 +1,98 @@
+from pathlib import Path
+import sys
+import pytest
+
+# Ensure the package is importable when running tests from any location
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from magic_combat import CombatCreature, CombatSimulator
+
+
+def test_skulk_bushido_block_illegal():
+    """CR 702.72a & 702.46a: Skulk checks power before bushido triggers."""
+    attacker = CombatCreature("Sneaky Samurai", 2, 2, "A", skulk=True, bushido=2)
+    blocker = CombatCreature("Giant", 3, 3, "B")
+    attacker.blocked_by.append(blocker)
+    blocker.blocking = attacker
+    sim = CombatSimulator([attacker], [blocker])
+    with pytest.raises(ValueError):
+        sim.validate_blocking()
+
+
+def test_skulk_bushido_equal_power_allowed():
+    """CR 702.72a: A blocker with equal power may block despite later bushido."""
+    attacker = CombatCreature("Sneaky Samurai", 2, 2, "A", skulk=True, bushido=2)
+    blocker = CombatCreature("Guard", 2, 2, "B")
+    attacker.blocked_by.append(blocker)
+    blocker.blocking = attacker
+    sim = CombatSimulator([attacker], [blocker])
+    sim.validate_blocking()  # should be allowed
+
+
+def test_flying_horsemanship_needs_both_flying_only():
+    """CR 702.9b & 702.108a: Flying alone can't block flying+horsemanship."""
+    attacker = CombatCreature("Pegasus Rider", 2, 2, "A", flying=True, horsemanship=True)
+    blocker = CombatCreature("Bird", 1, 1, "B", flying=True)
+    attacker.blocked_by.append(blocker)
+    blocker.blocking = attacker
+    sim = CombatSimulator([attacker], [blocker])
+    with pytest.raises(ValueError):
+        sim.validate_blocking()
+
+
+def test_flying_horsemanship_needs_both_horse_only():
+    """CR 702.9b & 702.108a: Horsemanship alone can't block flying+horsemanship."""
+    attacker = CombatCreature("Pegasus Rider", 2, 2, "A", flying=True, horsemanship=True)
+    blocker = CombatCreature("Cavalry", 2, 2, "B", horsemanship=True)
+    attacker.blocked_by.append(blocker)
+    blocker.blocking = attacker
+    sim = CombatSimulator([attacker], [blocker])
+    with pytest.raises(ValueError):
+        sim.validate_blocking()
+
+
+def test_flying_horsemanship_block_with_both_ok():
+    """CR 702.9b & 702.108a: A creature with both abilities can block."""
+    attacker = CombatCreature("Pegasus Rider", 2, 2, "A", flying=True, horsemanship=True)
+    blocker = CombatCreature("Winged Knight", 2, 2, "B", flying=True, horsemanship=True)
+    attacker.blocked_by.append(blocker)
+    blocker.blocking = attacker
+    sim = CombatSimulator([attacker], [blocker])
+    sim.validate_blocking()  # should not raise
+
+
+def test_flying_horsemanship_with_reach_and_horse_ok():
+    """CR 702.9c & 702.108a: Reach plus horsemanship can block."""
+    attacker = CombatCreature("Sky Cavalry", 2, 2, "A", flying=True, horsemanship=True)
+    blocker = CombatCreature("Archer", 2, 3, "B", reach=True, horsemanship=True)
+    attacker.blocked_by.append(blocker)
+    blocker.blocking = attacker
+    sim = CombatSimulator([attacker], [blocker])
+    sim.validate_blocking()  # should not raise
+
+
+def test_flanking_and_bushido_combined():
+    """CR 702.25a & 702.46a: Flanking debuffs blockers while bushido buffs the attacker."""
+    attacker = CombatCreature("Samurai Knight", 2, 2, "A", flanking=1, bushido=1)
+    blocker = CombatCreature("Hill Giant", 3, 3, "B")
+    attacker.blocked_by.append(blocker)
+    blocker.blocking = attacker
+    sim = CombatSimulator([attacker], [blocker])
+    result = sim.simulate()
+    assert blocker in result.creatures_destroyed
+    assert attacker not in result.creatures_destroyed
+
+
+def test_rampage_and_bushido_multi_block():
+    """CR 702.23a & 702.46a: Rampage and bushido bonuses stack with multiple blockers."""
+    attacker = CombatCreature("Warlord", 3, 3, "A", rampage=1, bushido=1)
+    b1 = CombatCreature("B1", 2, 2, "B")
+    b2 = CombatCreature("B2", 2, 2, "B")
+    attacker.blocked_by.extend([b1, b2])
+    b1.blocking = attacker
+    b2.blocking = attacker
+    sim = CombatSimulator([attacker], [b1, b2])
+    result = sim.simulate()
+    assert b1 in result.creatures_destroyed
+    assert b2 in result.creatures_destroyed
+    assert attacker not in result.creatures_destroyed


### PR DESCRIPTION
## Summary
- add new edge case tests covering complex interactions
- correct skulk rule so equal-power blocks are legal

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68562bb1d9c4832abf04dd8a03c4b539