### PR TITLE
Add PlayerState validation

### DIFF
--- a/magic_combat/gamestate.py
+++ b/magic_combat/gamestate.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Dict, List
 
+from .utils import check_non_negative
+
 from .creature import CombatCreature
 
 
@@ -15,6 +17,10 @@ class PlayerState:
     life: int
     creatures: List[CombatCreature]
     poison: int = 0
+
+    def __post_init__(self) -> None:
+        check_non_negative(self.life, "life")
+        check_non_negative(self.poison, "poison")
 
 
 @dataclass

--- a/tests/core/test_playerstate_validation.py
+++ b/tests/core/test_playerstate_validation.py
@@ -1,0 +1,15 @@
+import pytest
+
+from magic_combat import PlayerState
+
+
+def test_negative_life_init():
+    """CR 107.1: Numbers like life totals can't be negative."""
+    with pytest.raises(ValueError):
+        PlayerState(life=-1, creatures=[])
+
+
+def test_negative_poison_init():
+    """CR 107.1: Numbers like poison counters can't be negative."""
+    with pytest.raises(ValueError):
+        PlayerState(life=20, creatures=[], poison=-1)


### PR DESCRIPTION
## Summary
- validate player life and poison counters
- test that negative values for life or poison are invalid

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68565610fd08832aa816c625f200e9cb