### PR TITLE
Implement vigilance ability

### DIFF
--- a/magic_combat/simulator.py
+++ b/magic_combat/simulator.py
@@ -35,6 +35,11 @@ class CombatSimulator:
         self.lifegain: Dict[str, int] = {}
         self.assignment_strategy = strategy or MostCreaturesKilledStrategy()
 
+        for attacker in self.attackers:
+            attacker.attacking = True
+            if not attacker.vigilance:
+                attacker.tapped = True
+
     def validate_blocking(self):
         """Ensure blocking assignments are legal for this simplified simulator."""
         for blocker in self.defenders:

--- a/tests/abilities/test_keyword_abilities.py
+++ b/tests/abilities/test_keyword_abilities.py
@@ -201,3 +201,22 @@ def test_infect_poison_counters_on_player():
     result = sim.simulate()
     assert result.poison_counters["B"] == 2
     assert result.damage_to_players.get("B", 0) == 0
+
+
+def test_vigilance_attacker_stays_untapped():
+    """CR 702.21b: Attacking doesn't cause a creature with vigilance to tap."""
+    atk = CombatCreature("Watcher", 2, 2, "A", vigilance=True)
+    defender = CombatCreature("Dummy", 0, 1, "B")
+    sim = CombatSimulator([atk], [defender])
+    result = sim.simulate()
+    assert not atk.tapped
+    assert result.damage_to_players.get("B", 0) == 2
+
+
+def test_normal_attacker_taps_on_attack():
+    """CR 508.1g: Declaring an attacker causes it to become tapped."""
+    atk = CombatCreature("Orc", 2, 2, "A")
+    defender = CombatCreature("Dummy", 0, 1, "B")
+    sim = CombatSimulator([atk], [defender])
+    result = sim.simulate()
+    assert atk.tapped


### PR DESCRIPTION
## Summary
- tap attackers when combat starts
- skip tapping for attackers with vigilance
- add tests for vigilance behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68564c646d0c832a9ec0f8ea6e1a6fb4