### PR TITLE
Improve MostCreaturesKilled strategy

### DIFF
--- a/magic_combat/damage.py
+++ b/magic_combat/damage.py
@@ -1,6 +1,6 @@
 """Damage assignment ordering strategies."""
 
-from typing import List
+from typing import List, Tuple
 
 from .creature import CombatCreature
 
@@ -21,6 +21,86 @@ class MostCreaturesKilledStrategy(DamageAssignmentStrategy):
     def order_blockers(
         self, attacker: CombatCreature, blockers: List[CombatCreature]
     ) -> List[CombatCreature]:
-        # Sort by effective toughness ascending so the attacker deals damage to
-        # the most fragile creatures first.
-        return sorted(blockers, key=lambda c: c.effective_toughness())
+        power = attacker.effective_power()
+
+        def lethal_cost(blocker: CombatCreature) -> float:
+            """Damage needed to remove ``blocker`` from combat."""
+            if blocker.indestructible and not (attacker.infect or attacker.wither):
+                return float("inf")
+            if attacker.deathtouch and not blocker.indestructible:
+                return 1
+            return blocker.effective_toughness()
+
+        POSITIVE_KEYWORDS = [
+            "flying",
+            "reach",
+            "menace",
+            "fear",
+            "shadow",
+            "horsemanship",
+            "skulk",
+            "unblockable",
+            "vigilance",
+            "first_strike",
+            "double_strike",
+            "deathtouch",
+            "trample",
+            "lifelink",
+            "wither",
+            "infect",
+            "indestructible",
+            "melee",
+            "training",
+            "battalion",
+            "dethrone",
+            "intimidate",
+            "undying",
+            "persist",
+        ]
+
+        STACKABLE_KEYWORDS = [
+            "bushido",
+            "flanking",
+            "rampage",
+            "exalted_count",
+            "battle_cry_count",
+            "frenzy",
+            "afflict",
+        ]
+
+        def value(blocker: CombatCreature) -> float:
+            """Heuristic combat value for tie-breaking."""
+            positive = sum(1 for attr in POSITIVE_KEYWORDS if getattr(blocker, attr, False))
+            positive += sum(1 for attr in STACKABLE_KEYWORDS if getattr(blocker, attr, 0))
+            return blocker.power + blocker.toughness + positive / 2
+
+        costs = [lethal_cost(b) for b in blockers]
+        values = [value(b) for b in blockers]
+        n = len(blockers)
+
+        # Dynamic program over available power to maximize kills then value
+        dp: List[Tuple[int, float, List[int]]] = [(0, 0.0, []) for _ in range(power + 1)]
+        for i in range(n):
+            cost = costs[i]
+            if cost == float("inf") or cost > power:
+                continue
+            int_cost = int(cost)
+            for w in range(power, int_cost - 1, -1):
+                prev_cnt, prev_val, prev_set = dp[w - int_cost]
+                cand_cnt = prev_cnt + 1
+                cand_val = prev_val + values[i]
+                curr_cnt, curr_val, curr_set = dp[w]
+                if cand_cnt > curr_cnt or (cand_cnt == curr_cnt and cand_val > curr_val):
+                    dp[w] = (cand_cnt, cand_val, prev_set + [i])
+
+        best = dp[0]
+        for w in range(1, power + 1):
+            if dp[w][0] > best[0] or (dp[w][0] == best[0] and dp[w][1] > best[1]):
+                best = dp[w]
+
+        kill_indices = set(best[2])
+        kill_first = [blockers[i] for i in kill_indices]
+        kill_first.sort(key=value, reverse=True)
+        remaining = [b for idx, b in enumerate(blockers) if idx not in kill_indices]
+        remaining.sort(key=value, reverse=True)
+        return kill_first + remaining

--- a/tests/abilities/test_trample.py
+++ b/tests/abilities/test_trample.py
@@ -11,8 +11,8 @@ def test_trample_multiple_blockers_ordering():
     big.blocking = attacker
     sim = CombatSimulator([attacker], [small, big])
     result = sim.simulate()
-    assert small in result.creatures_destroyed
-    assert big not in result.creatures_destroyed
+    assert big in result.creatures_destroyed
+    assert small not in result.creatures_destroyed
     assert result.damage_to_players.get("B", 0) == 0
 
 

--- a/tests/core/test_extra_features.py
+++ b/tests/core/test_extra_features.py
@@ -61,6 +61,36 @@ def test_most_creatures_killed_strategy_sorts():
     assert ordered == [b2, b1]
 
 
+def test_most_creatures_killed_prefers_value_on_tie():
+    """CR 510.2: When only one kill is possible, the most valuable dies."""
+    strat = MostCreaturesKilledStrategy()
+    attacker = CombatCreature("Attacker", 5, 5, "A")
+    weak = CombatCreature("Weak", 2, 2, "B")
+    big = CombatCreature("Big", 4, 4, "B")
+    ordered = strat.order_blockers(attacker, [weak, big])
+    assert ordered[0] is big
+
+
+def test_indestructible_blocker_goes_last():
+    """CR 702.12b: Indestructible creatures can't be destroyed by damage."""
+    strat = MostCreaturesKilledStrategy()
+    attacker = CombatCreature("Attacker", 3, 3, "A")
+    ind = CombatCreature("Guardian", 2, 2, "B", indestructible=True)
+    norm = CombatCreature("Target", 2, 2, "B")
+    ordered = strat.order_blockers(attacker, [ind, norm])
+    assert ordered[-1] is ind
+
+
+def test_wither_can_target_indestructible_first():
+    """CR 702.90a & 702.12b: Wither counters can kill indestructible blockers."""
+    strat = MostCreaturesKilledStrategy()
+    attacker = CombatCreature("Attacker", 2, 2, "A", wither=True)
+    ind = CombatCreature("Guardian", 2, 2, "B", indestructible=True)
+    small = CombatCreature("Small", 1, 1, "B")
+    ordered = strat.order_blockers(attacker, [ind, small])
+    assert ordered[0] is ind
+
+
 def test_plus1_minus1_counter_setters():
     """CR 122.1a: Counters can increase or decrease stats."""
     creature = CombatCreature(name="Bug", power=1, toughness=1, controller="A")


### PR DESCRIPTION
## Summary
- implement smarter `MostCreaturesKilledStrategy`
- include positive keyword weighting in damage assignment
- ensure strategy handles indestructible and wither
- extend strategy tests for value ordering and indestructible
- update trample expectations to match new ordering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68565d360b08832aaba3202a28b5e711