### PR TITLE
Fix attacker tapping without GameState

### DIFF
--- a/magic_combat/simulator.py
+++ b/magic_combat/simulator.py
@@ -42,16 +42,16 @@ class CombatSimulator:
 
     def _check_players_lost(self) -> None:
         """Record any players who have lost the game."""
+        for attacker in self.attackers:
+            attacker.attacking = True
+            if not attacker.vigilance:
+                attacker.tapped = True
+
         if self.game_state is None:
             return
         for player in list(self.game_state.players.keys()):
             if has_player_lost(self.game_state, player) and player not in self.players_lost:
                 self.players_lost.append(player)
-
-        for attacker in self.attackers:
-            attacker.attacking = True
-            if not attacker.vigilance:
-                attacker.tapped = True
 
     def validate_blocking(self):
         """Ensure blocking assignments are legal for this simplified simulator."""


### PR DESCRIPTION
## Summary
- fix `_check_players_lost` to always mark attackers as attacking/tapped
- ensure players are still tracked as having lost when a `GameState` exists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685650e4541c832a9f050248cc408d77