### PR TITLE
Implement deathtouch ability

### DIFF
--- a/magic_combat/creature.py
+++ b/magic_combat/creature.py
@@ -57,6 +57,7 @@ class CombatCreature:
     blocking: Optional["CombatCreature"] = None
     blocked_by: List["CombatCreature"] = field(default_factory=list)
     damage_marked: int = 0
+    received_deathtouch_damage: bool = False
 
     # --- Counters ---
     _plus1_counters: int = field(default=0, repr=False)
@@ -98,8 +99,12 @@ class CombatCreature:
         )
 
     def is_destroyed_by_damage(self) -> bool:
-        """Check if marked damage is lethal, accounting for indestructibility"""
-        return not self.indestructible and self.damage_marked >= self.effective_toughness()
+        """Check if marked damage is lethal, accounting for indestructibility and deathtouch."""
+        if self.indestructible:
+            return False
+        lethal = self.damage_marked >= self.effective_toughness()
+        deathtouched = self.received_deathtouch_damage and self.damage_marked > 0
+        return lethal or deathtouched
 
     def __str__(self) -> str:
         return f"{self.name} ({self.power}/{self.toughness})"
@@ -138,3 +143,4 @@ class CombatCreature:
         """Clear temporary power and toughness modifiers."""
         self.temp_power = 0
         self.temp_toughness = 0
+        self.received_deathtouch_damage = False

--- a/magic_combat/simulator.py
+++ b/magic_combat/simulator.py
@@ -162,8 +162,13 @@ class CombatSimulator:
         ordered = self.assignment_strategy.order_blockers(attacker, blockers)
         remaining = attacker.effective_power()
         for blocker in ordered:
-            dmg = min(remaining, blocker.effective_toughness())
+            lethal = (
+                1 if attacker.deathtouch and not blocker.indestructible else blocker.effective_toughness()
+            )
+            dmg = min(remaining, lethal)
             blocker.damage_marked += dmg
+            if attacker.deathtouch and dmg > 0:
+                blocker.received_deathtouch_damage = True
             if attacker.lifelink:
                 self.lifegain[attacker.controller] = (
                     self.lifegain.get(attacker.controller, 0) + dmg
@@ -180,6 +185,8 @@ class CombatSimulator:
         for blocker in blockers:
             dmg = blocker.effective_power()
             attacker.damage_marked += dmg
+            if blocker.deathtouch and dmg > 0:
+                attacker.received_deathtouch_damage = True
             if blocker.lifelink:
                 self.lifegain[blocker.controller] = (
                     self.lifegain.get(blocker.controller, 0) + dmg
@@ -232,6 +239,9 @@ class CombatSimulator:
     def simulate(self) -> CombatResult:
         """Run a full combat phase resolution and return the result."""
         self.dead_creatures: List[CombatCreature] = []
+        for c in self.all_creatures:
+            c.damage_marked = 0
+            c.received_deathtouch_damage = False
         self.validate_blocking()
         self.apply_precombat_triggers()
 

--- a/tests/abilities/test_deathtouch.py
+++ b/tests/abilities/test_deathtouch.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from magic_combat import CombatCreature, CombatSimulator
+
+
+def test_deathtouch_double_block():
+    """CR 702.2b: Any amount of damage from a creature with deathtouch is lethal."""
+    attacker = CombatCreature("Assassin", 2, 2, "A", deathtouch=True)
+    b1 = CombatCreature("Guard1", 2, 2, "B")
+    b2 = CombatCreature("Guard2", 2, 2, "B")
+    attacker.blocked_by.extend([b1, b2])
+    b1.blocking = attacker
+    b2.blocking = attacker
+    sim = CombatSimulator([attacker], [b1, b2])
+    result = sim.simulate()
+    assert b1 in result.creatures_destroyed
+    assert b2 in result.creatures_destroyed
+    assert attacker in result.creatures_destroyed
+
+
+def test_deathtouch_prevented_by_first_strike():
+    """CR 702.2b & 702.7b: If a deathtouch creature dies before dealing damage, it destroys nothing."""
+    attacker = CombatCreature("Asp", 2, 2, "A", deathtouch=True)
+    blocker = CombatCreature("Knight", 2, 2, "B", first_strike=True)
+    attacker.blocked_by.append(blocker)
+    blocker.blocking = attacker
+    sim = CombatSimulator([attacker], [blocker])
+    result = sim.simulate()
+    assert attacker in result.creatures_destroyed
+    assert blocker not in result.creatures_destroyed
+
+
+def test_deathtouch_vs_indestructible():
+    """CR 702.2b & 702.12b: Deathtouch doesn't destroy indestructible creatures."""
+    attacker = CombatCreature("Snake", 1, 1, "A", deathtouch=True)
+    blocker = CombatCreature("Golem", 0, 3, "B", indestructible=True)
+    attacker.blocked_by.append(blocker)
+    blocker.blocking = attacker
+    sim = CombatSimulator([attacker], [blocker])
+    result = sim.simulate()
+    assert result.creatures_destroyed == []


### PR DESCRIPTION
## Summary
- implement deathtouch kill logic on creatures
- extend damage assignment strategy to work with deathtouch
- track when creatures receive deathtouch damage
- reset state before each simulation
- add comprehensive tests for deathtouch interactions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685642997158832a91bbeb8ccf66c231