### PR TITLE
Add zero toughness state-based action

### DIFF
--- a/magic_combat/simulator.py
+++ b/magic_combat/simulator.py
@@ -214,8 +214,17 @@ class CombatSimulator:
                     self._deal_damage_to_player(attacker)
 
     def check_lethal_damage(self):
-        """Evaluate which creatures die after damage."""
-        self.dead_creatures = [c for c in self.all_creatures if c.is_destroyed_by_damage()]
+        """Evaluate which creatures die after damage or state-based effects."""
+        destroyed_by_damage = [
+            c for c in self.all_creatures if c.is_destroyed_by_damage()
+        ]
+        zero_toughness = [
+            c for c in self.all_creatures if c.effective_toughness() <= 0
+        ]
+        self.dead_creatures = destroyed_by_damage
+        for creature in zero_toughness:
+            if creature not in self.dead_creatures:
+                self.dead_creatures.append(creature)
 
     def apply_lifelink_and_combat_lifegain(self):
         """Placeholder for additional combat-related lifegain."""
@@ -234,6 +243,7 @@ class CombatSimulator:
         self.dead_creatures: List[CombatCreature] = []
         self.validate_blocking()
         self.apply_precombat_triggers()
+        self.check_lethal_damage()
 
         # First strike step
         any_first_strike = any(c.first_strike or c.double_strike for c in self.all_creatures)

--- a/tests/combat/test_state_based_toughness.py
+++ b/tests/combat/test_state_based_toughness.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from magic_combat import CombatCreature, CombatSimulator
+
+
+def test_flanking_kills_weak_blocker_pre_damage():
+    """CR 704.5f: A creature with toughness 0 or less is put into its owner's graveyard."""
+    attacker = CombatCreature("Flanker", 1, 1, "A", flanking=1)
+    blocker = CombatCreature("Vanilla", 1, 1, "B")
+    attacker.blocked_by.append(blocker)
+    blocker.blocking = attacker
+    sim = CombatSimulator([attacker], [blocker])
+    result = sim.simulate()
+    assert blocker in result.creatures_destroyed
+    assert attacker not in result.creatures_destroyed
+
+
+def test_minus_counters_can_cause_precombat_death():
+    """CR 704.5f: State-based actions remove creatures with 0 toughness."""
+    attacker = CombatCreature("Ogre", 2, 2, "A")
+    blocker = CombatCreature("Weakling", 2, 2, "B", _minus1_counters=2)
+    attacker.blocked_by.append(blocker)
+    blocker.blocking = attacker
+    sim = CombatSimulator([attacker], [blocker])
+    result = sim.simulate()
+    assert blocker in result.creatures_destroyed
+    assert attacker not in result.creatures_destroyed
+
+
+def test_flanking_does_not_affect_other_flankers():
+    """CR 702.25a: Flanking applies only to creatures without flanking."""
+    attacker = CombatCreature("Knight1", 1, 1, "A", flanking=1)
+    blocker = CombatCreature("Knight2", 1, 1, "B", flanking=1)
+    attacker.blocked_by.append(blocker)
+    blocker.blocking = attacker
+    sim = CombatSimulator([attacker], [blocker])
+    result = sim.simulate()
+    assert blocker in result.creatures_destroyed
+    assert attacker in result.creatures_destroyed


### PR DESCRIPTION
## Summary
- add state based check for toughness before damage
- ensure zero-toughness creatures die precombat
- test that flanking and counters can reduce a blocker to zero toughness
- verify flankers trade normally when both have flanking

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68564329bc24832a9ea4e2a986d42b53