### PR TITLE
Expand first/double strike tests

### DIFF
--- a/tests/combat/test_first_double_stike.py
+++ b/tests/combat/test_first_double_stike.py
@@ -36,3 +36,26 @@ def test_double_strike_blocked_no_damage_to_player():
     assert blk in result.creatures_destroyed
     assert atk not in result.creatures_destroyed
     assert result.damage_to_players.get("B", 0) == 0
+
+
+def test_double_strike_kills_first_striker_no_damage_to_player():
+    """CR 702.4b & 506.4: A double strike creature that kills its blocker in the first-strike step is still blocked and deals no damage to the player."""
+    atk = CombatCreature("Champion", 2, 2, "A", double_strike=True)
+    blk = CombatCreature("Squire", 1, 1, "B", first_strike=True)
+    atk.blocked_by.append(blk)
+    blk.blocking = atk
+    sim = CombatSimulator([atk], [blk])
+    result = sim.simulate()
+    assert blk in result.creatures_destroyed
+    assert atk not in result.creatures_destroyed
+    assert result.damage_to_players.get("B", 0) == 0
+
+
+def test_double_strike_unblocked_hits_player_twice():
+    """CR 702.4b & 510.1c: A double strike creature unblocked deals damage twice to the defending player."""
+    atk = CombatCreature("Warrior", 3, 3, "A", double_strike=True)
+    defender = CombatCreature("Dummy", 0, 1, "B")
+    sim = CombatSimulator([atk], [defender])
+    result = sim.simulate()
+    assert result.damage_to_players["B"] == 6
+    assert result.creatures_destroyed == []


### PR DESCRIPTION
## Summary
- add more combat scenarios to `test_first_double_stike.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856578ff5a0832a81c32dc9bfd95cc1