### PR TITLE
Add counter annihilation logic and new tests

### DIFF
--- a/magic_combat/creature.py
+++ b/magic_combat/creature.py
@@ -158,6 +158,17 @@ class CombatCreature:
         check_non_negative(value, "minus1 counters")
         self._minus1_counters = value
 
+    def apply_counter_annihilation(self) -> None:
+        """Remove matched +1/+1 and -1/-1 counters.
+
+        CR 704.5q specifies that if a permanent has both a +1/+1 counter and
+        a -1/-1 counter on it, a +1/+1 counter and a -1/-1 counter are removed
+        from it until it has no counters of one of those kinds."""
+        cancel = min(self.plus1_counters, self.minus1_counters)
+        if cancel:
+            self._plus1_counters -= cancel
+            self._minus1_counters -= cancel
+
     def reset_temporary_bonuses(self) -> None:
         """Clear temporary power and toughness modifiers."""
         self.temp_power = 0

--- a/magic_combat/simulator.py
+++ b/magic_combat/simulator.py
@@ -357,6 +357,8 @@ class CombatSimulator:
 
     def check_lethal_damage(self):
         """Evaluate which creatures die after damage or state-based effects."""
+        for creature in self.all_creatures:
+            creature.apply_counter_annihilation()
         destroyed_by_damage = [
             c for c in self.all_creatures if c.is_destroyed_by_damage()
         ]

--- a/tests/test_counters.py
+++ b/tests/test_counters.py
@@ -1,0 +1,115 @@
+import pytest
+
+from magic_combat import (
+    CombatCreature,
+    CombatSimulator,
+    GameState,
+    PlayerState,
+)
+
+
+def test_effective_stats_with_plus1_counters():
+    """CR 122.1a: +1/+1 counters modify a creature's power and toughness."""
+    creature = CombatCreature("Scute", 1, 1, "A", _plus1_counters=2)
+    assert creature.effective_power() == 3
+    assert creature.effective_toughness() == 3
+
+
+def test_effective_stats_with_minus1_counters():
+    """CR 122.1a: -1/-1 counters lower a creature's power and toughness."""
+    creature = CombatCreature("Weakling", 3, 3, "A", _minus1_counters=1)
+    assert creature.effective_power() == 2
+    assert creature.effective_toughness() == 2
+
+
+def test_plus1_and_minus1_counters_net():
+    """CR 122.1a: Different counters stack algebraically on stats."""
+    creature = CombatCreature("Mixed", 2, 2, "A", _plus1_counters=2, _minus1_counters=1)
+    assert creature.effective_power() == 3
+    assert creature.effective_toughness() == 3
+
+
+def test_training_cancels_minus1_counter():
+    """CR 702.138a & 704.5q: Training adds a +1/+1 counter which cancels a -1/-1 counter."""
+    trainee = CombatCreature("Trainee", 2, 2, "A", training=True)
+    trainee.minus1_counters = 1
+    mentor = CombatCreature("Mentor", 3, 3, "A")
+    sim = CombatSimulator([trainee, mentor], [])
+    sim.simulate()
+    assert trainee.plus1_counters == 0
+    assert trainee.minus1_counters == 0
+
+
+def test_dethrone_counter_annihilates_existing_minus1():
+    """CR 702.103a & 704.5q: Dethrone's +1/+1 counter removes an existing -1/-1 counter."""
+    attacker = CombatCreature("Challenger", 2, 2, "A", dethrone=True)
+    attacker.minus1_counters = 1
+    defender = CombatCreature("Dummy", 0, 1, "B")
+    state = GameState(players={"A": PlayerState(life=20, creatures=[attacker]), "B": PlayerState(life=25, creatures=[defender])})
+    sim = CombatSimulator([attacker], [defender], game_state=state)
+    sim.simulate()
+    assert attacker.plus1_counters == 0
+    assert attacker.minus1_counters == 0
+
+
+def test_wither_damage_gives_minus1_counters():
+    """CR 702.90a: Damage from a creature with wither applies -1/-1 counters."""
+    atk = CombatCreature("Corrosive", 2, 2, "A", wither=True)
+    blk = CombatCreature("Wall", 2, 2, "B")
+    atk.blocked_by.append(blk)
+    blk.blocking = atk
+    sim = CombatSimulator([atk], [blk])
+    result = sim.simulate()
+    assert blk.minus1_counters == 2
+    assert blk in result.creatures_destroyed
+
+
+def test_persist_returns_with_counter():
+    """CR 702.77a: Persist returns a creature that died without -1/-1 counters."""
+    atk = CombatCreature("Giant", 3, 3, "A")
+    blk = CombatCreature("Spirit", 3, 3, "B", persist=True)
+    atk.blocked_by.append(blk)
+    blk.blocking = atk
+    sim = CombatSimulator([atk], [blk])
+    result = sim.simulate()
+    assert blk not in result.creatures_destroyed
+    assert blk.minus1_counters == 1
+
+
+def test_undying_returns_with_counter():
+    """CR 702.92a: Undying returns the creature with a +1/+1 counter if it had none."""
+    atk = CombatCreature("Phoenix", 2, 2, "A", undying=True)
+    blk = CombatCreature("Bear", 2, 2, "B")
+    atk.blocked_by.append(blk)
+    blk.blocking = atk
+    sim = CombatSimulator([atk], [blk])
+    result = sim.simulate()
+    assert blk in result.creatures_destroyed
+    assert atk.plus1_counters == 1
+    assert atk not in result.creatures_destroyed
+
+
+def test_annihilation_plus1_then_wither():
+    """CR 704.5q: A +1/+1 counter and a -1/-1 counter destroy each other."""
+    atk = CombatCreature("Witherer", 1, 1, "A", wither=True)
+    blk = CombatCreature("Veteran", 1, 1, "B")
+    blk.plus1_counters = 1
+    atk.blocked_by.append(blk)
+    blk.blocking = atk
+    sim = CombatSimulator([atk], [blk])
+    sim.simulate()
+    assert blk.plus1_counters == 0
+    assert blk.minus1_counters == 0
+
+
+def test_annihilation_multiple_pairs():
+    """CR 704.5q: All matching pairs of counters are removed."""
+    atk = CombatCreature("Witherer", 3, 3, "A", wither=True)
+    blk = CombatCreature("Hero", 2, 2, "B")
+    blk.plus1_counters = 2
+    atk.blocked_by.append(blk)
+    blk.blocking = atk
+    sim = CombatSimulator([atk], [blk])
+    sim.simulate()
+    assert blk.plus1_counters == 0
+    assert blk.minus1_counters == 1


### PR DESCRIPTION
## Summary
- make abilities tests a package so pytest can run without module name clashes
- implement +1/+1 and -1/-1 counter annihilation
- apply annihilation when checking lethal damage
- add extensive counter-focused tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685663fec8a8832a8122ccbaf1f731ea