### PR TITLE
Add extra first/double strike tests

### DIFF
--- a/tests/combat/test_first_double_stike.py
+++ b/tests/combat/test_first_double_stike.py
@@ -1,0 +1,38 @@
+from magic_combat import CombatCreature, CombatSimulator
+
+
+def test_first_strike_vs_first_strike_trade():
+    """CR 702.7b: Creatures with first strike deal combat damage in a special step before creatures without it."""
+    atk = CombatCreature("Duelist", 2, 2, "A", first_strike=True)
+    blk = CombatCreature("Guard", 2, 2, "B", first_strike=True)
+    atk.blocked_by.append(blk)
+    blk.blocking = atk
+    sim = CombatSimulator([atk], [blk])
+    result = sim.simulate()
+    assert atk in result.creatures_destroyed
+    assert blk in result.creatures_destroyed
+
+
+def test_double_strike_vs_first_strike_both_die_first_step():
+    """CR 702.4b: A creature with double strike deals damage in both first-strike and regular steps, but only if it survives the first."""
+    atk = CombatCreature("Champion", 2, 2, "A", double_strike=True)
+    blk = CombatCreature("Veteran", 2, 2, "B", first_strike=True)
+    atk.blocked_by.append(blk)
+    blk.blocking = atk
+    sim = CombatSimulator([atk], [blk])
+    result = sim.simulate()
+    assert atk in result.creatures_destroyed
+    assert blk in result.creatures_destroyed
+
+
+def test_double_strike_blocked_no_damage_to_player():
+    """CR 506.4: A blocked creature remains blocked even if its blockers are removed from combat."""
+    atk = CombatCreature("Blade", 2, 2, "A", double_strike=True)
+    blk = CombatCreature("Bear", 2, 2, "B")
+    atk.blocked_by.append(blk)
+    blk.blocking = atk
+    sim = CombatSimulator([atk], [blk])
+    result = sim.simulate()
+    assert blk in result.creatures_destroyed
+    assert atk not in result.creatures_destroyed
+    assert result.damage_to_players.get("B", 0) == 0


### PR DESCRIPTION
## Summary
- test more first strike interactions
- cover double strike edge cases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68565673d598832a88d9f8ec7818f3eb