### PR TITLE
Add life loss and poison counter tests

### DIFF
--- a/magic_combat/simulator.py
+++ b/magic_combat/simulator.py
@@ -36,17 +36,17 @@ class CombatSimulator:
         self.player_damage: Dict[str, int] = {}
         self.poison_counters: Dict[str, int] = {}
         self.lifegain: Dict[str, int] = {}
+        self._lifegain_applied: Dict[str, int] = {}
         self.assignment_strategy = strategy or MostCreaturesKilledStrategy()
         self.game_state = game_state
         self.players_lost: List[str] = []
 
     def _check_players_lost(self) -> None:
         """Record any players who have lost the game."""
-        if self.game_state is None:
-            return
-        for player in list(self.game_state.players.keys()):
-            if has_player_lost(self.game_state, player) and player not in self.players_lost:
-                self.players_lost.append(player)
+        if self.game_state is not None:
+            for player in list(self.game_state.players.keys()):
+                if has_player_lost(self.game_state, player) and player not in self.players_lost:
+                    self.players_lost.append(player)
 
         for attacker in self.attackers:
             attacker.attacking = True
@@ -298,10 +298,14 @@ class CombatSimulator:
         """Apply lifelink life gain to the game state, if any."""
         if self.game_state is not None:
             for player, gain in self.lifegain.items():
-                ps = self.game_state.players.setdefault(
-                    player, PlayerState(life=20, creatures=[], poison=0)
-                )
-                ps.life += gain
+                already = self._lifegain_applied.get(player, 0)
+                diff = gain - already
+                if diff:
+                    ps = self.game_state.players.setdefault(
+                        player, PlayerState(life=20, creatures=[], poison=0)
+                    )
+                    ps.life += diff
+                    self._lifegain_applied[player] = gain
         # lifegain remains tracked for CombatResult
 
     def finalize(self) -> CombatResult:

--- a/tests/combat/test_gamestate.py
+++ b/tests/combat/test_gamestate.py
@@ -40,3 +40,116 @@ def test_player_loses_from_poison():
     assert state.players["B"].poison == 11
     assert has_player_lost(state, "B")
     assert "B" in sim.players_lost
+
+
+def test_trample_infect_assigns_excess_poison():
+    """CR 702.19b & 702.90b: Trample with infect deals excess damage as poison counters."""
+    atk = CombatCreature("Toxic Beast", 4, 4, "A", trample=True, infect=True)
+    blk = CombatCreature("Chump", 1, 1, "B")
+    atk.blocked_by.append(blk)
+    blk.blocking = atk
+    state = GameState(
+        players={
+            "A": PlayerState(life=20, creatures=[atk]),
+            "B": PlayerState(life=20, creatures=[blk]),
+        }
+    )
+    sim = CombatSimulator([atk], [blk], game_state=state)
+    result = sim.simulate()
+    assert blk.minus1_counters == 1
+    assert state.players["B"].life == 20
+    assert state.players["B"].poison == 3
+    assert result.poison_counters["B"] == 3
+
+
+def test_infect_with_lifelink_grants_life():
+    """CR 702.90b & 702.15a: Infect damage gives poison counters but still triggers lifelink."""
+    atk = CombatCreature("Toxic Healer", 2, 2, "A", infect=True, lifelink=True)
+    defender = CombatCreature("Dummy", 0, 1, "B")
+    state = GameState(
+        players={
+            "A": PlayerState(life=10, creatures=[atk]),
+            "B": PlayerState(life=20, creatures=[defender]),
+        }
+    )
+    sim = CombatSimulator([atk], [defender], game_state=state)
+    result = sim.simulate()
+    assert result.poison_counters["B"] == 2
+    assert result.damage_to_players.get("B", 0) == 0
+    assert result.lifegain["A"] == 2
+    assert state.players["A"].life == 12
+
+
+def test_wither_and_lifelink_vs_creature():
+    """CR 702.90a & 702.15a: Wither deals -1/-1 counters but counts as damage for lifelink."""
+    atk = CombatCreature("Pain Giver", 3, 3, "A", wither=True, lifelink=True)
+    blk = CombatCreature("Target", 2, 2, "B")
+    atk.blocked_by.append(blk)
+    blk.blocking = atk
+    state = GameState(
+        players={
+            "A": PlayerState(life=20, creatures=[atk]),
+            "B": PlayerState(life=20, creatures=[blk]),
+        }
+    )
+    sim = CombatSimulator([atk], [blk], game_state=state)
+    result = sim.simulate()
+    assert blk.minus1_counters == 2
+    assert blk in result.creatures_destroyed
+    assert result.lifegain["A"] == 2
+    assert state.players["A"].life == 22
+
+
+def test_deathtouch_trample_hits_player():
+    """CR 702.19b & 702.2b: Only 1 damage must be assigned to the blocker before excess hits the player."""
+    atk = CombatCreature("Crusher", 4, 4, "A", trample=True, deathtouch=True)
+    blk = CombatCreature("Wall", 5, 5, "B")
+    atk.blocked_by.append(blk)
+    blk.blocking = atk
+    state = GameState(
+        players={
+            "A": PlayerState(life=20, creatures=[atk]),
+            "B": PlayerState(life=20, creatures=[blk]),
+        }
+    )
+    sim = CombatSimulator([atk], [blk], game_state=state)
+    result = sim.simulate()
+    assert result.damage_to_players["B"] == 3
+    assert blk.damage_marked == 1
+    assert blk in result.creatures_destroyed
+    assert state.players["B"].life == 17
+
+
+def test_double_strike_lifelink_twice():
+    """CR 702.4b & 702.15a: Double strike causes lifelink damage in both steps."""
+    atk = CombatCreature("Swift Healer", 2, 2, "A", double_strike=True, lifelink=True)
+    defender = CombatCreature("Dummy", 0, 1, "B")
+    state = GameState(
+        players={
+            "A": PlayerState(life=10, creatures=[atk]),
+            "B": PlayerState(life=20, creatures=[defender]),
+        }
+    )
+    sim = CombatSimulator([atk], [defender], game_state=state)
+    result = sim.simulate()
+    assert result.damage_to_players["B"] == 4
+    assert result.lifegain["A"] == 4
+    assert state.players["A"].life == 14
+
+
+def test_double_strike_infect_can_cause_loss():
+    """CR 702.4b & 104.3c: Infect with double strike can give enough poison counters to lose."""
+    atk = CombatCreature("Toxic Duelist", 1, 1, "A", infect=True, double_strike=True)
+    defender = CombatCreature("Dummy", 0, 1, "B")
+    state = GameState(
+        players={
+            "A": PlayerState(life=20, creatures=[atk]),
+            "B": PlayerState(life=20, creatures=[defender], poison=8),
+        }
+    )
+    sim = CombatSimulator([atk], [defender], game_state=state)
+    result = sim.simulate()
+    assert state.players["B"].poison == 10
+    assert has_player_lost(state, "B")
+    assert "B" in sim.players_lost
+    assert result.poison_counters["B"] == 2


### PR DESCRIPTION
## Summary
- fix `_check_players_lost` so attackers tap even without a `GameState`
- track applied lifelink so life gain isn't doubled
- add comprehensive tests for life loss, poison counters and losing the game

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68564f9462f0832a930b37e7c13e83d6