### PR TITLE
Clean test imports

### DIFF
--- a/tests/test_additional.py
+++ b/tests/test_additional.py
@@ -1,30 +1,21 @@
-from pathlib import Path
-import sys
 import pytest
 
-# Ensure the package is importable when running tests from any location
-sys.path.append(str(Path(__file__).resolve().parents[1]))
-
 from magic_combat import CombatCreature, CombatSimulator, DamageAssignmentStrategy
-
 
 def test_bad_power_init():
     """CR 107.1: game numbers can't be negative."""
     with pytest.raises(ValueError):
         CombatCreature(name="Zero", power=-1, toughness=1, controller="A")
 
-
 def test_bad_toughness_init():
     """CR 107.1: game numbers can't be negative."""
     with pytest.raises(ValueError):
         CombatCreature(name="Zero", power=1, toughness=0, controller="A")
 
-
 def test_bad_damage_marked_init():
     """CR 107.1: game numbers can't be negative."""
     with pytest.raises(ValueError):
         CombatCreature(name="Zero", power=1, toughness=1, controller="A", damage_marked=-1)
-
 
 def test_effective_stats_with_counters():
     """CR 121.5: +1/+1 and -1/-1 counters cancel each other out."""
@@ -32,19 +23,16 @@ def test_effective_stats_with_counters():
     assert c.effective_power() == 3
     assert c.effective_toughness() == 3
 
-
 def test_string_representation():
     """CR 110.6: power and toughness are written as 'X/Y'."""
     c = CombatCreature(name="Bear", power=2, toughness=2, controller="A")
     assert str(c) == "Bear (2/2)"
-
 
 def test_protection_check():
     """CR 702.16b: Protection prevents damage from sources of the stated quality."""
     c = CombatCreature(name="Knight", power=2, toughness=2, controller="A", protection_colors={"red"})
     assert c.has_protection_from("red")
     assert not c.has_protection_from("green")
-
 
 def test_property_setters():
     """CR 107.1: counters can't be negative."""
@@ -54,13 +42,11 @@ def test_property_setters():
     assert c.plus1_counters == 2
     assert c.minus1_counters == 1
 
-
 def test_is_destroyed_by_damage():
     """CR 704.5g: a creature with lethal damage is destroyed."""
     c = CombatCreature(name="Weak", power=1, toughness=1, controller="A")
     c.damage_marked = 1
     assert c.is_destroyed_by_damage()
-
 
 def test_base_strategy_returns_blockers():
     """CR 510.2: combat damage is dealt simultaneously to all blockers."""
@@ -70,14 +56,12 @@ def test_base_strategy_returns_blockers():
     ordered = strat.order_blockers(a, [b1])
     assert ordered == [b1]
 
-
 def test_unblocked_attacker_no_defenders():
     """CR 510.1c: unblocked attackers damage the player they're attacking."""
     a = CombatCreature("Lone", 3, 3, "A")
     sim = CombatSimulator([a], [])
     result = sim.simulate()
     assert result.damage_to_players["defender"] == 3
-
 
 def test_validate_blocking_unknown_attacker():
     """CR 509.1a: the defending player chooses which attackers blockers block."""

--- a/tests/test_blocking_keywords.py
+++ b/tests/test_blocking_keywords.py
@@ -1,12 +1,6 @@
 import pytest
-from pathlib import Path
-import sys
-
-# Ensure the package is importable when running tests from any location
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from magic_combat import CombatCreature, CombatSimulator
-
 
 def test_flying_requires_flying_or_reach():
     """CR 702.9b: A creature with flying can be blocked only by creatures with flying or reach."""
@@ -18,7 +12,6 @@ def test_flying_requires_flying_or_reach():
     with pytest.raises(ValueError):
         sim.validate_blocking()
 
-
 def test_reach_allows_blocking_flying():
     """CR 702.9c: Creatures with reach can block creatures with flying."""
     attacker = CombatCreature("Hawk", 1, 1, "A", flying=True)
@@ -28,7 +21,6 @@ def test_reach_allows_blocking_flying():
     sim = CombatSimulator([attacker], [blocker])
     # Should not raise
     sim.validate_blocking()
-
 
 def test_menace_requires_two_blockers():
     """CR 702.110b: A creature with menace can't be blocked except by two or more creatures."""
