### PR TITLE
Add game state tracking and player loss checks

### DIFF
--- a/magic_combat/__init__.py
+++ b/magic_combat/__init__.py
@@ -3,6 +3,7 @@
 from .creature import CombatCreature, Color
 from .simulator import CombatResult, CombatSimulator
 from .damage import DamageAssignmentStrategy, MostCreaturesKilledStrategy
+from .gamestate import GameState, PlayerState, has_player_lost
 
 __all__ = [
     "CombatCreature",
@@ -11,4 +12,7 @@ __all__ = [
     "CombatSimulator",
     "DamageAssignmentStrategy",
     "MostCreaturesKilledStrategy",
+    "GameState",
+    "PlayerState",
+    "has_player_lost",
 ]

--- a/magic_combat/gamestate.py
+++ b/magic_combat/gamestate.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+"""Game state representation for the combat simulator."""
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+from .creature import CombatCreature
+
+
+@dataclass
+class PlayerState:
+    """State for a single player."""
+
+    life: int
+    creatures: List[CombatCreature]
+    poison: int = 0
+
+
+@dataclass
+class GameState:
+    """Overall game state tracking both players."""
+
+    players: Dict[str, PlayerState] = field(default_factory=dict)
+
+
+def has_player_lost(state: GameState, player: str) -> bool:
+    """Return ``True`` if ``player`` has lost the game."""
+    ps = state.players.get(player)
+    if ps is None:
+        return False
+    return ps.life <= 0 or ps.poison >= 10

--- a/magic_combat/simulator.py
+++ b/magic_combat/simulator.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Optional
 
 from .creature import CombatCreature, Color
 from .damage import DamageAssignmentStrategy, MostCreaturesKilledStrategy
+from .gamestate import GameState, PlayerState, has_player_lost
 
 @dataclass
 class CombatResult:
@@ -14,6 +15,7 @@ class CombatResult:
     creatures_destroyed: List[CombatCreature]
     lifegain: Dict[str, int]
     poison_counters: Dict[str, int] = field(default_factory=dict)
+    players_lost: List[str] = field(default_factory=list)
 
 
 class CombatSimulator:
@@ -24,6 +26,7 @@ class CombatSimulator:
         attackers: List[CombatCreature],
         defenders: List[CombatCreature],
         strategy: Optional[DamageAssignmentStrategy] = None,
+        game_state: Optional["GameState"] = None,
     ):
         """Store combatants taking part in the current combat phase."""
 
@@ -34,6 +37,16 @@ class CombatSimulator:
         self.poison_counters: Dict[str, int] = {}
         self.lifegain: Dict[str, int] = {}
         self.assignment_strategy = strategy or MostCreaturesKilledStrategy()
+        self.game_state = game_state
+        self.players_lost: List[str] = []
+
+    def _check_players_lost(self) -> None:
+        """Record any players who have lost the game."""
+        if self.game_state is None:
+            return
+        for player in list(self.game_state.players.keys()):
+            if has_player_lost(self.game_state, player) and player not in self.players_lost:
+                self.players_lost.append(player)
 
     def validate_blocking(self):
         """Ensure blocking assignments are legal for this simplified simulator."""
@@ -223,8 +236,20 @@ class CombatSimulator:
         dmg = attacker.effective_power() if dmg is None else dmg
         if attacker.infect:
             self.poison_counters[defender] = self.poison_counters.get(defender, 0) + dmg
+            if self.game_state is not None:
+                ps = self.game_state.players.setdefault(
+                    defender,
+                    PlayerState(life=20, creatures=[], poison=0),
+                )
+                ps.poison += dmg
         else:
             self.player_damage[defender] = self.player_damage.get(defender, 0) + dmg
+            if self.game_state is not None:
+                ps = self.game_state.players.setdefault(
+                    defender,
+                    PlayerState(life=20, creatures=[], poison=0),
+                )
+                ps.life -= dmg
         if attacker.lifelink:
             self.lifegain[attacker.controller] = (
                 self.lifegain.get(attacker.controller, 0) + dmg
@@ -265,8 +290,14 @@ class CombatSimulator:
                 self.dead_creatures.append(creature)
 
     def apply_lifelink_and_combat_lifegain(self):
-        """Placeholder for additional combat-related lifegain."""
-        # lifegain has been accumulated during damage assignment
+        """Apply lifelink life gain to the game state, if any."""
+        if self.game_state is not None:
+            for player, gain in self.lifegain.items():
+                ps = self.game_state.players.setdefault(
+                    player, PlayerState(life=20, creatures=[], poison=0)
+                )
+                ps.life += gain
+        # lifegain remains tracked for CombatResult
 
     def finalize(self) -> CombatResult:
         """Return the outcome of combat."""
@@ -275,6 +306,7 @@ class CombatSimulator:
             poison_counters=self.poison_counters,
             creatures_destroyed=self.dead_creatures,
             lifegain=self.lifegain,
+            players_lost=self.players_lost,
         )
 
     def simulate(self) -> CombatResult:
@@ -288,10 +320,13 @@ class CombatSimulator:
         any_first_strike = any(c.first_strike or c.double_strike for c in self.all_creatures)
         if any_first_strike:
             self.resolve_first_strike_damage()
+            self.apply_lifelink_and_combat_lifegain()
             self.check_lethal_damage()
+            self._check_players_lost()
 
         self.resolve_normal_combat_damage()
-        self.check_lethal_damage()
         self.apply_lifelink_and_combat_lifegain()
+        self.check_lethal_damage()
+        self._check_players_lost()
 
         return self.finalize()

--- a/tests/combat/test_gamestate.py
+++ b/tests/combat/test_gamestate.py
@@ -1,0 +1,42 @@
+import pytest
+from magic_combat import (
+    CombatCreature,
+    CombatSimulator,
+    GameState,
+    PlayerState,
+    has_player_lost,
+)
+
+
+def test_player_loses_when_life_zero():
+    """CR 104.3a: A player with 0 or less life loses the game."""
+    atk = CombatCreature("Bear", 2, 2, "A")
+    defender = CombatCreature("Dummy", 0, 1, "B")
+    state = GameState(
+        players={
+            "A": PlayerState(life=20, creatures=[atk]),
+            "B": PlayerState(life=2, creatures=[defender]),
+        }
+    )
+    sim = CombatSimulator([atk], [defender], game_state=state)
+    sim.simulate()
+    assert state.players["B"].life == 0
+    assert has_player_lost(state, "B")
+    assert "B" in sim.players_lost
+
+
+def test_player_loses_from_poison():
+    """CR 104.3c: A player with ten or more poison counters loses the game."""
+    atk = CombatCreature("Infector", 2, 2, "A", infect=True)
+    defender = CombatCreature("Dummy", 0, 1, "B")
+    state = GameState(
+        players={
+            "A": PlayerState(life=20, creatures=[atk]),
+            "B": PlayerState(life=20, creatures=[defender], poison=9),
+        }
+    )
+    sim = CombatSimulator([atk], [defender], game_state=state)
+    sim.simulate()
+    assert state.players["B"].poison == 11
+    assert has_player_lost(state, "B")
+    assert "B" in sim.players_lost


### PR DESCRIPTION
## Summary
- add a simple `GameState` model and loss helper
- export the new state classes
- update simulator to apply damage/lifelink to the game state
- detect losing players after each combat stage
- test that players lose via life or poison counters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68564d1ac904832ab3b88b971526139e