### PR TITLE
Implement combat engine features

### DIFF
--- a/tests/test_advanced_combat.py
+++ b/tests/test_advanced_combat.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+import sys
+
+# Ensure the package is importable when running tests from any location
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from magic_combat import CombatCreature, CombatSimulator
+
+
+def test_double_strike_first_and_normal_damage():
+    """CR 702.4b: A creature with double strike deals damage during both first-strike and regular damage steps."""
+    attacker = CombatCreature("Duelist", 2, 2, "A", double_strike=True)
+    blocker = CombatCreature("Bear", 2, 2, "B")
+    attacker.blocked_by.append(blocker)
+    blocker.blocking = attacker
+    sim = CombatSimulator([attacker], [blocker])
+    result = sim.simulate()
+    assert blocker in result.creatures_destroyed
+    assert attacker not in result.creatures_destroyed
+
+
+def test_lifelink_grants_life_when_dealing_damage():
+    """CR 702.15a: Damage dealt by a creature with lifelink also causes its controller to gain that much life."""
+    attacker = CombatCreature("Cleric", 2, 2, "A", lifelink=True)
+    blocker = CombatCreature("Guard", 2, 2, "B")
+    attacker.blocked_by.append(blocker)
+    blocker.blocking = attacker
+    sim = CombatSimulator([attacker], [blocker])
+    result = sim.simulate()
+    assert result.lifegain["A"] == 2
+    assert attacker in result.creatures_destroyed
+    assert blocker in result.creatures_destroyed
+
+
+def test_lifelink_unblocked_attacker_gain_life_from_player_damage():
+    """CR 702.15a: Lifelink applies to combat damage dealt to a player."""
+    attacker = CombatCreature("Vampire", 3, 3, "A", lifelink=True)
+    defender = CombatCreature("Dummy", 0, 1, "B")
+    sim = CombatSimulator([attacker], [defender])
+    result = sim.simulate()
+    assert result.damage_to_players["B"] == 3
+    assert result.lifegain["A"] == 3
+

--- a/tests/test_vanilla_combat.py
+++ b/tests/test_vanilla_combat.py
@@ -109,16 +109,16 @@ def test_indestructible_creature_survives_lethal_damage():
     assert blocker not in result.creatures_destroyed
 
 
-def test_first_strike_not_implemented():
-    """CR 702.7b: First strike would let a creature deal damage before others."""
-    attacker = CombatCreature("Swift", 2, 1, "A", first_strike=True)
-    blocker = CombatCreature("Grizzly", 2, 2, "B")
+def test_first_strike_kills_before_normal_damage():
+    """CR 702.7b: Creatures with first strike deal combat damage before creatures without it."""
+    attacker = CombatCreature("Swift", 2, 2, "A", first_strike=True)
+    blocker = CombatCreature("Bear", 2, 2, "B")
     attacker.blocked_by.append(blocker)
     blocker.blocking = attacker
     sim = CombatSimulator([attacker], [blocker])
     result = sim.simulate()
-    assert attacker in result.creatures_destroyed
     assert blocker in result.creatures_destroyed
+    assert attacker not in result.creatures_destroyed
 
 
 def test_multiple_attackers_damage_added():


### PR DESCRIPTION
## Summary
- expand CombatSimulator to handle first and double strike damage steps
- implement lifelink life gain tracking
- update vanilla combat test for first strike behaviour
- add new tests covering double strike and lifelink

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685633c9fd94832aa4a1e3e3df11f77d