@@ -40,7 +32,6 @@ def test_menace_requires_two_blockers():
     with pytest.raises(ValueError):
         sim.validate_blocking()
 
-
 def test_menace_with_two_blockers_allowed():
     """CR 702.110b allows blocking a menace creature with two blockers."""
     attacker = CombatCreature("Ogre", 3, 3, "A", menace=True)
@@ -51,7 +42,6 @@ def test_menace_with_two_blockers_allowed():
     b2.blocking = attacker
     sim = CombatSimulator([attacker], [b1, b2])
     sim.validate_blocking()
-
 
 def test_fear_blocking():
     """CR 702.36b: Fear allows blocking only by artifact or black creatures."""
@@ -69,7 +59,6 @@ def test_fear_blocking():
     sim = CombatSimulator([attacker], [black_blocker])
     sim.validate_blocking()
 
-
 def test_protection_prevents_blocking():
     """CR 702.16b: Protection from a color means it can't be blocked by creatures of that color."""
     attacker = CombatCreature("Paladin", 2, 2, "A", protection_colors={"red"})
@@ -79,7 +68,6 @@ def test_protection_prevents_blocking():
     sim = CombatSimulator([attacker], [blocker])
     with pytest.raises(ValueError):
         sim.validate_blocking()
-
 
 def test_skulk_prevents_stronger_blocker_even_with_bushido():
     """CR 702.65a: Skulk says a creature can't be blocked by creatures with greater power."""

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -1,16 +1,9 @@
 import random
-from pathlib import Path
-import sys
-
-# Ensure the package is importable when running tests from any location
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from magic_combat import CombatCreature, CombatSimulator
 
-
 def random_creature(name, controller):
     return CombatCreature(name=name, power=random.randint(1, 5), toughness=random.randint(1, 5), controller=controller)
-
 
 def simulate_pair(a, b):
     a.blocked_by.append(b)

--- a/tests/test_creature_validation.py
+++ b/tests/test_creature_validation.py
@@ -1,30 +1,21 @@
-from pathlib import Path
-import sys
 import pytest
 
-# Ensure the package is importable when running tests from any location
-sys.path.append(str(Path(__file__).resolve().parents[1]))
-
 from magic_combat import CombatCreature
-
 
 def test_negative_counters_init():
     """CR 107.1: counters can't be negative."""
     with pytest.raises(ValueError):
         CombatCreature(name="Bad", power=1, toughness=1, controller="A", _plus1_counters=-1)
 
-
 def test_negative_counters_assignment():
     creature = CombatCreature(name="Good", power=1, toughness=1, controller="A")
     with pytest.raises(ValueError):
         creature.plus1_counters = -3
 
-
 def test_negative_minus1_counters_assignment():
     creature = CombatCreature(name="Good", power=1, toughness=1, controller="A")
     with pytest.raises(ValueError):
         creature.minus1_counters = -2
-
 
 def test_invalid_power_or_toughness():
     """CR 107.1: Numbers like power and toughness can't be negative."""

--- a/tests/test_edge_interactions.py
+++ b/tests/test_edge_interactions.py
@@ -1,12 +1,6 @@
-from pathlib import Path
-import sys
 import pytest
 
-# Ensure the package is importable when running tests from any location
-sys.path.append(str(Path(__file__).resolve().parents[1]))
-
 from magic_combat import CombatCreature, CombatSimulator
-
 
 def test_skulk_bushido_block_illegal():
     """CR 702.72a & 702.46a: Skulk checks power before bushido triggers."""
@@ -18,7 +12,6 @@ def test_skulk_bushido_block_illegal():
     with pytest.raises(ValueError):
         sim.validate_blocking()
 
-
 def test_skulk_bushido_equal_power_allowed():
     """CR 702.72a: A blocker with equal power may block despite later bushido."""
     attacker = CombatCreature("Sneaky Samurai", 2, 2, "A", skulk=True, bushido=2)
@@ -27,7 +20,6 @@ def test_skulk_bushido_equal_power_allowed():
     blocker.blocking = attacker
     sim = CombatSimulator([attacker], [blocker])
     sim.validate_blocking()  # should be allowed
-
 
 def test_flying_horsemanship_needs_both_flying_only():
     """CR 702.9b & 702.108a: Flying alone can't block flying+horsemanship."""
@@ -39,7 +31,6 @@ def test_flying_horsemanship_needs_both_flying_only():
     with pytest.raises(ValueError):
         sim.validate_blocking()
 
