### PR TITLE
Add additional interaction tests

### DIFF
--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -8,15 +8,14 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from magic_combat import CombatCreature, CombatSimulator
 
 
-def test_skulk_bushido_illegal_block():
-    """CR 702.120 & 702.46a: Skulk stops blocks by creatures with equal or greater power before Bushido applies."""
+def test_skulk_bushido_equal_power_block_ok():
+    """CR 702.121a & 702.46a: Skulk stops only blockers with greater power, so equal power is allowed."""
     atk = CombatCreature("Sneaky Samurai", 2, 2, "A", skulk=True, bushido=1)
     blk = CombatCreature("Guard", 2, 2, "B")
     atk.blocked_by.append(blk)
     blk.blocking = atk
     sim = CombatSimulator([atk], [blk])
-    with pytest.raises(ValueError):
-        sim.validate_blocking()
+    sim.validate_blocking()
 
 
 def test_skulk_bushido_combat():

--- a/tests/test_more_interactions.py
+++ b/tests/test_more_interactions.py
@@ -1,0 +1,38 @@
+import pytest
+from pathlib import Path
+import sys
+
+# Ensure the package is importable when running tests from any location
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from magic_combat import CombatCreature, CombatSimulator
+
+
+def test_fear_and_skulk_interaction():
+    """CR 702.36b & 702.121a: Fear limits blockers to artifact or black creatures, and skulk disallows those with greater power."""
+    attacker = CombatCreature("Sneaky Horror", 2, 2, "A", fear=True, skulk=True)
+    big_artifact = CombatCreature("Golem", 3, 3, "B", artifact=True)
+    attacker.blocked_by.append(big_artifact)
+    big_artifact.blocking = attacker
+    sim = CombatSimulator([attacker], [big_artifact])
+    with pytest.raises(ValueError):
+        sim.validate_blocking()
+
+    attacker.blocked_by.clear()
+    small_artifact = CombatCreature("Servo", 1, 1, "B", artifact=True)
+    attacker.blocked_by.append(small_artifact)
+    small_artifact.blocking = attacker
+    sim = CombatSimulator([attacker], [small_artifact])
+    sim.validate_blocking()
+
+
+def test_flanking_vs_flanking_blocker():
+    """CR 702.25a: Flanking gives -1/-1 only to blocking creatures without flanking."""
+    attacker = CombatCreature("Veteran", 2, 2, "A", flanking=1)
+    blocker = CombatCreature("Opposing Knight", 2, 2, "B", flanking=1)
+    attacker.blocked_by.append(blocker)
+    blocker.blocking = attacker
+    sim = CombatSimulator([attacker], [blocker])
+    result = sim.simulate()
+    assert attacker in result.creatures_destroyed
+    assert blocker in result.creatures_destroyed


### PR DESCRIPTION
## Summary
- allow equal-power skulk blockers in interaction tests
- add a fear/skulk interaction test
- add a flanking-vs-flanking test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68562f2a64dc832aa0d2a1cda0e91602