### PR TITLE
Implement repr for CombatResult and add test

### DIFF
--- a/magic_combat/simulator.py
+++ b/magic_combat/simulator.py
@@ -17,6 +17,15 @@ class CombatResult:
     poison_counters: Dict[str, int] = field(default_factory=dict)
     players_lost: List[str] = field(default_factory=list)
 
+    def __repr__(self) -> str:
+        cls = self.__class__.__name__
+        destroyed = [c.name for c in self.creatures_destroyed]
+        return (
+            f"{cls}(damage_to_players={self.damage_to_players}, "
+            f"creatures_destroyed={destroyed}, lifegain={self.lifegain}, "
+            f"poison_counters={self.poison_counters}, players_lost={self.players_lost})"
+        )
+
 
 class CombatSimulator:
     """High level orchestrator for combat resolution."""

--- a/tests/core/test_combat_result_repr.py
+++ b/tests/core/test_combat_result_repr.py
@@ -1,0 +1,21 @@
+import pytest
+
+from magic_combat import CombatCreature, CombatResult
+
+
+def test_combat_result_repr_readable():
+    """CR 104.3a: A player with 0 or less life loses the game."""
+    creature = CombatCreature("Goblin", 2, 2, "A")
+    result = CombatResult(
+        damage_to_players={"B": 3},
+        creatures_destroyed=[creature],
+        lifegain={"A": 2},
+        poison_counters={"B": 1},
+        players_lost=["B"],
+    )
+    expected = (
+        "CombatResult(damage_to_players={'B': 3}, "
+        "creatures_destroyed=['Goblin'], lifegain={'A': 2}, "
+        "poison_counters={'B': 1}, players_lost=['B'])"
+    )
+    assert repr(result) == expected


### PR DESCRIPTION
## Summary
- implement `__repr__` for `CombatResult` to show concise lists of destroyed creatures
- add unit test verifying readable representation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68565614f01c832aaf2b89dd2b1a6cf5