-
 def test_flying_horsemanship_needs_both_horse_only():
     """CR 702.9b & 702.108a: Horsemanship alone can't block flying+horsemanship."""
     attacker = CombatCreature("Pegasus Rider", 2, 2, "A", flying=True, horsemanship=True)
@@ -50,7 +41,6 @@ def test_flying_horsemanship_needs_both_horse_only():
     with pytest.raises(ValueError):
         sim.validate_blocking()
 
-
 def test_flying_horsemanship_block_with_both_ok():
     """CR 702.9b & 702.108a: A creature with both abilities can block."""
     attacker = CombatCreature("Pegasus Rider", 2, 2, "A", flying=True, horsemanship=True)
@@ -60,7 +50,6 @@ def test_flying_horsemanship_block_with_both_ok():
     sim = CombatSimulator([attacker], [blocker])
     sim.validate_blocking()  # should not raise
 
-
 def test_flying_horsemanship_with_reach_and_horse_ok():
     """CR 702.9c & 702.108a: Reach plus horsemanship can block."""
     attacker = CombatCreature("Sky Cavalry", 2, 2, "A", flying=True, horsemanship=True)
@@ -69,7 +58,6 @@ def test_flying_horsemanship_with_reach_and_horse_ok():
     blocker.blocking = attacker
     sim = CombatSimulator([attacker], [blocker])
     sim.validate_blocking()  # should not raise
-
 
 def test_flanking_and_bushido_combined():
     """CR 702.25a & 702.46a: Flanking debuffs blockers while bushido buffs the attacker."""

--- a/tests/test_extra.py
+++ b/tests/test_extra.py
@@ -1,12 +1,6 @@
-from pathlib import Path
-import sys
 import pytest
 
-# Ensure the package is importable when running tests from any location
-sys.path.append(str(Path(__file__).resolve().parents[1]))
-
 from magic_combat import CombatCreature, CombatSimulator, DamageAssignmentStrategy
-
 
 def test_invalid_power_and_toughness():
     """CR 302.4b states a creature with 0 or less toughness is put into its owner's graveyard."""
@@ -15,12 +9,10 @@ def test_invalid_power_and_toughness():
     with pytest.raises(ValueError):
         CombatCreature(name="Bad", power=1, toughness=0, controller="A")
 
-
 def test_damage_marked_non_negative():
     """CR 120.3d: Damage can't be negative."""
     with pytest.raises(ValueError):
         CombatCreature(name="Bad", power=1, toughness=1, controller="A", damage_marked=-1)
-
 
 def test_has_protection():
     """CR 702.16b: Protection from a color stops effects of that color."""
@@ -28,12 +20,10 @@ def test_has_protection():
     assert c.has_protection_from("black")
     assert not c.has_protection_from("red")
 
-
 def test_str_representation():
     """CR 208.1: A creature's power and toughness are written as "x/y"."""
     c = CombatCreature(name="Bear", power=2, toughness=2, controller="A")
     assert str(c) == "Bear (2/2)"
-
 
 def test_counters_modify_stats():
     """CR 122.1a: +1/+1 and -1/-1 counters modify power and toughness."""
@@ -42,7 +32,6 @@ def test_counters_modify_stats():
     c.minus1_counters = 1
     assert c.effective_power() == 2
     assert c.effective_toughness() == 2
-
 
 def test_base_damage_strategy_order():
     """CR 510.1: The attacking player announces damage assignment order."""

--- a/tests/test_extra_features.py
+++ b/tests/test_extra_features.py
@@ -1,9 +1,4 @@
 import pytest
