### PR TITLE
Implement deathtouch combat rules

### DIFF
--- a/magic_combat/creature.py
+++ b/magic_combat/creature.py
@@ -57,6 +57,7 @@ class CombatCreature:
     blocking: Optional["CombatCreature"] = None
     blocked_by: List["CombatCreature"] = field(default_factory=list)
     damage_marked: int = 0
+    damaged_by_deathtouch: bool = False
 
     # --- Counters ---
     _plus1_counters: int = field(default=0, repr=False)
@@ -99,7 +100,13 @@ class CombatCreature:
 
     def is_destroyed_by_damage(self) -> bool:
         """Check if marked damage is lethal, accounting for indestructibility"""
-        return not self.indestructible and self.damage_marked >= self.effective_toughness()
+        return (
+            not self.indestructible
+            and (
+                self.damage_marked >= self.effective_toughness()
+                or self.damaged_by_deathtouch
+            )
+        )
 
     def __str__(self) -> str:
         return f"{self.name} ({self.power}/{self.toughness})"

--- a/magic_combat/simulator.py
+++ b/magic_combat/simulator.py
@@ -162,8 +162,11 @@ class CombatSimulator:
         ordered = self.assignment_strategy.order_blockers(attacker, blockers)
         remaining = attacker.effective_power()
         for blocker in ordered:
-            dmg = min(remaining, blocker.effective_toughness())
+            lethal = 1 if attacker.deathtouch else blocker.effective_toughness()
+            dmg = min(remaining, lethal)
             blocker.damage_marked += dmg
+            if attacker.deathtouch and dmg > 0:
+                blocker.damaged_by_deathtouch = True
             if attacker.lifelink:
                 self.lifegain[attacker.controller] = (
                     self.lifegain.get(attacker.controller, 0) + dmg
@@ -180,6 +183,8 @@ class CombatSimulator:
         for blocker in blockers:
             dmg = blocker.effective_power()
             attacker.damage_marked += dmg
+            if blocker.deathtouch and dmg > 0:
+                attacker.damaged_by_deathtouch = True
             if blocker.lifelink:
                 self.lifegain[blocker.controller] = (
                     self.lifegain.get(blocker.controller, 0) + dmg

--- a/tests/test_keyword_abilities.py
+++ b/tests/test_keyword_abilities.py
@@ -97,3 +97,42 @@ def test_skulk_and_bushido_combo():
     result = sim.simulate()
     assert blocker in result.creatures_destroyed
     assert attacker not in result.creatures_destroyed
+
+
+def test_deathtouch_single_block():
+    """CR 702.2b: Any amount of damage from a creature with deathtouch is lethal."""
+    attacker = CombatCreature("Assassin", 1, 1, "A", deathtouch=True)
+    blocker = CombatCreature("Giant", 5, 5, "B")
+    attacker.blocked_by.append(blocker)
+    blocker.blocking = attacker
+    sim = CombatSimulator([attacker], [blocker])
+    result = sim.simulate()
+    assert blocker in result.creatures_destroyed
+    assert attacker in result.creatures_destroyed
+
+
+def test_deathtouch_double_block_assignment():
+    """CR 702.2b: With deathtouch, only 1 damage must be assigned to each blocker."""
+    attacker = CombatCreature("Snake", 3, 3, "A", deathtouch=True)
+    b1 = CombatCreature("Guard1", 3, 3, "B")
+    b2 = CombatCreature("Guard2", 3, 3, "B")
+    attacker.blocked_by.extend([b1, b2])
+    b1.blocking = attacker
+    b2.blocking = attacker
+    sim = CombatSimulator([attacker], [b1, b2])
+    result = sim.simulate()
+    assert b1 in result.creatures_destroyed
+    assert b2 in result.creatures_destroyed
+    assert attacker in result.creatures_destroyed
+
+
+def test_deathtouch_vs_indestructible():
+    """CR 702.12b & 702.2b: Indestructible prevents destruction even from deathtouch."""
+    attacker = CombatCreature("Rogue", 1, 1, "A", deathtouch=True)
+    blocker = CombatCreature("Guardian", 2, 2, "B", indestructible=True)
+    attacker.blocked_by.append(blocker)
+    blocker.blocking = attacker
+    sim = CombatSimulator([attacker], [blocker])
+    result = sim.simulate()
+    assert blocker not in result.creatures_destroyed
+    assert attacker in result.creatures_destroyed


### PR DESCRIPTION
## Summary
- model damage from deathtouch sources
- treat damage from deathtouch as lethal in destruction checks
- when assigning damage from a deathtouch creature, only 1 damage is needed per blocker
- propagate deathtouch damage from blockers to attackers
- add tests for deathtouch including indestructible interaction

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68563f1998b0832aa56ca05a60df3486