### PR TITLE
Refactor blocking setup in tests

### DIFF
--- a/tests/abilities/test_additional_keyword_abilities.py
+++ b/tests/abilities/test_additional_keyword_abilities.py
@@ -1,6 +1,7 @@
 import pytest
 
 from magic_combat import CombatCreature, CombatSimulator, GameState, PlayerState, Color
+from tests.conftest import link_block
 
 
 def test_defender_cannot_attack():
@@ -35,8 +36,7 @@ def test_undying_returns_with_counter():
     """CR 702.92a: Undying returns the creature with a +1/+1 counter if it had none."""
     atk = CombatCreature("Phoenix", 2, 2, "A", undying=True)
     blk = CombatCreature("Bear", 2, 2, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert blk in result.creatures_destroyed
@@ -48,8 +48,7 @@ def test_intimidate_blocking_restriction():
     """CR 702.13a: Intimidate allows blocking only by artifacts or creatures that share a color."""
     atk = CombatCreature("Rogue", 2, 2, "A", intimidate=True, colors={Color.RED})
     blk = CombatCreature("Guard", 2, 2, "B", colors={Color.WHITE})
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     with pytest.raises(ValueError):
         sim.validate_blocking()
@@ -70,8 +69,7 @@ def test_afflict_life_loss_when_blocked():
     """CR 702.131a: Afflict causes life loss when the creature becomes blocked."""
     atk = CombatCreature("Tormentor", 2, 2, "A", afflict=2)
     blk = CombatCreature("Soldier", 2, 2, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert result.damage_to_players["B"] == 2

--- a/tests/abilities/test_blocking_rules.py
+++ b/tests/abilities/test_blocking_rules.py
@@ -2,14 +2,14 @@ import pytest
 
 
 from magic_combat import CombatCreature, CombatSimulator, Color
+from tests.conftest import link_block
 
 
 def test_flying_requires_flying_or_reach():
     """CR 702.9b: A creature with flying can be blocked only by creatures with flying or reach."""
     attacker = CombatCreature("Hawk", 1, 1, "A", flying=True)
     blocker = CombatCreature("Bear", 2, 2, "B")
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     with pytest.raises(ValueError):
         sim.validate_blocking()
@@ -19,8 +19,7 @@ def test_reach_allows_blocking_flying():
     """CR 702.9c: Creatures with reach can block creatures with flying."""
     attacker = CombatCreature("Hawk", 1, 1, "A", flying=True)
     blocker = CombatCreature("Spider", 1, 2, "B", reach=True)
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     # Should not raise
     sim.validate_blocking()
@@ -30,8 +29,7 @@ def test_menace_requires_two_blockers():
     """CR 702.110b: A creature with menace can't be blocked except by two or more creatures."""
     attacker = CombatCreature("Ogre", 3, 3, "A", menace=True)
     blocker = CombatCreature("Goblin", 1, 1, "B")
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     with pytest.raises(ValueError):
         sim.validate_blocking()
@@ -42,9 +40,7 @@ def test_menace_with_two_blockers_allowed():
     attacker = CombatCreature("Ogre", 3, 3, "A", menace=True)
     b1 = CombatCreature("Goblin1", 1, 1, "B")
     b2 = CombatCreature("Goblin2", 1, 1, "B")
-    attacker.blocked_by.extend([b1, b2])
-    b1.blocking = attacker
-    b2.blocking = attacker
+    link_block(attacker, b1, b2)
     sim = CombatSimulator([attacker], [b1, b2])
     sim.validate_blocking()
 
@@ -53,8 +49,7 @@ def test_fear_blocking():
     """CR 702.36b: Fear allows blocking only by artifact or black creatures."""
     attacker = CombatCreature("Nightmare", 2, 2, "A", fear=True)
     blocker = CombatCreature("Knight", 2, 2, "B", colors={Color.WHITE})
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     with pytest.raises(ValueError):
         sim.validate_blocking()
@@ -70,8 +65,7 @@ def test_protection_prevents_blocking():
     """CR 702.16b: Protection from a color means it can't be blocked by creatures of that color."""
     attacker = CombatCreature("Paladin", 2, 2, "A", protection_colors={Color.RED})
     blocker = CombatCreature("Orc", 2, 2, "B", colors={Color.RED})
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     with pytest.raises(ValueError):
         sim.validate_blocking()
@@ -84,8 +78,7 @@ def test_shadow_requires_shadow_blocker():
     """CR 702.27b: A creature with shadow can be blocked only by creatures with shadow."""
     attacker = CombatCreature("Shade", 1, 1, "A", shadow=True)
     blocker = CombatCreature("Bear", 2, 2, "B")
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     with pytest.raises(ValueError):
         sim.validate_blocking()
@@ -95,8 +88,7 @@ def test_unblockable_cannot_be_blocked():
     """CR 509.1b: An unblockable creature can't be legally blocked."""
     attacker = CombatCreature("Sneak", 2, 2, "A", unblockable=True)
     blocker = CombatCreature("Guard", 2, 2, "B")
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     with pytest.raises(ValueError):
         sim.validate_blocking()
@@ -117,13 +109,11 @@ def test_flying_menace_requires_two_flying_blockers():
     """CR 702.9b & 702.110b: A creature with flying and menace can't be blocked unless two creatures with flying or reach do so."""
     attacker = CombatCreature("Horror", 3, 3, "A", flying=True, menace=True)
     flyer1 = CombatCreature("Bird1", 1, 1, "B", flying=True)
-    attacker.blocked_by.append(flyer1)
-    flyer1.blocking = attacker
+    link_block(attacker, flyer1)
     sim = CombatSimulator([attacker], [flyer1])
     with pytest.raises(ValueError):
         sim.validate_blocking()
     flyer2 = CombatCreature("Bird2", 1, 1, "B", flying=True)
-    attacker.blocked_by.append(flyer2)
-    flyer2.blocking = attacker
+    link_block(attacker, flyer2)
     sim = CombatSimulator([attacker], [flyer1, flyer2])
     sim.validate_blocking()

--- a/tests/abilities/test_deathtouch.py
+++ b/tests/abilities/test_deathtouch.py
@@ -1,14 +1,14 @@
 import pytest
 
 from magic_combat import CombatCreature, CombatSimulator, GameState, PlayerState
+from tests.conftest import link_block
 
 
 def test_zero_power_deathtouch_deals_no_damage():
     """CR 702.2b: Deathtouch only matters if damage is dealt; 0 damage isn't lethal."""
     atk = CombatCreature("Weak Snake", 0, 1, "A", deathtouch=True)
     blk = CombatCreature("Bear", 2, 2, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert blk not in result.creatures_destroyed
@@ -19,8 +19,7 @@ def test_infect_deathtouch_lethal():
     """CR 702.90b & 702.2b: Infect damage from a deathtouch creature is lethal."""
     atk = CombatCreature("Toxic Snake", 1, 1, "A", infect=True, deathtouch=True)
     blk = CombatCreature("Soldier", 2, 2, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert blk in result.creatures_destroyed
@@ -32,8 +31,7 @@ def test_wither_deathtouch_lethal():
     """CR 702.90a & 702.2b: Wither damage from deathtouch still destroys."""
     atk = CombatCreature("Corrosive", 1, 1, "A", wither=True, deathtouch=True)
     blk = CombatCreature("Giant", 4, 4, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert blk in result.creatures_destroyed
@@ -45,8 +43,7 @@ def test_deathtouch_lifelink_gain_life():
     """CR 702.15a & 702.2b: Lifelink still gains life when deathtouch kills a creature."""
     atk = CombatCreature("Vampire", 1, 1, "A", deathtouch=True, lifelink=True)
     blk = CombatCreature("Bear", 2, 2, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=20, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     result = sim.simulate()
@@ -59,8 +56,7 @@ def test_infect_deathtouch_vs_indestructible():
     """CR 702.12b & 702.90b & 702.2b: Indestructible survives but still gets counters."""
     atk = CombatCreature("Toxic Blade", 1, 1, "A", infect=True, deathtouch=True)
     blk = CombatCreature("Guardian", 2, 2, "B", indestructible=True)
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert blk not in result.creatures_destroyed
@@ -72,8 +68,7 @@ def test_double_strike_vs_deathtouch_blocker():
     """CR 702.4b & 702.2b: Double strike lets an attacker kill a deathtouch blocker before it strikes."""
     atk = CombatCreature("Champion", 2, 2, "A", double_strike=True)
     blk = CombatCreature("Assassin", 2, 2, "B", deathtouch=True)
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert blk in result.creatures_destroyed
@@ -84,8 +79,7 @@ def test_double_strike_deathtouch_no_player_damage():
     """CR 509.1h & 702.4b: A double strike deathtouch attacker remains blocked and deals no player damage."""
     atk = CombatCreature("Swift Blade", 3, 3, "A", deathtouch=True, double_strike=True)
     blk = CombatCreature("Wall", 1, 4, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert blk in result.creatures_destroyed
@@ -96,8 +90,7 @@ def test_first_strike_deathtouch_blocker():
     """CR 702.7b & 702.2b: A blocker with first strike and deathtouch kills before normal damage."""
     atk = CombatCreature("Bear", 2, 2, "A")
     blk = CombatCreature("Slayer", 1, 1, "B", deathtouch=True, first_strike=True)
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert atk in result.creatures_destroyed
@@ -108,8 +101,7 @@ def test_deathtouch_vs_undying_creature_returns():
     """CR 702.92a & 702.2b: Undying brings back a creature destroyed by deathtouch."""
     atk = CombatCreature("Killer", 1, 1, "A", deathtouch=True)
     blk = CombatCreature("Phoenix", 1, 1, "B", undying=True)
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert blk not in result.creatures_destroyed
@@ -120,8 +112,7 @@ def test_first_strike_deathtouch_both_sides():
     """CR 702.7b & 702.2b: With first strike and deathtouch on both sides, both die in the first strike step."""
     atk = CombatCreature("Duelist A", 1, 1, "A", deathtouch=True, first_strike=True)
     blk = CombatCreature("Duelist B", 1, 1, "B", deathtouch=True, first_strike=True)
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert atk in result.creatures_destroyed

--- a/tests/abilities/test_edge_cases.py
+++ b/tests/abilities/test_edge_cases.py
@@ -2,14 +2,14 @@ import pytest
 
 
 from magic_combat import CombatCreature, CombatSimulator
+from tests.conftest import link_block
 
 
 def test_skulk_bushido_block_illegal():
     """CR 702.72a & 702.46a: Skulk checks power before bushido triggers."""
     attacker = CombatCreature("Sneaky Samurai", 2, 2, "A", skulk=True, bushido=2)
     blocker = CombatCreature("Giant", 3, 3, "B")
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     with pytest.raises(ValueError):
         sim.validate_blocking()
@@ -19,8 +19,7 @@ def test_skulk_bushido_equal_power_allowed():
     """CR 702.72a: A blocker with equal power may block despite later bushido."""
     attacker = CombatCreature("Sneaky Samurai", 2, 2, "A", skulk=True, bushido=2)
     blocker = CombatCreature("Guard", 2, 2, "B")
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     sim.validate_blocking()  # should be allowed
 
@@ -29,8 +28,7 @@ def test_flying_horsemanship_needs_both_flying_only():
     """CR 702.9b & 702.108a: Flying alone can't block flying+horsemanship."""
     attacker = CombatCreature("Pegasus Rider", 2, 2, "A", flying=True, horsemanship=True)
     blocker = CombatCreature("Bird", 1, 1, "B", flying=True)
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     with pytest.raises(ValueError):
         sim.validate_blocking()
@@ -40,8 +38,7 @@ def test_flying_horsemanship_needs_both_horse_only():
     """CR 702.9b & 702.108a: Horsemanship alone can't block flying+horsemanship."""
     attacker = CombatCreature("Pegasus Rider", 2, 2, "A", flying=True, horsemanship=True)
     blocker = CombatCreature("Cavalry", 2, 2, "B", horsemanship=True)
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     with pytest.raises(ValueError):
         sim.validate_blocking()
@@ -51,8 +48,7 @@ def test_flying_horsemanship_block_with_both_ok():
     """CR 702.9b & 702.108a: A creature with both abilities can block."""
     attacker = CombatCreature("Pegasus Rider", 2, 2, "A", flying=True, horsemanship=True)
     blocker = CombatCreature("Winged Knight", 2, 2, "B", flying=True, horsemanship=True)
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     sim.validate_blocking()  # should not raise
 
@@ -61,8 +57,7 @@ def test_flying_horsemanship_with_reach_and_horse_ok():
     """CR 702.9c & 702.108a: Reach plus horsemanship can block."""
     attacker = CombatCreature("Sky Cavalry", 2, 2, "A", flying=True, horsemanship=True)
     blocker = CombatCreature("Archer", 2, 3, "B", reach=True, horsemanship=True)
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     sim.validate_blocking()  # should not raise
 
@@ -71,8 +66,7 @@ def test_flanking_and_bushido_combined():
     """CR 702.25a & 702.46a: Flanking debuffs blockers while bushido buffs the attacker."""
     attacker = CombatCreature("Samurai Knight", 2, 2, "A", flanking=1, bushido=1)
     blocker = CombatCreature("Hill Giant", 3, 3, "B")
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     result = sim.simulate()
     assert blocker in result.creatures_destroyed
@@ -84,9 +78,7 @@ def test_rampage_and_bushido_multi_block():
     attacker = CombatCreature("Warlord", 3, 3, "A", rampage=1, bushido=1)
     b1 = CombatCreature("B1", 2, 2, "B")
     b2 = CombatCreature("B2", 2, 2, "B")
-    attacker.blocked_by.extend([b1, b2])
-    b1.blocking = attacker
-    b2.blocking = attacker
+    link_block(attacker, b1, b2)
     sim = CombatSimulator([attacker], [b1, b2])
     result = sim.simulate()
     assert b1 in result.creatures_destroyed
@@ -97,8 +89,7 @@ def test_exalted_and_bushido_stack():
     """CR 702.90a & 702.46a: Exalted and bushido each grant +1/+1."""
     attacker = CombatCreature("Disciplined", 2, 2, "A", exalted_count=1, bushido=1)
     blocker = CombatCreature("Grunt", 2, 2, "B")
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     result = sim.simulate()
     assert blocker in result.creatures_destroyed
@@ -117,9 +108,7 @@ def test_rampage_and_flanking_multi_block():
     attacker = CombatCreature("Warrior", 3, 3, "A", rampage=2, flanking=1)
     b1 = CombatCreature("B1", 2, 2, "B")
     b2 = CombatCreature("B2", 2, 2, "B")
-    attacker.blocked_by.extend([b1, b2])
-    b1.blocking = attacker
-    b2.blocking = attacker
+    link_block(attacker, b1, b2)
     sim = CombatSimulator([attacker], [b1, b2])
     result = sim.simulate()
     assert b1 in result.creatures_destroyed
@@ -131,8 +120,7 @@ def test_blocked_creature_no_trample_hits_no_player():
     """CR 509.1h: A creature remains blocked even if its blocker dies."""
     attacker = CombatCreature("Fencer", 2, 2, "A", first_strike=True)
     blocker = CombatCreature("Guard", 2, 2, "B")
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     result = sim.simulate()
     assert result.damage_to_players.get("B", 0) == 0

--- a/tests/abilities/test_interactions.py
+++ b/tests/abilities/test_interactions.py
@@ -2,6 +2,7 @@ import pytest
 
 
 from magic_combat import CombatCreature, CombatSimulator, Color
+from tests.conftest import link_block
 
 
 def test_fear_and_protection_from_black():
@@ -12,8 +13,7 @@ def test_fear_and_protection_from_black():
     blk = CombatCreature(
         "Black Artifact", 2, 2, "B", colors={Color.BLACK}, artifact=True
     )
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     with pytest.raises(ValueError):
         sim.validate_blocking()
@@ -30,9 +30,7 @@ def test_menace_and_skulk_two_small_blockers():
     atk = CombatCreature("Tricky Brute", 2, 2, "A", menace=True, skulk=True)
     b1 = CombatCreature("Goblin1", 1, 1, "B")
     b2 = CombatCreature("Goblin2", 1, 1, "B")
-    atk.blocked_by.extend([b1, b2])
-    b1.blocking = atk
-    b2.blocking = atk
+    link_block(atk, b1, b2)
     sim = CombatSimulator([atk], [b1, b2])
     sim.validate_blocking()
 

--- a/tests/abilities/test_keyword_abilities.py
+++ b/tests/abilities/test_keyword_abilities.py
@@ -1,12 +1,12 @@
 from magic_combat import CombatCreature, CombatSimulator
+from tests.conftest import link_block
 
 
 def test_bushido_bonus():
     """CR 702.46a: Bushido gives the creature +N/+N when it blocks or becomes blocked."""
     atk = CombatCreature("Samurai", 2, 2, "A", bushido=1)
     blk = CombatCreature("Bear", 2, 2, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert blk in result.creatures_destroyed
@@ -17,8 +17,7 @@ def test_flanking_debuff_blocker():
     """CR 702.25a: Flanking gives blocking creatures without flanking -1/-1."""
     atk = CombatCreature("Knight", 2, 2, "A", flanking=1)
     blk = CombatCreature("Soldier", 2, 2, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert blk in result.creatures_destroyed
@@ -29,8 +28,7 @@ def test_exalted_single_attacker_multiple_instances():
     """CR 702.90a: Each instance of exalted grants +1/+1 if a creature attacks alone."""
     atk = CombatCreature("Lone", 2, 2, "A", exalted_count=2)
     blk = CombatCreature("Grizzly", 2, 2, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert blk in result.creatures_destroyed
@@ -42,9 +40,7 @@ def test_rampage_with_multiple_blockers():
     atk = CombatCreature("Beast", 3, 3, "A", rampage=2)
     b1 = CombatCreature("B1", 2, 2, "B")
     b2 = CombatCreature("B2", 2, 2, "B")
-    atk.blocked_by.extend([b1, b2])
-    b1.blocking = atk
-    b2.blocking = atk
+    link_block(atk, b1, b2)
     sim = CombatSimulator([atk], [b1, b2])
     result = sim.simulate()
     assert b1 in result.creatures_destroyed
@@ -65,8 +61,7 @@ def test_melee_bonus_on_attack():
     """CR 702.111a: Melee gives the creature +1/+1 for each opponent it's attacking."""
     atk = CombatCreature("Soldier", 2, 2, "A", melee=True)
     blk = CombatCreature("Guard", 2, 2, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert blk in result.creatures_destroyed
@@ -86,8 +81,7 @@ def test_skulk_and_bushido_combo():
     """CR 702.65a & 702.46a: Skulk restricts blocks to weaker creatures and bushido gives +N/+N when blocked."""
     attacker = CombatCreature("Ninja", 2, 2, "A", skulk=True, bushido=1)
     blocker = CombatCreature("Guard", 1, 1, "B")
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     result = sim.simulate()
     assert blocker in result.creatures_destroyed
@@ -107,8 +101,7 @@ def test_deathtouch_basic_lethal():
     """CR 702.2b: Any nonzero damage from a creature with deathtouch is lethal."""
     atk = CombatCreature("Assassin", 1, 1, "A", deathtouch=True)
     blk = CombatCreature("Bear", 2, 2, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert atk in result.creatures_destroyed
@@ -120,9 +113,7 @@ def test_deathtouch_multiple_blockers():
     atk = CombatCreature("Venomous", 3, 3, "A", deathtouch=True)
     b1 = CombatCreature("Guard1", 3, 3, "B")
     b2 = CombatCreature("Guard2", 3, 3, "B")
-    atk.blocked_by.extend([b1, b2])
-    b1.blocking = atk
-    b2.blocking = atk
+    link_block(atk, b1, b2)
     sim = CombatSimulator([atk], [b1, b2])
     result = sim.simulate()
     assert atk in result.creatures_destroyed
@@ -134,8 +125,7 @@ def test_deathtouch_vs_indestructible():
     """CR 702.12b: Indestructible permanents aren't destroyed by deathtouch."""
     atk = CombatCreature("Snake", 1, 1, "A", deathtouch=True)
     blk = CombatCreature("Guardian", 2, 2, "B", indestructible=True)
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert atk in result.creatures_destroyed
@@ -146,8 +136,7 @@ def test_deathtouch_killed_before_dealing_damage():
     """CR 702.7b: First strike damage can kill a deathtouch creature before it deals damage."""
     atk = CombatCreature("Biter", 2, 2, "A", deathtouch=True)
     blk = CombatCreature("Duelist", 2, 2, "B", first_strike=True)
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert atk in result.creatures_destroyed
@@ -158,8 +147,7 @@ def test_trample_excess_damage_to_player():
     """CR 702.19b: Damage beyond lethal can be assigned to the defending player."""
     atk = CombatCreature("Rhino", 4, 4, "A", trample=True)
     blk = CombatCreature("Wall", 0, 3, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert blk in result.creatures_destroyed
@@ -171,9 +159,7 @@ def test_deathtouch_trample_multiple_blockers():
     atk = CombatCreature("Beast", 3, 3, "A", trample=True, deathtouch=True)
     b1 = CombatCreature("B1", 2, 2, "B")
     b2 = CombatCreature("B2", 2, 2, "B")
-    atk.blocked_by.extend([b1, b2])
-    b1.blocking = atk
-    b2.blocking = atk
+    link_block(atk, b1, b2)
     sim = CombatSimulator([atk], [b1, b2])
     result = sim.simulate()
     assert b1 in result.creatures_destroyed
@@ -185,8 +171,7 @@ def test_wither_damage_adds_counters():
     """CR 702.90a: Damage from wither is dealt as -1/-1 counters."""
     atk = CombatCreature("Witherer", 3, 3, "A", wither=True)
     blk = CombatCreature("Target", 2, 2, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert blk.minus1_counters == 2

--- a/tests/abilities/test_lifelink.py
+++ b/tests/abilities/test_lifelink.py
@@ -1,5 +1,6 @@
 import pytest
 from magic_combat import CombatCreature, CombatSimulator, GameState, PlayerState
+from tests.conftest import link_block
 
 
 
@@ -7,8 +8,7 @@ def test_wither_lifelink_blocker_gains_life():
     """CR 702.90a & 702.15a: Wither damage is -1/-1 counters but still causes life gain from lifelink."""
     atk = CombatCreature("Aggressor", 2, 2, "A")
     blk = CombatCreature("Corrosive Guard", 1, 1, "B", wither=True, lifelink=True)
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert atk.minus1_counters == 1
@@ -20,8 +20,7 @@ def test_afflict_lifelink_no_extra_life():
     """CR 702.131a & 702.15a: Afflict causes life loss that isn't damage, so lifelink only counts combat damage."""
     atk = CombatCreature("Tormentor", 3, 3, "A", afflict=2, lifelink=True)
     blk = CombatCreature("Soldier", 2, 2, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert result.damage_to_players["B"] == 2
@@ -32,8 +31,7 @@ def test_double_strike_trample_lifelink():
     """CR 702.4b, 702.19b & 702.15a: Double strike with trample deals damage twice and lifelink gains that much life."""
     atk = CombatCreature("Champion", 2, 2, "A", double_strike=True, trample=True, lifelink=True)
     blk = CombatCreature("Chump", 1, 1, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert result.damage_to_players["B"] == 3
@@ -44,8 +42,7 @@ def test_first_strike_lifelink_vs_deathtouch():
     """CR 702.7b, 702.2b & 702.15a: First strike lifelink kills a deathtouch blocker before it can deal damage."""
     atk = CombatCreature("Paladin", 2, 2, "A", first_strike=True, lifelink=True)
     blk = CombatCreature("Assassin", 2, 2, "B", deathtouch=True)
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert blk in result.creatures_destroyed
@@ -57,8 +54,7 @@ def test_lifelink_blocker_gains_life():
     """CR 702.15a: A creature with lifelink gains life when dealing combat damage as a blocker."""
     atk = CombatCreature("Brute", 2, 2, "A")
     blk = CombatCreature("Healer", 2, 2, "B", lifelink=True)
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert result.lifegain["B"] == 2
@@ -79,8 +75,7 @@ def test_infect_lifelink_blocker():
     """CR 702.90b & 702.15a: Infect damage from a lifelink blocker still grants life."""
     atk = CombatCreature("Attacker", 3, 3, "A")
     blk = CombatCreature("Toxic Guard", 1, 1, "B", infect=True, lifelink=True)
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert atk.minus1_counters == 1
@@ -91,8 +86,7 @@ def test_deathtouch_lifelink_blocker():
     """CR 702.2b & 702.15a: Deathtouch from a lifelink blocker destroys and also grants life."""
     atk = CombatCreature("Charger", 2, 2, "A")
     blk = CombatCreature("Venomous", 1, 1, "B", deathtouch=True, lifelink=True)
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert atk in result.creatures_destroyed
@@ -115,8 +109,7 @@ def test_lifelink_on_both_sides():
     """CR 702.15a: When both creatures have lifelink, each controller gains life for the damage their creature deals."""
     atk = CombatCreature("Angel", 2, 2, "A", lifelink=True)
     blk = CombatCreature("Cleric", 2, 2, "B", lifelink=True)
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert result.lifegain["A"] == 2

--- a/tests/abilities/test_protection_rules.py
+++ b/tests/abilities/test_protection_rules.py
@@ -1,14 +1,14 @@
 import pytest
 
 from magic_combat import CombatCreature, CombatSimulator, Color
+from tests.conftest import link_block
 
 
 def test_protection_allows_other_color_block():
     """CR 702.16b: Protection from a color doesn't stop blockers of other colors."""
     attacker = CombatCreature("Paladin", 2, 2, "A", protection_colors={Color.RED})
     blocker = CombatCreature("Bear", 2, 2, "B", colors={Color.GREEN})
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     sim.validate_blocking()
 
@@ -17,8 +17,7 @@ def test_protection_stops_matching_color():
     """CR 702.16b: A creature can't be blocked by creatures of a color it has protection from."""
     attacker = CombatCreature("Paladin", 2, 2, "A", protection_colors={Color.BLACK})
     blocker = CombatCreature("Shade", 2, 2, "B", colors={Color.BLACK})
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     with pytest.raises(ValueError):
         sim.validate_blocking()
@@ -32,8 +31,7 @@ def test_protection_multiple_colors_blocker_illegal():
     blocker = CombatCreature(
         "Hybrid", 2, 2, "B", colors={Color.RED, Color.BLUE}
     )
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     with pytest.raises(ValueError):
         sim.validate_blocking()
@@ -43,8 +41,7 @@ def test_protection_allows_colorless_artifact_block():
     """CR 702.16b: Protection from blue doesn't stop colorless artifact creatures from blocking."""
     attacker = CombatCreature("Mage", 2, 2, "A", protection_colors={Color.BLUE})
     blocker = CombatCreature("Golem", 2, 2, "B", artifact=True)
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     sim.validate_blocking()
 
@@ -56,9 +53,7 @@ def test_menace_with_protection_one_blocker_illegal():
     )
     legal = CombatCreature("Knight", 2, 2, "B", colors={Color.WHITE})
     illegal = CombatCreature("Elf", 2, 2, "B", colors={Color.GREEN})
-    attacker.blocked_by.extend([legal, illegal])
-    legal.blocking = attacker
-    illegal.blocking = attacker
+    link_block(attacker, legal, illegal)
     sim = CombatSimulator([attacker], [legal, illegal])
     with pytest.raises(ValueError):
         sim.validate_blocking()
@@ -71,9 +66,7 @@ def test_menace_with_protection_two_legal_blockers():
     )
     b1 = CombatCreature("Soldier1", 2, 2, "B", colors={Color.WHITE})
     b2 = CombatCreature("Soldier2", 2, 2, "B", colors={Color.RED})
-    attacker.blocked_by.extend([b1, b2])
-    b1.blocking = attacker
-    b2.blocking = attacker
+    link_block(attacker, b1, b2)
     sim = CombatSimulator([attacker], [b1, b2])
     sim.validate_blocking()
 
@@ -84,8 +77,7 @@ def test_intimidate_same_color_blocker_illegal_due_to_protection():
         "Sneak", 2, 2, "A", intimidate=True, colors={Color.RED}, protection_colors={Color.RED}
     )
     blocker = CombatCreature("Berserker", 2, 2, "B", colors={Color.RED})
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     with pytest.raises(ValueError):
         sim.validate_blocking()
@@ -97,8 +89,7 @@ def test_intimidate_artifact_blocker_still_legal():
         "Sneak", 2, 2, "A", intimidate=True, colors={Color.BLACK}, protection_colors={Color.BLACK}
     )
     blocker = CombatCreature("Golem", 2, 2, "B", artifact=True)
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     sim.validate_blocking()
 
@@ -117,8 +108,7 @@ def test_multicolor_blocker_illegal_if_contains_protected_color():
     """CR 702.16b: Any matching color in a multicolored blocker violates protection."""
     attacker = CombatCreature("Hero", 2, 2, "A", protection_colors={Color.GREEN})
     blocker = CombatCreature("Hybrid", 2, 2, "B", colors={Color.GREEN, Color.WHITE})
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     with pytest.raises(ValueError):
         sim.validate_blocking()
@@ -128,7 +118,6 @@ def test_multicolor_blocker_allowed_if_no_protected_colors():
     """CR 702.16b: A blocker with none of the protected colors may block."""
     attacker = CombatCreature("Hero", 2, 2, "A", protection_colors={Color.GREEN})
     blocker = CombatCreature("Hybrid", 2, 2, "B", colors={Color.BLUE, Color.WHITE})
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     sim.validate_blocking()

--- a/tests/abilities/test_skulk_basic.py
+++ b/tests/abilities/test_skulk_basic.py
@@ -1,14 +1,14 @@
 import pytest
 
 from magic_combat import CombatCreature, CombatSimulator, Color
+from tests.conftest import link_block
 
 
 def test_skulk_blocked_by_greater_power_illegal():
     """CR 702.72a: Skulk prevents blocks by creatures with greater power."""
     attacker = CombatCreature("Sneak", 2, 2, "A", skulk=True)
     blocker = CombatCreature("Ogre", 3, 3, "B")
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     with pytest.raises(ValueError):
         sim.validate_blocking()
@@ -18,8 +18,7 @@ def test_skulk_block_equal_power_allowed():
     """CR 702.72a: A blocker with equal power may block a skulk creature."""
     attacker = CombatCreature("Rogue", 2, 2, "A", skulk=True)
     blocker = CombatCreature("Guard", 2, 2, "B")
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     result = sim.simulate()
     assert attacker in result.creatures_destroyed
@@ -30,8 +29,7 @@ def test_skulk_block_smaller_creature_allowed():
     """CR 702.72a: Creatures with lesser power can block a skulk attacker."""
     attacker = CombatCreature("Shadow", 3, 3, "A", skulk=True)
     blocker = CombatCreature("Goblin", 1, 1, "B")
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     result = sim.simulate()
     assert blocker in result.creatures_destroyed
@@ -43,8 +41,7 @@ def test_skulk_blocker_with_counters_illegal():
     attacker = CombatCreature("Sneak", 2, 2, "A", skulk=True)
     blocker = CombatCreature("Fodder", 1, 1, "B")
     blocker.plus1_counters = 2
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     with pytest.raises(ValueError):
         sim.validate_blocking()
@@ -54,8 +51,7 @@ def test_skulk_blocker_bushido_bonus_after_blocking():
     """CR 702.72a & 702.46a: Bushido bonuses don't affect skulk's legality."""
     attacker = CombatCreature("Ninja", 2, 2, "A", skulk=True)
     blocker = CombatCreature("Samurai", 2, 2, "B", bushido=2)
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     result = sim.simulate()
     assert attacker in result.creatures_destroyed
@@ -67,9 +63,7 @@ def test_skulk_double_block_one_big_illegal():
     attacker = CombatCreature("Sneak", 2, 2, "A", skulk=True)
     big = CombatCreature("Giant", 4, 4, "B")
     small = CombatCreature("Helper", 1, 1, "B")
-    attacker.blocked_by.extend([big, small])
-    big.blocking = attacker
-    small.blocking = attacker
+    link_block(attacker, big, small)
     sim = CombatSimulator([attacker], [big, small])
     with pytest.raises(ValueError):
         sim.validate_blocking()
@@ -80,9 +74,7 @@ def test_skulk_menace_big_and_small_blockers():
     attacker = CombatCreature("Brute", 2, 2, "A", skulk=True, menace=True)
     big = CombatCreature("Ogre", 3, 3, "B")
     small = CombatCreature("Goblin", 1, 1, "B")
-    attacker.blocked_by.extend([big, small])
-    big.blocking = attacker
-    small.blocking = attacker
+    link_block(attacker, big, small)
     sim = CombatSimulator([attacker], [big, small])
     with pytest.raises(ValueError):
         sim.validate_blocking()
@@ -92,8 +84,7 @@ def test_skulk_flying_big_flyer_illegal():
     """CR 702.72a & 702.9b: A larger flying creature can't block skulk."""
     attacker = CombatCreature("Spy", 2, 2, "A", skulk=True, flying=True)
     blocker = CombatCreature("Dragon", 4, 4, "B", flying=True)
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     with pytest.raises(ValueError):
         sim.validate_blocking()
@@ -103,8 +94,7 @@ def test_skulk_flying_reach_small_allowed():
     """CR 702.72a & 702.9c: A small creature with reach can block a skulk flyer."""
     attacker = CombatCreature("Spy", 2, 2, "A", skulk=True, flying=True)
     blocker = CombatCreature("Archer", 1, 3, "B", reach=True)
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     result = sim.simulate()
     assert result.creatures_destroyed == []
@@ -114,8 +104,7 @@ def test_skulk_intimidate_artifact_big_illegal():
     """CR 702.72a & 702.68a: Intimidate doesn't bypass skulk's power restriction."""
     attacker = CombatCreature("Ghost", 2, 2, "A", skulk=True, intimidate=True)
     blocker = CombatCreature("Construct", 3, 3, "B", artifact=True)
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     with pytest.raises(ValueError):
         sim.validate_blocking()

--- a/tests/abilities/test_trample.py
+++ b/tests/abilities/test_trample.py
@@ -1,4 +1,5 @@
 from magic_combat import CombatCreature, CombatSimulator
+from tests.conftest import link_block
 
 
 def test_trample_multiple_blockers_ordering():
@@ -6,9 +7,7 @@ def test_trample_multiple_blockers_ordering():
     attacker = CombatCreature("Giant", 5, 5, "A", trample=True)
     small = CombatCreature("Soldier", 2, 2, "B")
     big = CombatCreature("Golem", 5, 5, "B")
-    attacker.blocked_by.extend([small, big])
-    small.blocking = attacker
-    big.blocking = attacker
+    link_block(attacker, small, big)
     sim = CombatSimulator([attacker], [small, big])
     result = sim.simulate()
     assert big in result.creatures_destroyed
@@ -20,8 +19,7 @@ def test_trample_first_strike_hits_player():
     """CR 702.19b & 702.7b: A first strike attacker assigns trample damage during the first-strike step."""
     attacker = CombatCreature("Charging Knight", 3, 3, "A", trample=True, first_strike=True)
     blocker = CombatCreature("Bear", 2, 2, "B")
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     result = sim.simulate()
     assert result.damage_to_players["B"] == 1
@@ -32,8 +30,7 @@ def test_trample_attacker_killed_by_first_strike():
     """CR 702.7b & 702.19b: If the blocker deals first-strike lethal damage, the trample creature deals none."""
     attacker = CombatCreature("Boar", 2, 2, "A", trample=True)
     blocker = CombatCreature("Elite Guard", 3, 3, "B", first_strike=True)
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     result = sim.simulate()
     assert attacker in result.creatures_destroyed
@@ -44,8 +41,7 @@ def test_double_strike_trample_deals_damage_twice():
     """CR 702.4b & 702.19b: Double strike with trample deals damage in both steps, assigning excess to the player each time."""
     attacker = CombatCreature("Ferocious Duelist", 3, 3, "A", trample=True, double_strike=True)
     blocker = CombatCreature("Peasant", 1, 1, "B")
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     result = sim.simulate()
     assert result.damage_to_players["B"] == 5

--- a/tests/combat/test_advanced_combat.py
+++ b/tests/combat/test_advanced_combat.py
@@ -1,12 +1,12 @@
 from magic_combat import CombatCreature, CombatSimulator
+from tests.conftest import link_block
 
 
 def test_double_strike_first_and_normal_damage():
     """CR 702.4b: A creature with double strike deals damage during both first-strike and regular damage steps."""
     attacker = CombatCreature("Duelist", 2, 2, "A", double_strike=True)
     blocker = CombatCreature("Bear", 2, 2, "B")
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     result = sim.simulate()
     assert blocker in result.creatures_destroyed
@@ -17,8 +17,7 @@ def test_lifelink_grants_life_when_dealing_damage():
     """CR 702.15a: Damage dealt by a creature with lifelink also causes its controller to gain that much life."""
     attacker = CombatCreature("Cleric", 2, 2, "A", lifelink=True)
     blocker = CombatCreature("Guard", 2, 2, "B")
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     result = sim.simulate()
     assert result.lifegain["A"] == 2

--- a/tests/combat/test_basic_combat.py
+++ b/tests/combat/test_basic_combat.py
@@ -2,13 +2,13 @@ import pytest
 
 
 from magic_combat import CombatCreature, CombatSimulator
+from tests.conftest import link_block
 
 
 def setup_vanilla():
     attacker = CombatCreature("Bear", 2, 2, "A")
     blocker = CombatCreature("Piker", 3, 1, "B")
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     return attacker, blocker
 
 
@@ -26,9 +26,7 @@ def test_double_block_simple():
     a = CombatCreature("Bear", 2, 2, "A")
     b1 = CombatCreature("Goblin", 1, 1, "B")
     b2 = CombatCreature("Goblin2", 1, 1, "B")
-    a.blocked_by.extend([b1, b2])
-    b1.blocking = a
-    b2.blocking = a
+    link_block(a, b1, b2)
     sim = CombatSimulator([a], [b1, b2])
     result = sim.simulate()
     assert a in result.creatures_destroyed
@@ -40,9 +38,7 @@ def test_most_creatures_killed_ordering():
     a = CombatCreature("Beast", 3, 3, "A")
     wall = CombatCreature("Wall", 0, 4, "B")
     goblin = CombatCreature("Goblin", 1, 1, "B")
-    a.blocked_by.extend([wall, goblin])
-    wall.blocking = a
-    goblin.blocking = a
+    link_block(a, wall, goblin)
     sim = CombatSimulator([a], [wall, goblin])
     result = sim.simulate()
     assert goblin in result.creatures_destroyed
@@ -64,8 +60,7 @@ def test_blocker_survives_nonlethal_damage():
     """CR 704.5g: Creatures with damage less than toughness aren't destroyed."""
     attacker = CombatCreature("Bear", 2, 2, "A")
     blocker = CombatCreature("Wall", 1, 3, "B")
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     result = sim.simulate()
     assert result.creatures_destroyed == []
@@ -75,8 +70,7 @@ def test_attacker_survives_and_kills_blocker():
     """CR 704.5g: A creature with lethal damage is destroyed."""
     attacker = CombatCreature("Ogre", 3, 3, "A")
     blocker = CombatCreature("Goblin", 2, 2, "B")
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     result = sim.simulate()
     assert blocker in result.creatures_destroyed
@@ -97,8 +91,7 @@ def test_indestructible_creature_survives_lethal_damage():
     """CR 702.12b: Indestructible permanents aren't destroyed by lethal damage."""
     attacker = CombatCreature("Giant", 5, 5, "A")
     blocker = CombatCreature("Guardian", 2, 2, "B", indestructible=True)
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     result = sim.simulate()
     assert attacker not in result.creatures_destroyed
@@ -109,8 +102,7 @@ def test_first_strike_kills_before_normal_damage():
     """CR 702.7b: Creatures with first strike deal combat damage before creatures without it."""
     attacker = CombatCreature("Swift", 2, 2, "A", first_strike=True)
     blocker = CombatCreature("Bear", 2, 2, "B")
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     result = sim.simulate()
     assert blocker in result.creatures_destroyed

--- a/tests/combat/test_combat_buffs.py
+++ b/tests/combat/test_combat_buffs.py
@@ -1,5 +1,6 @@
 import pytest
 from magic_combat import CombatCreature, CombatSimulator, GameState, PlayerState
+from tests.conftest import link_block
 
 
 # Rampage tests
@@ -9,9 +10,7 @@ def test_rampage_bonus_with_extra_blockers():
     atk = CombatCreature("Beast", 2, 2, "A", rampage=1)
     b1 = CombatCreature("B1", 2, 2, "B")
     b2 = CombatCreature("B2", 2, 2, "B")
-    atk.blocked_by.extend([b1, b2])
-    b1.blocking = atk
-    b2.blocking = atk
+    link_block(atk, b1, b2)
     sim = CombatSimulator([atk], [b1, b2])
     result = sim.simulate()
     assert b1 in result.creatures_destroyed
@@ -22,8 +21,7 @@ def test_rampage_no_bonus_single_blocker():
     """CR 702.23a doesn't provide a bonus with only one blocker."""
     atk = CombatCreature("Beast", 2, 2, "A", rampage=2)
     blk = CombatCreature("Wall", 0, 3, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert result.creatures_destroyed == []
@@ -34,8 +32,7 @@ def test_bushido_on_attacker():
     """CR 702.46a: Bushido grants +N/+N when blocked."""
     atk = CombatCreature("Samurai", 2, 2, "A", bushido=2)
     blk = CombatCreature("Ogre", 3, 3, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert blk in result.creatures_destroyed
@@ -45,8 +42,7 @@ def test_bushido_on_blocker():
     """CR 702.46a applies when the creature blocks or becomes blocked."""
     atk = CombatCreature("Bear", 2, 2, "A")
     blk = CombatCreature("Samurai", 2, 2, "B", bushido=1)
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert atk in result.creatures_destroyed
@@ -58,8 +54,7 @@ def test_exalted_single_attacker():
     """CR 702.90a: Exalted gives +1/+1 if a creature attacks alone."""
     atk = CombatCreature("Champion", 2, 2, "A", exalted_count=1)
     blk = CombatCreature("Soldier", 2, 2, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert blk in result.creatures_destroyed
@@ -69,8 +64,7 @@ def test_exalted_multiple_instances_stack():
     """CR 702.90a: Multiple instances of exalted each apply."""
     atk = CombatCreature("Hero", 2, 2, "A", exalted_count=2)
     blk = CombatCreature("Giant", 3, 3, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert blk in result.creatures_destroyed
@@ -81,8 +75,7 @@ def test_exalted_no_bonus_with_multiple_attackers():
     atk = CombatCreature("Lone", 2, 2, "A", exalted_count=1)
     ally = CombatCreature("Ally", 2, 2, "A")
     blk = CombatCreature("Guard", 2, 2, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk, ally], [blk])
     result = sim.simulate()
     assert blk in result.creatures_destroyed
@@ -122,8 +115,7 @@ def test_melee_bonus_when_attacking():
     """CR 702.111a: Melee gives +1/+1 while attacking a player."""
     atk = CombatCreature("Soldier", 2, 2, "A", melee=True)
     blk = CombatCreature("Guard", 2, 2, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert blk in result.creatures_destroyed
@@ -214,8 +206,7 @@ def test_frenzy_no_bonus_when_blocked():
     """CR 702.35a: Frenzy has no effect if the creature is blocked."""
     atk = CombatCreature("Berserker", 2, 2, "A", frenzy=3)
     blk = CombatCreature("Guard", 3, 3, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert atk in result.creatures_destroyed
@@ -228,9 +219,7 @@ def test_rampage_and_bushido_stack():
     atk = CombatCreature("Warrior", 2, 2, "A", rampage=1, bushido=1)
     b1 = CombatCreature("B1", 2, 2, "B")
     b2 = CombatCreature("B2", 2, 2, "B")
-    atk.blocked_by.extend([b1, b2])
-    b1.blocking = atk
-    b2.blocking = atk
+    link_block(atk, b1, b2)
     sim = CombatSimulator([atk], [b1, b2])
     result = sim.simulate()
     assert b1 in result.creatures_destroyed

--- a/tests/combat/test_consistency.py
+++ b/tests/combat/test_consistency.py
@@ -2,6 +2,7 @@ import random
 
 
 from magic_combat import CombatCreature, CombatSimulator
+from tests.conftest import link_block
 
 
 def random_creature(name, controller):
@@ -9,8 +10,7 @@ def random_creature(name, controller):
 
 
 def simulate_pair(a, b):
-    a.blocked_by.append(b)
-    b.blocking = a
+    link_block(a, b)
     sim = CombatSimulator([a], [b])
     return sim.simulate()
 
@@ -25,10 +25,8 @@ def test_combat_independence():
         b2 = random_creature("b2", "B")
 
         # combined simulation
-        a1.blocked_by.append(b1)
-        b1.blocking = a1
-        a2.blocked_by.append(b2)
-        b2.blocking = a2
+        link_block(a1, b1)
+        link_block(a2, b2)
         combined = CombatSimulator([a1, a2], [b1, b2])
         comb_res = combined.simulate()
 

--- a/tests/combat/test_first_double_stike.py
+++ b/tests/combat/test_first_double_stike.py
@@ -1,12 +1,12 @@
 from magic_combat import CombatCreature, CombatSimulator
+from tests.conftest import link_block
 
 
 def test_first_strike_vs_first_strike_trade():
     """CR 702.7b: Creatures with first strike deal combat damage in a special step before creatures without it."""
     atk = CombatCreature("Duelist", 2, 2, "A", first_strike=True)
     blk = CombatCreature("Guard", 2, 2, "B", first_strike=True)
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert atk in result.creatures_destroyed
@@ -17,8 +17,7 @@ def test_double_strike_vs_first_strike_both_die_first_step():
     """CR 702.4b: A creature with double strike deals damage in both first-strike and regular steps, but only if it survives the first."""
     atk = CombatCreature("Champion", 2, 2, "A", double_strike=True)
     blk = CombatCreature("Veteran", 2, 2, "B", first_strike=True)
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert atk in result.creatures_destroyed
@@ -29,8 +28,7 @@ def test_double_strike_blocked_no_damage_to_player():
     """CR 506.4: A blocked creature remains blocked even if its blockers are removed from combat."""
     atk = CombatCreature("Blade", 2, 2, "A", double_strike=True)
     blk = CombatCreature("Bear", 2, 2, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert blk in result.creatures_destroyed
@@ -42,8 +40,7 @@ def test_double_strike_kills_first_striker_no_damage_to_player():
     """CR 702.4b & 506.4: A double strike creature that kills its blocker in the first-strike step is still blocked and deals no damage to the player."""
     atk = CombatCreature("Champion", 2, 2, "A", double_strike=True)
     blk = CombatCreature("Squire", 1, 1, "B", first_strike=True)
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert blk in result.creatures_destroyed

--- a/tests/combat/test_game_loss_scenarios.py
+++ b/tests/combat/test_game_loss_scenarios.py
@@ -1,5 +1,6 @@
 import pytest
 from magic_combat import CombatCreature, CombatSimulator, GameState, PlayerState, has_player_lost
+from tests.conftest import link_block
 
 
 
@@ -7,8 +8,7 @@ def test_afflict_lethal_when_blocked():
     """CR 702.131a & 104.3a: Afflict causes life loss when this creature becomes blocked; a player with 0 or less life loses the game."""
     atk = CombatCreature("Tormentor", 2, 2, "A", afflict=2)
     blk = CombatCreature("Guard", 2, 2, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=2, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     sim.simulate()
@@ -21,8 +21,7 @@ def test_afflict_and_trample_combined_lethal():
     """CR 702.131a, 702.19b & 104.3a: Afflict reduces life before damage and excess trample damage can finish a player off."""
     atk = CombatCreature("Rager", 2, 2, "A", afflict=2, trample=True)
     blk = CombatCreature("Chump", 1, 1, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=3, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     sim.simulate()
@@ -71,8 +70,7 @@ def test_double_strike_trample_overkill():
     """CR 702.4b, 702.19b & 104.3a: Damage from both combat steps of a double strike trampler can reduce a player's life below zero."""
     atk = CombatCreature("Crusher", 3, 3, "A", double_strike=True, trample=True)
     blk = CombatCreature("Blocker", 1, 1, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=3, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     sim.simulate()
@@ -85,8 +83,7 @@ def test_first_strike_blocker_barely_survives():
     """CR 702.7b & 104.3a: A blocker with first strike can kill the attacker before it deals damage, letting a low-life player survive."""
     atk = CombatCreature("Brute", 2, 2, "A")
     blk = CombatCreature("Savior", 2, 2, "B", first_strike=True)
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=1, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     sim.simulate()
@@ -99,8 +96,7 @@ def test_trample_lifelink_kills_player():
     """CR 702.19b, 702.15a & 104.3a: Trample can assign lethal damage to the player and lifelink gains that much life for the attacker."""
     atk = CombatCreature("Juggernaut", 4, 4, "A", trample=True, lifelink=True)
     blk = CombatCreature("Chump", 1, 1, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     state = GameState(players={"A": PlayerState(life=10, creatures=[atk]), "B": PlayerState(life=3, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     sim.simulate()
@@ -127,8 +123,7 @@ def test_afflict_lethal_before_lifelink_can_save():
     """CR 702.131a & 104.3a: Afflict resolves before combat damage. If it drops a player to 0 life, they lose before lifelink damage occurs."""
     atk = CombatCreature("Menace", 2, 2, "A", afflict=1)
     blk = CombatCreature("Healer", 2, 2, "B", lifelink=True)
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=1, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     sim.simulate()

--- a/tests/combat/test_gamestate.py
+++ b/tests/combat/test_gamestate.py
@@ -6,6 +6,7 @@ from magic_combat import (
     PlayerState,
     has_player_lost,
 )
+from tests.conftest import link_block
 
 
 def test_player_loses_when_life_zero():
@@ -46,8 +47,7 @@ def test_trample_infect_assigns_excess_poison():
     """CR 702.19b & 702.90b: Trample with infect deals excess damage as poison counters."""
     atk = CombatCreature("Toxic Beast", 4, 4, "A", trample=True, infect=True)
     blk = CombatCreature("Chump", 1, 1, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     state = GameState(
         players={
             "A": PlayerState(life=20, creatures=[atk]),
@@ -84,8 +84,7 @@ def test_wither_and_lifelink_vs_creature():
     """CR 702.90a & 702.15a: Wither deals -1/-1 counters but counts as damage for lifelink."""
     atk = CombatCreature("Pain Giver", 3, 3, "A", wither=True, lifelink=True)
     blk = CombatCreature("Target", 2, 2, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     state = GameState(
         players={
             "A": PlayerState(life=20, creatures=[atk]),
@@ -104,8 +103,7 @@ def test_deathtouch_trample_hits_player():
     """CR 702.19b & 702.2b: Only 1 damage must be assigned to the blocker before excess hits the player."""
     atk = CombatCreature("Crusher", 4, 4, "A", trample=True, deathtouch=True)
     blk = CombatCreature("Wall", 5, 5, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     state = GameState(
         players={
             "A": PlayerState(life=20, creatures=[atk]),

--- a/tests/combat/test_life_poison.py
+++ b/tests/combat/test_life_poison.py
@@ -1,5 +1,6 @@
 import pytest
 from magic_combat import CombatCreature, CombatSimulator, GameState, PlayerState, has_player_lost
+from tests.conftest import link_block
 
 
 def test_infect_lifelink_poison_lethal():
@@ -61,8 +62,7 @@ def test_lifelink_killed_before_dealing_damage():
     """CR 702.7b & 702.15a: A lifelink creature killed by first strike deals no damage and grants no life."""
     atk = CombatCreature("Cleric", 2, 2, "A", lifelink=True)
     blk = CombatCreature("First Striker", 2, 2, "B", first_strike=True)
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert result.lifegain.get("A", 0) == 0
@@ -74,8 +74,7 @@ def test_trample_deathtouch_lifelink_lethal():
     """CR 702.2b, 702.19b & 702.15a: With trample and deathtouch only 1 damage must be assigned to the blocker; the rest hits the player and lifelink gains total damage."""
     atk = CombatCreature("Charging Snake", 3, 3, "A", trample=True, deathtouch=True, lifelink=True)
     blk = CombatCreature("Bear", 2, 2, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     state = GameState(
         players={
             "A": PlayerState(life=20, creatures=[atk]),

--- a/tests/combat/test_state_based_toughness.py
+++ b/tests/combat/test_state_based_toughness.py
@@ -1,12 +1,12 @@
 from magic_combat import CombatCreature, CombatSimulator
+from tests.conftest import link_block
 
 
 def test_flanking_kills_weak_blocker_pre_damage():
     """CR 704.5f: A creature with toughness 0 or less is put into its owner's graveyard."""
     attacker = CombatCreature("Flanker", 1, 1, "A", flanking=1)
     blocker = CombatCreature("Vanilla", 1, 1, "B")
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     result = sim.simulate()
     assert blocker in result.creatures_destroyed
@@ -17,8 +17,7 @@ def test_minus_counters_can_cause_precombat_death():
     """CR 704.5f: State-based actions remove creatures with 0 toughness."""
     attacker = CombatCreature("Ogre", 2, 2, "A")
     blocker = CombatCreature("Weakling", 2, 2, "B", _minus1_counters=2)
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     result = sim.simulate()
     assert blocker in result.creatures_destroyed
@@ -29,8 +28,7 @@ def test_flanking_does_not_affect_other_flankers():
     """CR 702.25a: Flanking applies only to creatures without flanking."""
     attacker = CombatCreature("Knight1", 1, 1, "A", flanking=1)
     blocker = CombatCreature("Knight2", 1, 1, "B", flanking=1)
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     result = sim.simulate()
     assert blocker in result.creatures_destroyed

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,3 +3,11 @@ from pathlib import Path
 
 # Ensure the package is importable when running tests from any location
 sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def link_block(attacker, *blockers):
+    """Connect an attacker with one or more blockers."""
+    attacker.blocked_by.extend(blockers)
+    for b in blockers:
+        b.blocking = attacker
+

--- a/tests/poison/test_poison_extra.py
+++ b/tests/poison/test_poison_extra.py
@@ -1,13 +1,13 @@
 import pytest
 from magic_combat import CombatCreature, CombatSimulator, GameState, PlayerState
+from tests.conftest import link_block
 
 
 def test_infect_kills_creature_with_counters():
     """CR 702.90b: Infect damage to a creature is dealt as -1/-1 counters."""
     atk = CombatCreature("Toxic Bear", 3, 3, "A", infect=True)
     blk = CombatCreature("Wall", 2, 2, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert blk.minus1_counters == 2
@@ -18,8 +18,7 @@ def test_infect_lifelink_vs_blocker():
     """CR 702.90b & 702.15a: Infect gives counters and lifelink gains that much life."""
     atk = CombatCreature("Toxic Cleric", 2, 2, "A", infect=True, lifelink=True)
     blk = CombatCreature("Bear", 2, 2, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     state = GameState(players={"A": PlayerState(life=10, creatures=[atk]), "B": PlayerState(life=20, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     result = sim.simulate()
@@ -32,8 +31,7 @@ def test_infect_first_strike_kills_before_damage():
     """CR 702.7b & 702.90b: First strike infect kills the blocker before it can deal damage."""
     atk = CombatCreature("Toxic Fencer", 2, 2, "A", infect=True, first_strike=True)
     blk = CombatCreature("Bear", 2, 2, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert blk.minus1_counters == 2
@@ -56,9 +54,7 @@ def test_trample_infect_multiple_blockers():
     atk = CombatCreature("Toxic Beast", 3, 3, "A", trample=True, infect=True)
     b1 = CombatCreature("Goblin1", 1, 1, "B")
     b2 = CombatCreature("Goblin2", 1, 1, "B")
-    atk.blocked_by.extend([b1, b2])
-    b1.blocking = atk
-    b2.blocking = atk
+    link_block(atk, b1, b2)
     sim = CombatSimulator([atk], [b1, b2])
     result = sim.simulate()
     assert b1.minus1_counters == 1
@@ -71,8 +67,7 @@ def test_infect_prevents_persist_return():
     """CR 702.90b & 702.77a: Infect counters stop a persist creature from returning."""
     atk = CombatCreature("Infecting Knight", 2, 2, "A", infect=True)
     blk = CombatCreature("Everlasting", 2, 2, "B", persist=True)
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert blk in result.creatures_destroyed
@@ -83,8 +78,7 @@ def test_infect_kills_undying_but_it_returns():
     """CR 702.92a & 702.90b: Undying brings back a creature even if infect dealt the damage."""
     atk = CombatCreature("Toxic Slayer", 2, 2, "A", infect=True)
     blk = CombatCreature("Spirit", 2, 2, "B", undying=True)
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert blk not in result.creatures_destroyed
@@ -105,8 +99,7 @@ def test_lifelink_infect_vs_creature():
     """CR 702.15a & 702.90b: Lifelink gains life even when infect damages a creature."""
     atk = CombatCreature("Toxic Healer", 3, 3, "A", infect=True, lifelink=True)
     blk = CombatCreature("Bear", 3, 3, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     state = GameState(players={"A": PlayerState(life=10, creatures=[atk]), "B": PlayerState(life=20, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     result = sim.simulate()
@@ -119,8 +112,7 @@ def test_infect_with_afflict_still_causes_life_loss():
     """CR 702.131a & 702.90b: Afflict causes life loss even when an infect creature is blocked."""
     atk = CombatCreature("Tormentor", 2, 2, "A", infect=True, afflict=1)
     blk = CombatCreature("Guard", 2, 2, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=20, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     result = sim.simulate()

--- a/tests/test_counters.py
+++ b/tests/test_counters.py
@@ -6,6 +6,7 @@ from magic_combat import (
     GameState,
     PlayerState,
 )
+from tests.conftest import link_block
 
 
 def test_effective_stats_with_plus1_counters():
@@ -56,8 +57,7 @@ def test_wither_damage_gives_minus1_counters():
     """CR 702.90a: Damage from a creature with wither applies -1/-1 counters."""
     atk = CombatCreature("Corrosive", 2, 2, "A", wither=True)
     blk = CombatCreature("Wall", 2, 2, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert blk.minus1_counters == 2
@@ -68,8 +68,7 @@ def test_persist_returns_with_counter():
     """CR 702.77a: Persist returns a creature that died without -1/-1 counters."""
     atk = CombatCreature("Giant", 3, 3, "A")
     blk = CombatCreature("Spirit", 3, 3, "B", persist=True)
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert blk not in result.creatures_destroyed
@@ -80,8 +79,7 @@ def test_undying_returns_with_counter():
     """CR 702.92a: Undying returns the creature with a +1/+1 counter if it had none."""
     atk = CombatCreature("Phoenix", 2, 2, "A", undying=True)
     blk = CombatCreature("Bear", 2, 2, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert blk in result.creatures_destroyed
@@ -94,8 +92,7 @@ def test_annihilation_plus1_then_wither():
     atk = CombatCreature("Witherer", 1, 1, "A", wither=True)
     blk = CombatCreature("Veteran", 1, 1, "B")
     blk.plus1_counters = 1
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     sim.simulate()
     assert blk.plus1_counters == 0
@@ -107,8 +104,7 @@ def test_annihilation_multiple_pairs():
     atk = CombatCreature("Witherer", 3, 3, "A", wither=True)
     blk = CombatCreature("Hero", 2, 2, "B")
     blk.plus1_counters = 2
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     sim.simulate()
     assert blk.plus1_counters == 0

--- a/tests/test_indestructible.py
+++ b/tests/test_indestructible.py
@@ -1,12 +1,12 @@
 from magic_combat import CombatCreature, CombatSimulator, GameState, PlayerState
+from tests.conftest import link_block
 
 
 def test_indestructible_attacker_survives_block():
     """CR 702.12b: Indestructible permanents aren't destroyed by lethal damage."""
     attacker = CombatCreature("Hero", 2, 2, "A", indestructible=True)
     blocker = CombatCreature("Ogre", 3, 3, "B")
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     result = sim.simulate()
     assert attacker not in result.creatures_destroyed
@@ -17,8 +17,7 @@ def test_double_strike_indestructible_attacker_survives():
     """CR 702.4b & 702.12b: Double strike doesn't destroy an indestructible creature even after lethal damage."""
     attacker = CombatCreature("Champion", 2, 2, "A", indestructible=True, double_strike=True)
     blocker = CombatCreature("Guard", 3, 3, "B")
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     result = sim.simulate()
     assert attacker not in result.creatures_destroyed
@@ -29,8 +28,7 @@ def test_trample_vs_indestructible_blocker():
     """CR 702.12b & 702.19b: Trample must still assign lethal damage to an indestructible blocker."""
     attacker = CombatCreature("Beast", 5, 5, "A", trample=True)
     blocker = CombatCreature("Guardian", 2, 2, "B", indestructible=True)
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     result = sim.simulate()
     assert result.damage_to_players["B"] == 3
@@ -41,8 +39,7 @@ def test_wither_damage_kills_indestructible():
     """CR 702.90a & 702.12b: Wither counters can cause an indestructible creature to die."""
     attacker = CombatCreature("Corrosive Blade", 2, 2, "A", wither=True)
     blocker = CombatCreature("Steel Guardian", 2, 2, "B", indestructible=True)
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     result = sim.simulate()
     assert blocker in result.creatures_destroyed
@@ -53,8 +50,7 @@ def test_double_strike_wither_kills_indestructible():
     """CR 702.4b & 702.90a & 702.12b: Double strike with wither can destroy an indestructible creature in the first-strike step."""
     attacker = CombatCreature("Acid Duelist", 1, 1, "A", double_strike=True, wither=True)
     blocker = CombatCreature("Iron Guardian", 1, 1, "B", indestructible=True)
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     result = sim.simulate()
     assert blocker in result.creatures_destroyed
@@ -66,8 +62,7 @@ def test_persist_indestructible_dies_no_return_with_counters():
     """CR 702.12b & 702.77a: Persist doesn't return a creature that dies with a -1/-1 counter."""
     attacker = CombatCreature("Corrosive", 2, 2, "A", wither=True)
     blocker = CombatCreature("Everlasting", 2, 2, "B", indestructible=True, persist=True)
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     result = sim.simulate()
     assert blocker in result.creatures_destroyed
@@ -78,8 +73,7 @@ def test_undying_indestructible_returns_with_counter():
     """CR 702.12b & 702.92a: An indestructible creature with undying returns with a +1/+1 counter if it dies without one."""
     attacker = CombatCreature("Corrosive", 1, 1, "A", wither=True)
     blocker = CombatCreature("Phoenix", 1, 1, "B", indestructible=True, undying=True)
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     result = sim.simulate()
     assert blocker not in result.creatures_destroyed
@@ -91,8 +85,7 @@ def test_indestructible_lifelink_gains_life():
     """CR 702.15a & 702.12b: Lifelink causes life gain even if the creature is indestructible."""
     attacker = CombatCreature("Angel", 2, 2, "A", indestructible=True, lifelink=True)
     blocker = CombatCreature("Bear", 2, 2, "B")
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     state = GameState(players={"A": PlayerState(life=10, creatures=[attacker]), "B": PlayerState(life=20, creatures=[blocker])})
     sim = CombatSimulator([attacker], [blocker], game_state=state)
     result = sim.simulate()
@@ -105,8 +98,7 @@ def test_trample_wither_vs_indestructible_blocker():
     """CR 702.19b, 702.90a & 702.12b: Trample with wither assigns lethal counters before excess damage."""
     attacker = CombatCreature("Toxic Beast", 3, 3, "A", trample=True, wither=True)
     blocker = CombatCreature("Steel Wall", 2, 2, "B", indestructible=True)
-    attacker.blocked_by.append(blocker)
-    blocker.blocking = attacker
+    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
     result = sim.simulate()
     assert blocker in result.creatures_destroyed
@@ -119,9 +111,7 @@ def test_indestructible_attacker_multiple_blockers():
     attacker = CombatCreature("Titan", 4, 4, "A", indestructible=True)
     b1 = CombatCreature("Soldier1", 2, 2, "B")
     b2 = CombatCreature("Soldier2", 2, 2, "B")
-    attacker.blocked_by.extend([b1, b2])
-    b1.blocking = attacker
-    b2.blocking = attacker
+    link_block(attacker, b1, b2)
     sim = CombatSimulator([attacker], [b1, b2])
     result = sim.simulate()
     assert attacker not in result.creatures_destroyed

--- a/tests/test_poison_suite.py
+++ b/tests/test_poison_suite.py
@@ -1,13 +1,13 @@
 import pytest
 from magic_combat import CombatCreature, CombatSimulator, GameState, PlayerState
+from tests.conftest import link_block
 
 
 def test_infect_kills_creature_with_counters():
     """CR 702.90b: Infect damage to a creature is dealt as -1/-1 counters."""
     atk = CombatCreature("Toxic Bear", 3, 3, "A", infect=True)
     blk = CombatCreature("Wall", 2, 2, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert blk.minus1_counters == 2
@@ -18,8 +18,7 @@ def test_infect_lifelink_vs_blocker():
     """CR 702.90b & 702.15a: Infect gives counters and lifelink gains that much life."""
     atk = CombatCreature("Toxic Cleric", 2, 2, "A", infect=True, lifelink=True)
     blk = CombatCreature("Bear", 2, 2, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     state = GameState(players={"A": PlayerState(life=10, creatures=[atk]), "B": PlayerState(life=20, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     result = sim.simulate()
@@ -32,8 +31,7 @@ def test_infect_first_strike_kills_before_damage():
     """CR 702.7b & 702.90b: First strike infect kills the blocker before it can deal damage."""
     atk = CombatCreature("Toxic Fencer", 2, 2, "A", infect=True, first_strike=True)
     blk = CombatCreature("Bear", 2, 2, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert blk.minus1_counters == 2
@@ -56,9 +54,7 @@ def test_trample_infect_multiple_blockers():
     atk = CombatCreature("Toxic Beast", 3, 3, "A", trample=True, infect=True)
     b1 = CombatCreature("Goblin1", 1, 1, "B")
     b2 = CombatCreature("Goblin2", 1, 1, "B")
-    atk.blocked_by.extend([b1, b2])
-    b1.blocking = atk
-    b2.blocking = atk
+    link_block(atk, b1, b2)
     sim = CombatSimulator([atk], [b1, b2])
     result = sim.simulate()
     assert b1.minus1_counters == 1
@@ -71,8 +67,7 @@ def test_infect_prevents_persist_return():
     """CR 702.90b & 702.77a: Infect counters stop a persist creature from returning."""
     atk = CombatCreature("Infecting Knight", 2, 2, "A", infect=True)
     blk = CombatCreature("Everlasting", 2, 2, "B", persist=True)
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert blk in result.creatures_destroyed
@@ -83,8 +78,7 @@ def test_infect_kills_undying_but_it_returns():
     """CR 702.92a & 702.90b: Undying brings back a creature even if infect dealt the damage."""
     atk = CombatCreature("Toxic Slayer", 2, 2, "A", infect=True)
     blk = CombatCreature("Spirit", 2, 2, "B", undying=True)
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     sim = CombatSimulator([atk], [blk])
     result = sim.simulate()
     assert blk not in result.creatures_destroyed
@@ -105,8 +99,7 @@ def test_lifelink_infect_vs_creature():
     """CR 702.15a & 702.90b: Lifelink gains life even when infect damages a creature."""
     atk = CombatCreature("Toxic Healer", 3, 3, "A", infect=True, lifelink=True)
     blk = CombatCreature("Bear", 3, 3, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     state = GameState(players={"A": PlayerState(life=10, creatures=[atk]), "B": PlayerState(life=20, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     result = sim.simulate()
@@ -119,8 +112,7 @@ def test_infect_with_afflict_still_causes_life_loss():
     """CR 702.131a & 702.90b: Afflict causes life loss even when an infect creature is blocked."""
     atk = CombatCreature("Tormentor", 2, 2, "A", infect=True, afflict=1)
     blk = CombatCreature("Guard", 2, 2, "B")
-    atk.blocked_by.append(blk)
-    blk.blocking = atk
+    link_block(atk, blk)
     state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=20, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     result = sim.simulate()


### PR DESCRIPTION
## Summary
- add `link_block` helper in tests
- refactor tests to use `link_block`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68566868d504832aba79a8fb431e2213