-from pathlib import Path
-import sys
-
-# Ensure the package is importable when running tests from any location
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from magic_combat import (
     CombatCreature,
@@ -12,12 +7,10 @@ from magic_combat import (
     CombatSimulator,
 )
 
-
 def test_string_representation():
     """CR 109.2: A creature's power and toughness are written as `X/Y`."""
     creature = CombatCreature(name="Bear", power=2, toughness=2, controller="A")
     assert str(creature) == "Bear (2/2)"
-
 
 def test_effective_stats_with_counters():
     """CR 122.1a: +1/+1 counters modify a creature's power and toughness."""
@@ -27,7 +20,6 @@ def test_effective_stats_with_counters():
     assert creature.effective_power() == 2
     assert creature.effective_toughness() == 2
 
-
 def test_has_protection_from():
     """CR 702.16b: Protection prevents effects from objects of that color."""
     creature = CombatCreature(
@@ -36,13 +28,11 @@ def test_has_protection_from():
     assert creature.has_protection_from("black")
     assert not creature.has_protection_from("red")
 
-
 def test_destroyed_by_damage():
     """CR 704.5g: A creature with lethal damage is destroyed."""
     creature = CombatCreature(name="Goblin", power=2, toughness=2, controller="A")
     creature.damage_marked = 3
     assert creature.is_destroyed_by_damage()
-
 
 def test_damage_assignment_strategy_identity():
     """CR 510.2: Damage assignment order matters only if multiple blockers are present."""
@@ -53,7 +43,6 @@ def test_damage_assignment_strategy_identity():
     ordered = strat.order_blockers(a, [b1, b2])
     assert ordered == [b1, b2]
 
-
 def test_most_creatures_killed_strategy_sorts():
     """CR 510.2: Attackers may order blockers to maximize kills."""
     strat = MostCreaturesKilledStrategy()
@@ -62,7 +51,6 @@ def test_most_creatures_killed_strategy_sorts():
     b2 = CombatCreature("Goblin", 1, 1, "B")
     ordered = strat.order_blockers(a, [b1, b2])
     assert ordered == [b2, b1]
-
 
 def test_plus1_minus1_counter_setters():
     """CR 122.1a: Counters can increase or decrease stats."""
@@ -73,7 +61,6 @@ def test_plus1_minus1_counter_setters():
     assert creature.minus1_counters == 1
     assert creature.effective_power() == 1
     assert creature.effective_toughness() == 1
-
 
 def test_validate_blocking_unknown_attacker():
     """CR 509.1a: A creature can block only a creature that's attacking it."""

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,11 +1,4 @@
-from pathlib import Path
-import sys
-
-# Ensure the package is importable when running tests from any location
-sys.path.append(str(Path(__file__).resolve().parents[1]))
-
 from magic_combat import CombatCreature, CombatResult, CombatSimulator
-
 
 def test_imports():
     creature = CombatCreature(name="Goblin", power=1, toughness=1, controller="player")

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -1,12 +1,6 @@
-from pathlib import Path
-import sys
 import pytest
 
-# Ensure the package is importable when running tests from any location
-sys.path.append(str(Path(__file__).resolve().parents[1]))
-
 from magic_combat import CombatCreature, CombatSimulator
-
 
 def test_skulk_bushido_illegal_block():
     """CR 702.120 & 702.46a: Skulk stops blocks by creatures with equal or greater power before Bushido applies."""
@@ -18,7 +12,6 @@ def test_skulk_bushido_illegal_block():
     with pytest.raises(ValueError):
         sim.validate_blocking()
 
-
 def test_skulk_bushido_combat():
     """CR 702.120 & 702.46a: Bushido bonuses apply after blockers are declared."""
     atk = CombatCreature("Sneaky Samurai", 2, 2, "A", skulk=True, bushido=1)
@@ -29,7 +22,6 @@ def test_skulk_bushido_combat():
     result = sim.simulate()
     assert blk in result.creatures_destroyed
     assert atk not in result.creatures_destroyed
-
 
 def test_flying_and_horsemanship_blocking():
     """CR 702.9b & 702.30a: A creature with flying and horsemanship can be blocked only by one with horsemanship and flying or reach."""
@@ -60,7 +52,6 @@ def test_flying_and_horsemanship_blocking():
     reach_both.blocking = atk
     sim = CombatSimulator([atk], [reach_both])
     sim.validate_blocking()
-
 
 def test_fear_and_protection_from_black():
     """CR 702.36b & 702.16b: Fear allows only artifact or black blockers, but protection from black stops black blockers."""

--- a/tests/test_keyword_abilities.py
+++ b/tests/test_keyword_abilities.py
@@ -1,10 +1,4 @@
-from pathlib import Path
-import sys
-
-sys.path.append(str(Path(__file__).resolve().parents[1]))
-
 from magic_combat import CombatCreature, CombatSimulator
-
 
 def test_bushido_bonus():
     """CR 702.46a: Bushido gives the creature +N/+N when it blocks or becomes blocked."""
@@ -17,7 +11,6 @@ def test_bushido_bonus():
     assert blk in result.creatures_destroyed
     assert atk not in result.creatures_destroyed
 
-
 def test_flanking_debuff_blocker():
     """CR 702.25a: Flanking gives blocking creatures without flanking -1/-1."""
     atk = CombatCreature("Knight", 2, 2, "A", flanking=1)
@@ -29,7 +22,6 @@ def test_flanking_debuff_blocker():
     assert blk in result.creatures_destroyed
     assert atk not in result.creatures_destroyed
 
-
 def test_exalted_single_attacker_multiple_instances():
     """CR 702.90a: Each instance of exalted grants +1/+1 if a creature attacks alone."""
     atk = CombatCreature("Lone", 2, 2, "A", exalted_count=2)
@@ -40,7 +32,6 @@ def test_exalted_single_attacker_multiple_instances():
     result = sim.simulate()
     assert blk in result.creatures_destroyed
     assert atk not in result.creatures_destroyed
-
 
 def test_rampage_with_multiple_blockers():
     """CR 702.23a: Rampage gives +N/+N for each blocker beyond the first."""
@@ -56,7 +47,6 @@ def test_rampage_with_multiple_blockers():
     assert b2 in result.creatures_destroyed
     assert atk not in result.creatures_destroyed
 
-
 def test_battle_cry_boosts_allies():
     """CR 702.92a: Battle cry gives each other attacking creature +1/+0."""
     leader = CombatCreature("Leader", 2, 2, "A", battle_cry_count=1)
@@ -64,7 +54,6 @@ def test_battle_cry_boosts_allies():
     sim = CombatSimulator([leader, ally], [])
     result = sim.simulate()
     assert result.damage_to_players["defender"] == 5
-
 
 def test_melee_bonus_on_attack():
     """CR 702.111a: Melee gives the creature +1/+1 for each opponent it's attacking."""
@@ -76,7 +65,6 @@ def test_melee_bonus_on_attack():
     result = sim.simulate()
     assert blk in result.creatures_destroyed
     assert atk not in result.creatures_destroyed
-
 
 def test_training_adds_counter():
     """CR 702.138a: Training puts a +1/+1 counter on the creature if it attacks with a stronger ally."""

--- a/tests/test_more_features.py
+++ b/tests/test_more_features.py
@@ -1,12 +1,6 @@
-from pathlib import Path
-import sys
 import pytest
 
-# Ensure the package is importable when running tests from any location
-sys.path.append(str(Path(__file__).resolve().parents[1]))
-
 from magic_combat import CombatCreature, CombatSimulator, DamageAssignmentStrategy, MostCreaturesKilledStrategy
-
 
 def test_effective_power_toughness():
     """CR 121.1a: Each +1/+1 counter on a creature gives it +1/+1."""
@@ -16,13 +10,11 @@ def test_effective_power_toughness():
     assert c.effective_power() == 3
     assert c.effective_toughness() == 3
 
-
 def test_has_protection_from():
     """CR 702.16b: A creature with protection from a color can't be damaged by sources of that color."""
     c = CombatCreature("Paladin", 2, 2, "A", protection_colors={"black"})
     assert c.has_protection_from("black")
     assert not c.has_protection_from("red")
-
 
 def test_is_destroyed_by_damage_indestructible():
     """CR 702.12b: Indestructible permanents aren't destroyed by lethal damage."""
@@ -30,12 +22,10 @@ def test_is_destroyed_by_damage_indestructible():
     c.damage_marked = 5
     assert not c.is_destroyed_by_damage()
 
-
 def test_string_representation():
     """CR 108.1: A creature's name and stats are public information."""
     c = CombatCreature("Ogre", 3, 3, "A")
     assert str(c) == "Ogre (3/3)"
-
 
 def test_validate_blocking_unknown_attacker():
     """CR 509.1a: A creature can block only a creature that's attacking the player or planeswalker it's defending."""
@@ -46,7 +36,6 @@ def test_validate_blocking_unknown_attacker():
     with pytest.raises(ValueError):
         sim.validate_blocking()
 
-
 def test_validate_blocking_inconsistent_assignments():
     """CR 509.2: Each blocker must actually block the creature it's declared to block."""
     atk = CombatCreature("Attacker", 2, 2, "A")
@@ -56,7 +45,6 @@ def test_validate_blocking_inconsistent_assignments():
     sim = CombatSimulator([atk], [blk])
     with pytest.raises(ValueError):
         sim.validate_blocking()
-
 
 def test_strategy_called_for_ordering(monkeypatch):
     """CR 510.1a: The attacking creature's controller orders blockers for assigning damage."""
@@ -79,7 +67,6 @@ def test_strategy_called_for_ordering(monkeypatch):
     sim.simulate()
     assert called
     assert b2.damage_marked > 0  # first in reversed order
-
 
 def test_most_creatures_killed_strategy_sort():
     """CR 510.1a: Damage is assigned in the order chosen by the attacker."""

--- a/tests/test_vanilla_combat.py
+++ b/tests/test_vanilla_combat.py
@@ -1,12 +1,6 @@
-from pathlib import Path
-import sys
 import pytest
 
-# Ensure the package is importable when running tests from any location
-sys.path.append(str(Path(__file__).resolve().parents[1]))
-
 from magic_combat import CombatCreature, CombatSimulator
-
 
 def setup_vanilla():
     attacker = CombatCreature("Bear", 2, 2, "A")
@@ -15,7 +9,6 @@ def setup_vanilla():
     blocker.blocking = attacker
     return attacker, blocker
 
-
 def test_simple_trade():
     """CR 510.2: combat damage is dealt simultaneously."""
     a, b = setup_vanilla()
@@ -23,7 +16,6 @@ def test_simple_trade():
     result = sim.simulate()
     assert a in result.creatures_destroyed
     assert b in result.creatures_destroyed
-
 
 def test_double_block_simple():
     """Two 1/1 creatures trade with a 2/2 attacker."""
@@ -39,7 +31,6 @@ def test_double_block_simple():
     assert b1 in result.creatures_destroyed
     assert b2 in result.creatures_destroyed
 
-
 def test_most_creatures_killed_ordering():
     a = CombatCreature("Beast", 3, 3, "A")
     wall = CombatCreature("Wall", 0, 4, "B")
@@ -53,7 +44,6 @@ def test_most_creatures_killed_ordering():
     assert wall not in result.creatures_destroyed
     assert a not in result.creatures_destroyed
 
-
 def test_unblocked_attacker_hits_player():
     """CR 510.1c: An unblocked creature deals damage to the player it's attacking."""
     attacker = CombatCreature("Bear", 2, 2, "A")
@@ -62,7 +52,6 @@ def test_unblocked_attacker_hits_player():
     result = sim.simulate()
     assert result.damage_to_players["B"] == 2
     assert result.creatures_destroyed == []
-
 
 def test_blocker_survives_nonlethal_damage():
     """CR 704.5g: Creatures with damage less than toughness aren't destroyed."""
@@ -73,7 +62,6 @@ def test_blocker_survives_nonlethal_damage():
     sim = CombatSimulator([attacker], [blocker])
     result = sim.simulate()
     assert result.creatures_destroyed == []
-
 
 def test_attacker_survives_and_kills_blocker():
     """CR 704.5g: A creature with lethal damage is destroyed."""
@@ -86,7 +74,6 @@ def test_attacker_survives_and_kills_blocker():
     assert blocker in result.creatures_destroyed
     assert attacker not in result.creatures_destroyed
 
-
 def test_zero_power_attacker_deals_no_damage():
     """CR 120.3d: A creature with 0 power deals no combat damage."""
     attacker = CombatCreature("Pacifist", 0, 2, "A")
@@ -95,7 +82,6 @@ def test_zero_power_attacker_deals_no_damage():
     result = sim.simulate()
     assert result.damage_to_players.get("B", 0) == 0
     assert result.creatures_destroyed == []
-
 
 def test_indestructible_creature_survives_lethal_damage():
     """CR 702.12b: Indestructible permanents aren't destroyed by lethal damage."""
@@ -107,7 +93,6 @@ def test_indestructible_creature_survives_lethal_damage():
     result = sim.simulate()
     assert attacker not in result.creatures_destroyed
     assert blocker not in result.creatures_destroyed
-
 
 def test_first_strike_not_implemented():
     """CR 702.7b: First strike would let a creature deal damage before others."""


### PR DESCRIPTION
## Summary
- drop manual path fiddling from test modules
- centralize sys.path adjustment in `tests/conftest.py`

## Testing
- `pytest -q` *(fails: test_skulk_bushido_illegal_block)*

------
https://chatgpt.com/codex/tasks/task_e_68563053942c832a83553004ff3fe92a