### PR TITLE
Introduce Color enum

### DIFF
--- a/magic_combat/creature.py
+++ b/magic_combat/creature.py
@@ -2,10 +2,18 @@
 
 from dataclasses import dataclass, field
 from typing import Set, List, Optional
+from enum import Enum
 
 from .utils import check_non_negative, check_positive
 
-Color = str  # e.g., "white", "blue", "black", "red", "green"
+class Color(Enum):
+    """Enumeration of Magic: The Gathering's five colors."""
+
+    WHITE = "white"
+    BLUE = "blue"
+    BLACK = "black"
+    RED = "red"
+    GREEN = "green"
 
 
 @dataclass

--- a/magic_combat/simulator.py
+++ b/magic_combat/simulator.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 
-from .creature import CombatCreature
+from .creature import CombatCreature, Color
 from .damage import DamageAssignmentStrategy, MostCreaturesKilledStrategy
 
 @dataclass
@@ -64,7 +64,9 @@ class CombatSimulator:
                 if attacker.skulk and blocker.effective_power() > attacker.effective_power():
                     raise ValueError("Skulk prevents block by higher power")
 
-                if attacker.fear and not (blocker.artifact or "black" in blocker.colors):
+                if attacker.fear and not (
+                    blocker.artifact or Color.BLACK in blocker.colors
+                ):
                     raise ValueError("Fear creature blocked illegally")
 
                 if attacker.protection_colors & blocker.colors:

--- a/tests/abilities/test_blocking_rules.py
+++ b/tests/abilities/test_blocking_rules.py
@@ -5,7 +5,7 @@ import sys
 # Ensure the package is importable when running tests from any location
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from magic_combat import CombatCreature, CombatSimulator
+from magic_combat import CombatCreature, CombatSimulator, Color
 
 
 def test_flying_requires_flying_or_reach():
@@ -56,14 +56,14 @@ def test_menace_with_two_blockers_allowed():
 def test_fear_blocking():
     """CR 702.36b: Fear allows blocking only by artifact or black creatures."""
     attacker = CombatCreature("Nightmare", 2, 2, "A", fear=True)
-    blocker = CombatCreature("Knight", 2, 2, "B", colors={"white"})
+    blocker = CombatCreature("Knight", 2, 2, "B", colors={Color.WHITE})
     attacker.blocked_by.append(blocker)
     blocker.blocking = attacker
     sim = CombatSimulator([attacker], [blocker])
     with pytest.raises(ValueError):
         sim.validate_blocking()
 
-    black_blocker = CombatCreature("Shade", 1, 1, "B", colors={"black"})
+    black_blocker = CombatCreature("Shade", 1, 1, "B", colors={Color.BLACK})
     attacker.blocked_by = [black_blocker]
     black_blocker.blocking = attacker
     sim = CombatSimulator([attacker], [black_blocker])
@@ -72,8 +72,8 @@ def test_fear_blocking():
 
 def test_protection_prevents_blocking():
     """CR 702.16b: Protection from a color means it can't be blocked by creatures of that color."""
-    attacker = CombatCreature("Paladin", 2, 2, "A", protection_colors={"red"})
-    blocker = CombatCreature("Orc", 2, 2, "B", colors={"red"})
+    attacker = CombatCreature("Paladin", 2, 2, "A", protection_colors={Color.RED})
+    blocker = CombatCreature("Orc", 2, 2, "B", colors={Color.RED})
     attacker.blocked_by.append(blocker)
     blocker.blocking = attacker
     sim = CombatSimulator([attacker], [blocker])

--- a/tests/abilities/test_interactions.py
+++ b/tests/abilities/test_interactions.py
@@ -5,16 +5,16 @@ import pytest
 # Ensure the package is importable when running tests from any location
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from magic_combat import CombatCreature, CombatSimulator
+from magic_combat import CombatCreature, CombatSimulator, Color
 
 
 def test_fear_and_protection_from_black():
     """CR 702.36b & 702.16b: Fear allows only artifact or black blockers, but protection from black stops black blockers."""
     atk = CombatCreature(
-        "Nightblade", 2, 2, "A", fear=True, protection_colors={"black"}
+        "Nightblade", 2, 2, "A", fear=True, protection_colors={Color.BLACK}
     )
     blk = CombatCreature(
-        "Black Artifact", 2, 2, "B", colors={"black"}, artifact=True
+        "Black Artifact", 2, 2, "B", colors={Color.BLACK}, artifact=True
     )
     atk.blocked_by.append(blk)
     blk.blocking = atk

--- a/tests/core/test_extra_features.py
+++ b/tests/core/test_extra_features.py
@@ -10,6 +10,7 @@ from magic_combat import (
     DamageAssignmentStrategy,
     MostCreaturesKilledStrategy,
     CombatSimulator,
+    Color,
 )
 
 
@@ -31,10 +32,10 @@ def test_effective_stats_with_counters():
 def test_has_protection_from():
     """CR 702.16b: Protection prevents effects from objects of that color."""
     creature = CombatCreature(
-        name="Paladin", power=2, toughness=2, controller="A", protection_colors={"black"}
+        name="Paladin", power=2, toughness=2, controller="A", protection_colors={Color.BLACK}
     )
-    assert creature.has_protection_from("black")
-    assert not creature.has_protection_from("red")
+    assert creature.has_protection_from(Color.BLACK)
+    assert not creature.has_protection_from(Color.RED)
 
 
 def test_destroyed_by_damage():


### PR DESCRIPTION
## Summary
- convert `Color` from a simple alias to an `Enum`
- update simulator to check for `Color.BLACK`
- adapt unit tests to use the enum

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68564a9922a0832a918caf675f534a4b