### PR TITLE
Add trample ability with rules-based tests

### DIFF
--- a/tests/abilities/test_edge_cases.py
+++ b/tests/abilities/test_edge_cases.py
@@ -129,3 +129,14 @@ def test_rampage_and_flanking_multi_block():
     assert b1 in result.creatures_destroyed
     assert b2 in result.creatures_destroyed
     assert attacker not in result.creatures_destroyed
+
+
+def test_blocked_creature_no_trample_hits_no_player():
+    """CR 509.1h: A creature remains blocked even if its blocker dies."""
+    attacker = CombatCreature("Fencer", 2, 2, "A", first_strike=True)
+    blocker = CombatCreature("Guard", 2, 2, "B")
+    attacker.blocked_by.append(blocker)
+    blocker.blocking = attacker
+    sim = CombatSimulator([attacker], [blocker])
+    result = sim.simulate()
+    assert result.damage_to_players.get("B", 0) == 0

--- a/tests/abilities/test_keyword_abilities.py
+++ b/tests/abilities/test_keyword_abilities.py
@@ -157,3 +157,30 @@ def test_deathtouch_killed_before_dealing_damage():
     result = sim.simulate()
     assert atk in result.creatures_destroyed
     assert blk not in result.creatures_destroyed
+
+
+def test_trample_excess_damage_to_player():
+    """CR 702.19b: Damage beyond lethal can be assigned to the defending player."""
+    atk = CombatCreature("Rhino", 4, 4, "A", trample=True)
+    blk = CombatCreature("Wall", 0, 3, "B")
+    atk.blocked_by.append(blk)
+    blk.blocking = atk
+    sim = CombatSimulator([atk], [blk])
+    result = sim.simulate()
+    assert blk in result.creatures_destroyed
+    assert result.damage_to_players["B"] == 1
+
+
+def test_deathtouch_trample_multiple_blockers():
+    """CR 702.19b & 702.2b: With deathtouch, only 1 damage is lethal per blocker."""
+    atk = CombatCreature("Beast", 3, 3, "A", trample=True, deathtouch=True)
+    b1 = CombatCreature("B1", 2, 2, "B")
+    b2 = CombatCreature("B2", 2, 2, "B")
+    atk.blocked_by.extend([b1, b2])
+    b1.blocking = atk
+    b2.blocking = atk
+    sim = CombatSimulator([atk], [b1, b2])
+    result = sim.simulate()
+    assert b1 in result.creatures_destroyed
+    assert b2 in result.creatures_destroyed
+    assert result.damage_to_players["B"] == 1


### PR DESCRIPTION
## Summary
- handle excess damage to player for trample creatures
- ensure blocked creatures don't hit players unless they have trample
- test trample on its own and with deathtouch
- test that creatures remain blocked when their blocker dies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856464f01d4832aa6fd9ff7e8ee7208