### PR TITLE
Check for duplicate blockers

### DIFF
--- a/magic_combat/simulator.py
+++ b/magic_combat/simulator.py
@@ -45,6 +45,14 @@ class CombatSimulator:
                     raise ValueError("Inconsistent blocking assignments")
 
         for attacker in self.attackers:
+            seen_ids = set()
+            for blocker in attacker.blocked_by:
+                bid = id(blocker)
+                if bid in seen_ids:
+                    raise ValueError("Blocker listed multiple times")
+                seen_ids.add(bid)
+
+        for attacker in self.attackers:
             if attacker.unblockable and attacker.blocked_by:
                 raise ValueError("Unblockable creature was blocked")
 

--- a/tests/abilities/test_blocking_rules.py
+++ b/tests/abilities/test_blocking_rules.py
@@ -104,3 +104,14 @@ def test_unblockable_cannot_be_blocked():
     sim = CombatSimulator([attacker], [blocker])
     with pytest.raises(ValueError):
         sim.validate_blocking()
+
+
+def test_blocker_listed_multiple_times():
+    """CR 509.1c: A creature can't block the same attacker more than once."""
+    attacker = CombatCreature("Ogre", 3, 3, "A")
+    blocker = CombatCreature("Soldier", 2, 2, "B")
+    attacker.blocked_by.extend([blocker, blocker])
+    blocker.blocking = attacker
+    sim = CombatSimulator([attacker], [blocker])
+    with pytest.raises(ValueError):
+        sim.validate_blocking()


### PR DESCRIPTION
## Summary
- prevent declaring the same blocker multiple times for one attacker
- test blocker duplication error using CR 509.1c

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68564ac44130832ab88df6da232f2dac