### PR TITLE
Fix ordering strategy immutability

### DIFF
--- a/magic_combat/damage.py
+++ b/magic_combat/damage.py
@@ -12,7 +12,7 @@ class DamageAssignmentStrategy:
         self, attacker: CombatCreature, blockers: List[CombatCreature]
     ) -> List[CombatCreature]:
         """Return blockers in the order the attacker will assign damage."""
-        return blockers
+        return list(blockers)
 
 
 class MostCreaturesKilledStrategy(DamageAssignmentStrategy):


### PR DESCRIPTION
## Summary
- avoid mutating lists in `DamageAssignmentStrategy.order_blockers`
- confirm `MostCreaturesKilledStrategy` returns a new list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68564ad1bc8c832abb8312260f88062a