### PR TITLE
Add poison counter tests

### DIFF
--- a/tests/test_poison.py
+++ b/tests/test_poison.py
@@ -1,0 +1,148 @@
+import pytest
+
+from magic_combat import CombatCreature, CombatSimulator, GameState, PlayerState, has_player_lost
+
+
+def test_infect_creature_gets_minus1_counters():
+    """CR 702.90a: Damage from a creature with infect gives -1/-1 counters to creatures."""
+    atk = CombatCreature("Agent", 2, 2, "A", infect=True)
+    blk = CombatCreature("Target", 2, 2, "B")
+    atk.blocked_by.append(blk)
+    blk.blocking = atk
+    sim = CombatSimulator([atk], [blk])
+    result = sim.simulate()
+    assert blk.minus1_counters == 2
+    assert blk in result.creatures_destroyed
+
+
+def test_infect_lifelink_vs_creature():
+    """CR 702.90a & 702.15a: Infect still deals damage for lifelink purposes."""
+    atk = CombatCreature("Toxic Healer", 2, 2, "A", infect=True, lifelink=True)
+    blk = CombatCreature("Guard", 2, 2, "B")
+    atk.blocked_by.append(blk)
+    blk.blocking = atk
+    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=20, creatures=[blk])})
+    sim = CombatSimulator([atk], [blk], game_state=state)
+    result = sim.simulate()
+    assert blk.minus1_counters == 2
+    assert result.lifegain["A"] == 2
+    assert state.players["A"].life == 22
+
+
+def test_trample_infect_lifelink_poison_and_life():
+    """CR 702.19b, 702.90b & 702.15a: Trample with infect gives poison counters for excess and lifelink gains that much life."""
+    atk = CombatCreature("Plague Rhino", 3, 3, "A", infect=True, lifelink=True, trample=True)
+    blk = CombatCreature("Chump", 1, 1, "B")
+    atk.blocked_by.append(blk)
+    blk.blocking = atk
+    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=20, creatures=[blk])})
+    sim = CombatSimulator([atk], [blk], game_state=state)
+    result = sim.simulate()
+    assert blk.minus1_counters == 1
+    assert state.players["B"].poison == 2
+    assert result.poison_counters["B"] == 2
+    assert result.lifegain["A"] == 3
+    assert state.players["A"].life == 23
+
+
+def test_double_strike_infect_creature_counters_accumulate():
+    """CR 702.4b & 702.90a: An infect creature with double strike deals counters in both damage steps."""
+    atk = CombatCreature("Toxic Duelist", 1, 1, "A", infect=True, double_strike=True)
+    blk = CombatCreature("Giant", 3, 3, "B")
+    atk.blocked_by.append(blk)
+    blk.blocking = atk
+    sim = CombatSimulator([atk], [blk])
+    result = sim.simulate()
+    assert blk.minus1_counters == 2
+    assert blk not in result.creatures_destroyed
+
+
+def test_first_strike_infect_weakens_before_hit_back():
+    """CR 702.7b & 702.90a: First strike infect damage is dealt before normal damage."""
+    atk = CombatCreature("Plague Knight", 2, 2, "A", infect=True, first_strike=True)
+    blk = CombatCreature("Ogre", 3, 3, "B")
+    atk.blocked_by.append(blk)
+    blk.blocking = atk
+    sim = CombatSimulator([atk], [blk])
+    result = sim.simulate()
+    assert blk.minus1_counters == 2
+    assert atk.damage_marked == 1
+    assert atk not in result.creatures_destroyed
+    assert blk not in result.creatures_destroyed
+
+
+def test_infect_kills_persist_creature_without_return():
+    """CR 702.90a & 702.77a: A creature killed with -1/-1 counters doesn't return with persist."""
+    atk = CombatCreature("Blighted", 2, 2, "A", infect=True)
+    blk = CombatCreature("Undying Wall", 2, 2, "B", persist=True)
+    atk.blocked_by.append(blk)
+    blk.blocking = atk
+    sim = CombatSimulator([atk], [blk])
+    result = sim.simulate()
+    assert blk in result.creatures_destroyed
+    assert blk.minus1_counters == 2
+
+
+def test_infect_and_toxic_stack_poison():
+    """CR 702.90b & 702.??: Infect and toxic add poison counters together."""
+    atk = CombatCreature("Venomous", 2, 2, "A", infect=True, toxic=1)
+    defender = CombatCreature("Dummy", 0, 1, "B")
+    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=20, creatures=[defender])})
+    sim = CombatSimulator([atk], [defender], game_state=state)
+    result = sim.simulate()
+    assert state.players["B"].poison == 3
+    assert result.poison_counters["B"] == 3
+
+
+def test_infect_counters_kill_indestructible():
+    """CR 702.90a & 702.12b: Indestructible doesn't prevent death from 0 toughness."""
+    atk = CombatCreature("Corruptor", 1, 1, "A", infect=True)
+    blk = CombatCreature("Steel Golem", 1, 1, "B", indestructible=True)
+    atk.blocked_by.append(blk)
+    blk.blocking = atk
+    sim = CombatSimulator([atk], [blk])
+    result = sim.simulate()
+    assert blk in result.creatures_destroyed
+    assert blk.minus1_counters == 1
+
+
+def test_player_loses_at_ten_poison():
+    """CR 104.3c: A player with ten or more poison counters loses the game."""
+    atk = CombatCreature("Infector", 1, 1, "A", infect=True)
+    defender = CombatCreature("Dummy", 0, 1, "B")
+    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=20, creatures=[defender], poison=9)})
+    sim = CombatSimulator([atk], [defender], game_state=state)
+    sim.simulate()
+    assert state.players["B"].poison == 10
+    assert has_player_lost(state, "B")
+    assert "B" in sim.players_lost
+
+
+def test_infect_against_multiple_blockers():
+    """CR 702.90a: Infect assigns -1/-1 counters to each blocker in order."""
+    atk = CombatCreature("Plague Bear", 3, 3, "A", infect=True)
+    b1 = CombatCreature("B1", 2, 2, "B")
+    b2 = CombatCreature("B2", 2, 2, "B")
+    atk.blocked_by.extend([b1, b2])
+    b1.blocking = atk
+    b2.blocking = atk
+    sim = CombatSimulator([atk], [b1, b2])
+    result = sim.simulate()
+    assert b1.minus1_counters == 2
+    assert b2.minus1_counters == 1
+    assert b1 in result.creatures_destroyed
+    assert b2 not in result.creatures_destroyed
+
+
+def test_infect_with_afflict_still_deals_life_loss():
+    """CR 702.131 & 702.90a: Afflict damage is normal even if the creature has infect."""
+    atk = CombatCreature("Torturer", 2, 2, "A", infect=True, afflict=2)
+    blk = CombatCreature("Guard", 2, 2, "B")
+    atk.blocked_by.append(blk)
+    blk.blocking = atk
+    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=20, creatures=[blk])})
+    sim = CombatSimulator([atk], [blk], game_state=state)
+    result = sim.simulate()
+    assert result.damage_to_players["B"] == 2
+    assert state.players["B"].life == 18
+    assert blk.minus1_counters == 2


### PR DESCRIPTION
## Summary
- add dedicated `test_poison.py` covering infect and toxic rules
- verify poison counters interactions with lifelink, trample, first/double strike, persist, afflict, and indestructible

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68565c737c68832aa89f807aa2d0e996