### PR TITLE
Simplify test imports

### DIFF
--- a/tests/abilities/test_blocking_rules.py
+++ b/tests/abilities/test_blocking_rules.py
@@ -1,9 +1,5 @@
 import pytest
-from pathlib import Path
-import sys
 
-# Ensure the package is importable when running tests from any location
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from magic_combat import CombatCreature, CombatSimulator
 

--- a/tests/abilities/test_edge_cases.py
+++ b/tests/abilities/test_edge_cases.py
@@ -1,9 +1,5 @@
-from pathlib import Path
-import sys
 import pytest
 
-# Ensure the package is importable when running tests from any location
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from magic_combat import CombatCreature, CombatSimulator
 

--- a/tests/abilities/test_interactions.py
+++ b/tests/abilities/test_interactions.py
@@ -1,9 +1,5 @@
-from pathlib import Path
-import sys
 import pytest
 
-# Ensure the package is importable when running tests from any location
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from magic_combat import CombatCreature, CombatSimulator
 

--- a/tests/abilities/test_keyword_abilities.py
+++ b/tests/abilities/test_keyword_abilities.py
@@ -1,8 +1,3 @@
-from pathlib import Path
-import sys
-
-sys.path.append(str(Path(__file__).resolve().parents[1]))
-
 from magic_combat import CombatCreature, CombatSimulator
 
 

--- a/tests/combat/test_advanced_combat.py
+++ b/tests/combat/test_advanced_combat.py
@@ -1,9 +1,3 @@
-from pathlib import Path
-import sys
-
-# Ensure the package is importable when running tests from any location
-sys.path.append(str(Path(__file__).resolve().parents[1]))
-
 from magic_combat import CombatCreature, CombatSimulator
 
 

--- a/tests/combat/test_basic_combat.py
+++ b/tests/combat/test_basic_combat.py
@@ -1,9 +1,5 @@
-from pathlib import Path
-import sys
 import pytest
 
-# Ensure the package is importable when running tests from any location
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from magic_combat import CombatCreature, CombatSimulator
 

--- a/tests/combat/test_consistency.py
+++ b/tests/combat/test_consistency.py
@@ -1,9 +1,5 @@
 import random
-from pathlib import Path
-import sys
 
-# Ensure the package is importable when running tests from any location
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from magic_combat import CombatCreature, CombatSimulator
 

--- a/tests/combat/test_state_based_toughness.py
+++ b/tests/combat/test_state_based_toughness.py
@@ -1,8 +1,3 @@
-from pathlib import Path
-import sys
-
-sys.path.append(str(Path(__file__).resolve().parents[1]))
-
 from magic_combat import CombatCreature, CombatSimulator
 
 

--- a/tests/core/test_creature_validation.py
+++ b/tests/core/test_creature_validation.py
@@ -1,9 +1,5 @@
-from pathlib import Path
-import sys
 import pytest
 
-# Ensure the package is importable when running tests from any location
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from magic_combat import CombatCreature
 

--- a/tests/core/test_extra_features.py
+++ b/tests/core/test_extra_features.py
@@ -1,9 +1,5 @@
 import pytest
-from pathlib import Path
-import sys
 
-# Ensure the package is importable when running tests from any location
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from magic_combat import (
     CombatCreature,

--- a/tests/core/test_imports.py
+++ b/tests/core/test_imports.py
@@ -1,9 +1,3 @@
-from pathlib import Path
-import sys
-
-# Ensure the package is importable when running tests from any location
-sys.path.append(str(Path(__file__).resolve().parents[1]))
-
 from magic_combat import CombatCreature, CombatResult, CombatSimulator
 
 


### PR DESCRIPTION
## Summary
- drop `sys.path.append` setup from all tests
- rely on `conftest.py` for repository path handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68564a848be0832ab9279ef88ed658c8