### PR TITLE
Add STARTING_LIFE_TOTAL constant

### DIFF
--- a/magic_combat/__init__.py
+++ b/magic_combat/__init__.py
@@ -3,7 +3,12 @@
 from .creature import CombatCreature, Color
 from .simulator import CombatResult, CombatSimulator
 from .damage import DamageAssignmentStrategy, MostCreaturesKilledStrategy
-from .gamestate import GameState, PlayerState, has_player_lost
+from .gamestate import (
+    GameState,
+    PlayerState,
+    STARTING_LIFE_TOTAL,
+    has_player_lost,
+)
 
 __all__ = [
     "CombatCreature",
@@ -14,5 +19,6 @@ __all__ = [
     "MostCreaturesKilledStrategy",
     "GameState",
     "PlayerState",
+    "STARTING_LIFE_TOTAL",
     "has_player_lost",
 ]

--- a/magic_combat/gamestate.py
+++ b/magic_combat/gamestate.py
@@ -7,6 +7,9 @@ from typing import Dict, List
 
 from .utils import check_non_negative
 
+# Default starting life total for new players
+STARTING_LIFE_TOTAL = 20
+
 from .creature import CombatCreature
 
 

--- a/magic_combat/simulator.py
+++ b/magic_combat/simulator.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional
 
 from .creature import CombatCreature, Color
 from .damage import DamageAssignmentStrategy, MostCreaturesKilledStrategy
-from .gamestate import GameState, PlayerState, has_player_lost
+from .gamestate import GameState, PlayerState, STARTING_LIFE_TOTAL, has_player_lost
 
 @dataclass
 class CombatResult:
@@ -193,7 +193,7 @@ class CombatSimulator:
         if self.game_state is not None:
             max_life = max(ps.life for ps in self.game_state.players.values())
             defender_life = self.game_state.players.get(
-                defender_player, PlayerState(life=20, creatures=[], poison=0)
+                defender_player, PlayerState(life=STARTING_LIFE_TOTAL, creatures=[], poison=0)
             ).life
             for atk in self.attackers:
                 if atk.dethrone and defender_life >= max_life:
@@ -207,7 +207,7 @@ class CombatSimulator:
                 defender = defender_player if self.defenders else "defender"
                 self.player_damage[defender] = self.player_damage.get(defender, 0) + atk.afflict
                 if self.game_state is not None:
-                    ps = self.game_state.players.setdefault(defender, PlayerState(life=20, creatures=[], poison=0))
+                    ps = self.game_state.players.setdefault(defender, PlayerState(life=STARTING_LIFE_TOTAL, creatures=[], poison=0))
                     ps.life -= atk.afflict
 
         # Bushido, Rampage, and Flanking - CR 702.46, 702.23 & 702.25
@@ -310,7 +310,7 @@ class CombatSimulator:
             if self.game_state is not None:
                 ps = self.game_state.players.setdefault(
                     defender,
-                    PlayerState(life=20, creatures=[], poison=0),
+                    PlayerState(life=STARTING_LIFE_TOTAL, creatures=[], poison=0),
                 )
                 ps.poison += dmg
         else:
@@ -318,7 +318,7 @@ class CombatSimulator:
             if self.game_state is not None:
                 ps = self.game_state.players.setdefault(
                     defender,
-                    PlayerState(life=20, creatures=[], poison=0),
+                    PlayerState(life=STARTING_LIFE_TOTAL, creatures=[], poison=0),
                 )
                 ps.life -= dmg
         if attacker.lifelink:
@@ -330,7 +330,7 @@ class CombatSimulator:
             if self.game_state is not None:
                 ps = self.game_state.players.setdefault(
                     defender,
-                    PlayerState(life=20, creatures=[], poison=0),
+                    PlayerState(life=STARTING_LIFE_TOTAL, creatures=[], poison=0),
                 )
                 ps.poison += attacker.toxic
 
@@ -392,7 +392,7 @@ class CombatSimulator:
                 diff = gain - already
                 if diff:
                     ps = self.game_state.players.setdefault(
-                        player, PlayerState(life=20, creatures=[], poison=0)
+                        player, PlayerState(life=STARTING_LIFE_TOTAL, creatures=[], poison=0)
                     )
                     ps.life += diff
                     self._lifegain_applied[player] = gain

--- a/tests/abilities/test_additional_keyword_abilities.py
+++ b/tests/abilities/test_additional_keyword_abilities.py
@@ -1,6 +1,13 @@
 import pytest
 
-from magic_combat import CombatCreature, CombatSimulator, GameState, PlayerState, Color
+from magic_combat import (
+    CombatCreature,
+    CombatSimulator,
+    GameState,
+    PlayerState,
+    STARTING_LIFE_TOTAL,
+    Color,
+)
 
 
 def test_defender_cannot_attack():
@@ -81,7 +88,7 @@ def test_dethrone_adds_counter():
     """CR 702.103a: Dethrone grants a +1/+1 counter when attacking the player with the most life."""
     atk = CombatCreature("Challenger", 2, 2, "A", dethrone=True)
     defender = CombatCreature("Dummy", 0, 1, "B")
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=25, creatures=[defender])})
+    state = GameState(players={"A": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[atk]), "B": PlayerState(life=25, creatures=[defender])})
     sim = CombatSimulator([atk], [defender], game_state=state)
     sim.simulate()
     assert atk.plus1_counters == 1

--- a/tests/abilities/test_complex_ability_combos.py
+++ b/tests/abilities/test_complex_ability_combos.py
@@ -5,6 +5,7 @@ from magic_combat import (
     CombatSimulator,
     GameState,
     PlayerState,
+    STARTING_LIFE_TOTAL,
     Color,
 )
 
@@ -56,8 +57,8 @@ def test_double_strike_infect_toxic_lifelink():
     defender = CombatCreature("Dummy", 0, 1, "B")
     state = GameState(
         players={
-            "A": PlayerState(life=20, creatures=[attacker]),
-            "B": PlayerState(life=20, creatures=[defender]),
+            "A": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[attacker]),
+            "B": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[defender]),
         }
     )
     sim = CombatSimulator([attacker], [defender], game_state=state)

--- a/tests/abilities/test_deathtouch.py
+++ b/tests/abilities/test_deathtouch.py
@@ -1,6 +1,12 @@
 import pytest
 
-from magic_combat import CombatCreature, CombatSimulator, GameState, PlayerState
+from magic_combat import (
+    CombatCreature,
+    CombatSimulator,
+    GameState,
+    PlayerState,
+    STARTING_LIFE_TOTAL,
+)
 
 
 def test_zero_power_deathtouch_deals_no_damage():
@@ -47,7 +53,7 @@ def test_deathtouch_lifelink_gain_life():
     blk = CombatCreature("Bear", 2, 2, "B")
     atk.blocked_by.append(blk)
     blk.blocking = atk
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=20, creatures=[blk])})
+    state = GameState(players={"A": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[atk]), "B": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     result = sim.simulate()
     assert blk in result.creatures_destroyed

--- a/tests/abilities/test_poison.py
+++ b/tests/abilities/test_poison.py
@@ -1,6 +1,13 @@
 import pytest
 
-from magic_combat import CombatCreature, CombatSimulator, GameState, PlayerState, has_player_lost
+from magic_combat import (
+    CombatCreature,
+    CombatSimulator,
+    GameState,
+    PlayerState,
+    STARTING_LIFE_TOTAL,
+    has_player_lost,
+)
 
 
 def test_infect_creature_gets_minus1_counters():
@@ -21,7 +28,7 @@ def test_infect_lifelink_vs_creature():
     blk = CombatCreature("Guard", 2, 2, "B")
     atk.blocked_by.append(blk)
     blk.blocking = atk
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=20, creatures=[blk])})
+    state = GameState(players={"A": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[atk]), "B": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     result = sim.simulate()
     assert blk.minus1_counters == 2
@@ -35,7 +42,7 @@ def test_trample_infect_lifelink_poison_and_life():
     blk = CombatCreature("Chump", 1, 1, "B")
     atk.blocked_by.append(blk)
     blk.blocking = atk
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=20, creatures=[blk])})
+    state = GameState(players={"A": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[atk]), "B": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     result = sim.simulate()
     assert blk.minus1_counters == 1
@@ -87,7 +94,7 @@ def test_infect_and_toxic_stack_poison():
     """CR 702.90b & 702.??: Infect and toxic add poison counters together."""
     atk = CombatCreature("Venomous", 2, 2, "A", infect=True, toxic=1)
     defender = CombatCreature("Dummy", 0, 1, "B")
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=20, creatures=[defender])})
+    state = GameState(players={"A": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[atk]), "B": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[defender])})
     sim = CombatSimulator([atk], [defender], game_state=state)
     result = sim.simulate()
     assert state.players["B"].poison == 3
@@ -110,7 +117,7 @@ def test_player_loses_at_ten_poison():
     """CR 104.3c: A player with ten or more poison counters loses the game."""
     atk = CombatCreature("Infector", 1, 1, "A", infect=True)
     defender = CombatCreature("Dummy", 0, 1, "B")
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=20, creatures=[defender], poison=9)})
+    state = GameState(players={"A": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[atk]), "B": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[defender], poison=9)})
     sim = CombatSimulator([atk], [defender], game_state=state)
     sim.simulate()
     assert state.players["B"].poison == 10
@@ -140,7 +147,7 @@ def test_infect_with_afflict_still_deals_life_loss():
     blk = CombatCreature("Guard", 2, 2, "B")
     atk.blocked_by.append(blk)
     blk.blocking = atk
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=20, creatures=[blk])})
+    state = GameState(players={"A": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[atk]), "B": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     result = sim.simulate()
     assert result.damage_to_players["B"] == 2
@@ -162,7 +169,7 @@ def test_infect_unblocked_lifelink_gains_life():
     """CR 702.15a & 702.90b: Lifelink triggers even when infect damage becomes poison counters."""
     atk = CombatCreature("Healer", 2, 2, "A", infect=True, lifelink=True)
     defender = CombatCreature("Dummy", 0, 1, "B")
-    state = GameState(players={"A": PlayerState(life=10, creatures=[atk]), "B": PlayerState(life=20, creatures=[defender])})
+    state = GameState(players={"A": PlayerState(life=10, creatures=[atk]), "B": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[defender])})
     sim = CombatSimulator([atk], [defender], game_state=state)
     result = sim.simulate()
     assert result.poison_counters["B"] == 2

--- a/tests/combat/test_combat_buffs.py
+++ b/tests/combat/test_combat_buffs.py
@@ -1,5 +1,11 @@
 import pytest
-from magic_combat import CombatCreature, CombatSimulator, GameState, PlayerState
+from magic_combat import (
+    CombatCreature,
+    CombatSimulator,
+    GameState,
+    PlayerState,
+    STARTING_LIFE_TOTAL,
+)
 
 
 # Rampage tests
@@ -184,7 +190,7 @@ def test_dethrone_when_opponent_highest_life():
     """CR 702.103a: Dethrone gives a +1/+1 counter if the defending player has the most life."""
     atk = CombatCreature("Challenger", 2, 2, "A", dethrone=True)
     defender = CombatCreature("Dummy", 0, 1, "B")
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=25, creatures=[defender])})
+    state = GameState(players={"A": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[atk]), "B": PlayerState(life=25, creatures=[defender])})
     sim = CombatSimulator([atk], [defender], game_state=state)
     sim.simulate()
     assert atk.plus1_counters == 1
@@ -194,7 +200,7 @@ def test_dethrone_no_counter_when_not_highest():
     """CR 702.103a: No dethrone counter if defender doesn't have the most life."""
     atk = CombatCreature("Challenger", 2, 2, "A", dethrone=True)
     defender = CombatCreature("Dummy", 0, 1, "B")
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=15, creatures=[defender])})
+    state = GameState(players={"A": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[atk]), "B": PlayerState(life=15, creatures=[defender])})
     sim = CombatSimulator([atk], [defender], game_state=state)
     sim.simulate()
     assert atk.plus1_counters == 0

--- a/tests/combat/test_game_loss_scenarios.py
+++ b/tests/combat/test_game_loss_scenarios.py
@@ -1,5 +1,12 @@
 import pytest
-from magic_combat import CombatCreature, CombatSimulator, GameState, PlayerState, has_player_lost
+from magic_combat import (
+    CombatCreature,
+    CombatSimulator,
+    GameState,
+    PlayerState,
+    STARTING_LIFE_TOTAL,
+    has_player_lost,
+)
 
 
 
@@ -9,7 +16,7 @@ def test_afflict_lethal_when_blocked():
     blk = CombatCreature("Guard", 2, 2, "B")
     atk.blocked_by.append(blk)
     blk.blocking = atk
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=2, creatures=[blk])})
+    state = GameState(players={"A": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[atk]), "B": PlayerState(life=2, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     sim.simulate()
     assert state.players["B"].life == 0
@@ -23,7 +30,7 @@ def test_afflict_and_trample_combined_lethal():
     blk = CombatCreature("Chump", 1, 1, "B")
     atk.blocked_by.append(blk)
     blk.blocking = atk
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=3, creatures=[blk])})
+    state = GameState(players={"A": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[atk]), "B": PlayerState(life=3, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     sim.simulate()
     assert state.players["B"].life == 0
@@ -35,7 +42,7 @@ def test_toxic_three_poison_counters_causes_loss():
     """CR 702.??? & 104.3c: Toxic gives that many poison counters; a player with ten or more poison counters loses."""
     atk = CombatCreature("Stinger", 1, 1, "A", toxic=3)
     defender = CombatCreature("Dummy", 0, 1, "B")
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=20, creatures=[defender], poison=8)})
+    state = GameState(players={"A": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[atk]), "B": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[defender], poison=8)})
     sim = CombatSimulator([atk], [defender], game_state=state)
     sim.simulate()
     assert state.players["B"].poison == 11
@@ -47,7 +54,7 @@ def test_infect_and_toxic_exactly_ten_poison():
     """CR 702.90b & 104.3c: Infect and toxic together can give enough poison counters for a player to lose."""
     atk = CombatCreature("Toxic Infector", 2, 2, "A", infect=True, toxic=2)
     defender = CombatCreature("Dummy", 0, 1, "B")
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=20, creatures=[defender], poison=6)})
+    state = GameState(players={"A": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[atk]), "B": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[defender], poison=6)})
     sim = CombatSimulator([atk], [defender], game_state=state)
     sim.simulate()
     assert state.players["B"].poison == 10
@@ -59,7 +66,7 @@ def test_double_strike_infect_first_step_loss():
     """CR 702.4b, 702.90b & 104.3c: Double strike with infect can cause a player to lose after the first combat damage step."""
     atk = CombatCreature("Toxic Duelist", 1, 1, "A", infect=True, double_strike=True)
     defender = CombatCreature("Dummy", 0, 1, "B")
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=20, creatures=[defender], poison=9)})
+    state = GameState(players={"A": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[atk]), "B": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[defender], poison=9)})
     sim = CombatSimulator([atk], [defender], game_state=state)
     sim.simulate()
     assert state.players["B"].poison == 11
@@ -73,7 +80,7 @@ def test_double_strike_trample_overkill():
     blk = CombatCreature("Blocker", 1, 1, "B")
     atk.blocked_by.append(blk)
     blk.blocking = atk
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=3, creatures=[blk])})
+    state = GameState(players={"A": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[atk]), "B": PlayerState(life=3, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     sim.simulate()
     assert state.players["B"].life == -2
@@ -87,7 +94,7 @@ def test_first_strike_blocker_barely_survives():
     blk = CombatCreature("Savior", 2, 2, "B", first_strike=True)
     atk.blocked_by.append(blk)
     blk.blocking = atk
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=1, creatures=[blk])})
+    state = GameState(players={"A": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[atk]), "B": PlayerState(life=1, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     sim.simulate()
     assert state.players["B"].life == 1
@@ -114,7 +121,7 @@ def test_lifelink_cannot_prevent_poison_loss():
     """CR 702.15a, 702.90b & 104.3c: Lifelink doesn't stop a player from losing to poison counters inflicted by infect."""
     atk = CombatCreature("Toxic Vampire", 1, 1, "A", infect=True, lifelink=True)
     defender = CombatCreature("Dummy", 0, 1, "B")
-    state = GameState(players={"A": PlayerState(life=5, creatures=[atk]), "B": PlayerState(life=20, creatures=[defender], poison=9)})
+    state = GameState(players={"A": PlayerState(life=5, creatures=[atk]), "B": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[defender], poison=9)})
     sim = CombatSimulator([atk], [defender], game_state=state)
     sim.simulate()
     assert state.players["A"].life == 6
@@ -129,7 +136,7 @@ def test_afflict_lethal_before_lifelink_can_save():
     blk = CombatCreature("Healer", 2, 2, "B", lifelink=True)
     atk.blocked_by.append(blk)
     blk.blocking = atk
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=1, creatures=[blk])})
+    state = GameState(players={"A": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[atk]), "B": PlayerState(life=1, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     sim.simulate()
     assert state.players["B"].life == 2

--- a/tests/combat/test_gamestate.py
+++ b/tests/combat/test_gamestate.py
@@ -4,6 +4,7 @@ from magic_combat import (
     CombatSimulator,
     GameState,
     PlayerState,
+    STARTING_LIFE_TOTAL,
     has_player_lost,
 )
 
@@ -14,7 +15,7 @@ def test_player_loses_when_life_zero():
     defender = CombatCreature("Dummy", 0, 1, "B")
     state = GameState(
         players={
-            "A": PlayerState(life=20, creatures=[atk]),
+            "A": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[atk]),
             "B": PlayerState(life=2, creatures=[defender]),
         }
     )
@@ -31,8 +32,8 @@ def test_player_loses_from_poison():
     defender = CombatCreature("Dummy", 0, 1, "B")
     state = GameState(
         players={
-            "A": PlayerState(life=20, creatures=[atk]),
-            "B": PlayerState(life=20, creatures=[defender], poison=9),
+            "A": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[atk]),
+            "B": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[defender], poison=9),
         }
     )
     sim = CombatSimulator([atk], [defender], game_state=state)
@@ -50,8 +51,8 @@ def test_trample_infect_assigns_excess_poison():
     blk.blocking = atk
     state = GameState(
         players={
-            "A": PlayerState(life=20, creatures=[atk]),
-            "B": PlayerState(life=20, creatures=[blk]),
+            "A": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[atk]),
+            "B": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[blk]),
         }
     )
     sim = CombatSimulator([atk], [blk], game_state=state)
@@ -69,7 +70,7 @@ def test_infect_with_lifelink_grants_life():
     state = GameState(
         players={
             "A": PlayerState(life=10, creatures=[atk]),
-            "B": PlayerState(life=20, creatures=[defender]),
+            "B": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[defender]),
         }
     )
     sim = CombatSimulator([atk], [defender], game_state=state)
@@ -88,8 +89,8 @@ def test_wither_and_lifelink_vs_creature():
     blk.blocking = atk
     state = GameState(
         players={
-            "A": PlayerState(life=20, creatures=[atk]),
-            "B": PlayerState(life=20, creatures=[blk]),
+            "A": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[atk]),
+            "B": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[blk]),
         }
     )
     sim = CombatSimulator([atk], [blk], game_state=state)
@@ -108,8 +109,8 @@ def test_deathtouch_trample_hits_player():
     blk.blocking = atk
     state = GameState(
         players={
-            "A": PlayerState(life=20, creatures=[atk]),
-            "B": PlayerState(life=20, creatures=[blk]),
+            "A": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[atk]),
+            "B": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[blk]),
         }
     )
     sim = CombatSimulator([atk], [blk], game_state=state)
@@ -127,7 +128,7 @@ def test_double_strike_lifelink_twice():
     state = GameState(
         players={
             "A": PlayerState(life=10, creatures=[atk]),
-            "B": PlayerState(life=20, creatures=[defender]),
+            "B": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[defender]),
         }
     )
     sim = CombatSimulator([atk], [defender], game_state=state)
@@ -143,8 +144,8 @@ def test_double_strike_infect_can_cause_loss():
     defender = CombatCreature("Dummy", 0, 1, "B")
     state = GameState(
         players={
-            "A": PlayerState(life=20, creatures=[atk]),
-            "B": PlayerState(life=20, creatures=[defender], poison=8),
+            "A": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[atk]),
+            "B": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[defender], poison=8),
         }
     )
     sim = CombatSimulator([atk], [defender], game_state=state)

--- a/tests/combat/test_life_poison.py
+++ b/tests/combat/test_life_poison.py
@@ -1,5 +1,12 @@
 import pytest
-from magic_combat import CombatCreature, CombatSimulator, GameState, PlayerState, has_player_lost
+from magic_combat import (
+    CombatCreature,
+    CombatSimulator,
+    GameState,
+    PlayerState,
+    STARTING_LIFE_TOTAL,
+    has_player_lost,
+)
 
 
 def test_infect_lifelink_poison_lethal():
@@ -8,8 +15,8 @@ def test_infect_lifelink_poison_lethal():
     defender = CombatCreature("Dummy", 0, 1, "B")
     state = GameState(
         players={
-            "A": PlayerState(life=20, creatures=[atk]),
-            "B": PlayerState(life=20, creatures=[defender], poison=8),
+            "A": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[atk]),
+            "B": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[defender], poison=8),
         }
     )
     sim = CombatSimulator([atk], [defender], game_state=state)
@@ -27,7 +34,7 @@ def test_double_strike_lifelink_player_lethal():
     defender = CombatCreature("Dummy", 0, 1, "B")
     state = GameState(
         players={
-            "A": PlayerState(life=20, creatures=[atk]),
+            "A": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[atk]),
             "B": PlayerState(life=3, creatures=[defender]),
         }
     )
@@ -45,8 +52,8 @@ def test_infect_double_strike_lifelink_poison_lethal():
     defender = CombatCreature("Dummy", 0, 1, "B")
     state = GameState(
         players={
-            "A": PlayerState(life=20, creatures=[atk]),
-            "B": PlayerState(life=20, creatures=[defender], poison=9),
+            "A": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[atk]),
+            "B": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[defender], poison=9),
         }
     )
     sim = CombatSimulator([atk], [defender], game_state=state)
@@ -78,7 +85,7 @@ def test_trample_deathtouch_lifelink_lethal():
     blk.blocking = atk
     state = GameState(
         players={
-            "A": PlayerState(life=20, creatures=[atk]),
+            "A": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[atk]),
             "B": PlayerState(life=2, creatures=[blk]),
         }
     )

--- a/tests/core/test_playerstate_validation.py
+++ b/tests/core/test_playerstate_validation.py
@@ -1,6 +1,6 @@
 import pytest
 
-from magic_combat import PlayerState
+from magic_combat import PlayerState, STARTING_LIFE_TOTAL
 
 
 def test_negative_life_init():
@@ -12,4 +12,4 @@ def test_negative_life_init():
 def test_negative_poison_init():
     """CR 107.1: Numbers like poison counters can't be negative."""
     with pytest.raises(ValueError):
-        PlayerState(life=20, creatures=[], poison=-1)
+        PlayerState(life=STARTING_LIFE_TOTAL, creatures=[], poison=-1)

--- a/tests/poison/test_poison_extra.py
+++ b/tests/poison/test_poison_extra.py
@@ -1,5 +1,11 @@
 import pytest
-from magic_combat import CombatCreature, CombatSimulator, GameState, PlayerState
+from magic_combat import (
+    CombatCreature,
+    CombatSimulator,
+    GameState,
+    PlayerState,
+    STARTING_LIFE_TOTAL,
+)
 
 
 def test_infect_kills_creature_with_counters():
@@ -20,7 +26,7 @@ def test_infect_lifelink_vs_blocker():
     blk = CombatCreature("Bear", 2, 2, "B")
     atk.blocked_by.append(blk)
     blk.blocking = atk
-    state = GameState(players={"A": PlayerState(life=10, creatures=[atk]), "B": PlayerState(life=20, creatures=[blk])})
+    state = GameState(players={"A": PlayerState(life=10, creatures=[atk]), "B": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     result = sim.simulate()
     assert blk.minus1_counters == 2
@@ -107,7 +113,7 @@ def test_lifelink_infect_vs_creature():
     blk = CombatCreature("Bear", 3, 3, "B")
     atk.blocked_by.append(blk)
     blk.blocking = atk
-    state = GameState(players={"A": PlayerState(life=10, creatures=[atk]), "B": PlayerState(life=20, creatures=[blk])})
+    state = GameState(players={"A": PlayerState(life=10, creatures=[atk]), "B": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     result = sim.simulate()
     assert result.lifegain["A"] == 3
@@ -121,7 +127,7 @@ def test_infect_with_afflict_still_causes_life_loss():
     blk = CombatCreature("Guard", 2, 2, "B")
     atk.blocked_by.append(blk)
     blk.blocking = atk
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=20, creatures=[blk])})
+    state = GameState(players={"A": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[atk]), "B": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     result = sim.simulate()
     assert state.players["B"].life == 19

--- a/tests/test_counters.py
+++ b/tests/test_counters.py
@@ -5,6 +5,7 @@ from magic_combat import (
     CombatSimulator,
     GameState,
     PlayerState,
+    STARTING_LIFE_TOTAL,
 )
 
 
@@ -45,7 +46,7 @@ def test_dethrone_counter_annihilates_existing_minus1():
     attacker = CombatCreature("Challenger", 2, 2, "A", dethrone=True)
     attacker.minus1_counters = 1
     defender = CombatCreature("Dummy", 0, 1, "B")
-    state = GameState(players={"A": PlayerState(life=20, creatures=[attacker]), "B": PlayerState(life=25, creatures=[defender])})
+    state = GameState(players={"A": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[attacker]), "B": PlayerState(life=25, creatures=[defender])})
     sim = CombatSimulator([attacker], [defender], game_state=state)
     sim.simulate()
     assert attacker.plus1_counters == 0

--- a/tests/test_indestructible.py
+++ b/tests/test_indestructible.py
@@ -1,4 +1,10 @@
-from magic_combat import CombatCreature, CombatSimulator, GameState, PlayerState
+from magic_combat import (
+    CombatCreature,
+    CombatSimulator,
+    GameState,
+    PlayerState,
+    STARTING_LIFE_TOTAL,
+)
 
 
 def test_indestructible_attacker_survives_block():
@@ -93,7 +99,7 @@ def test_indestructible_lifelink_gains_life():
     blocker = CombatCreature("Bear", 2, 2, "B")
     attacker.blocked_by.append(blocker)
     blocker.blocking = attacker
-    state = GameState(players={"A": PlayerState(life=10, creatures=[attacker]), "B": PlayerState(life=20, creatures=[blocker])})
+    state = GameState(players={"A": PlayerState(life=10, creatures=[attacker]), "B": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[blocker])})
     sim = CombatSimulator([attacker], [blocker], game_state=state)
     result = sim.simulate()
     assert result.lifegain["A"] == 2

--- a/tests/test_poison_suite.py
+++ b/tests/test_poison_suite.py
@@ -1,5 +1,11 @@
 import pytest
-from magic_combat import CombatCreature, CombatSimulator, GameState, PlayerState
+from magic_combat import (
+    CombatCreature,
+    CombatSimulator,
+    GameState,
+    PlayerState,
+    STARTING_LIFE_TOTAL,
+)
 
 
 def test_infect_kills_creature_with_counters():
@@ -20,7 +26,7 @@ def test_infect_lifelink_vs_blocker():
     blk = CombatCreature("Bear", 2, 2, "B")
     atk.blocked_by.append(blk)
     blk.blocking = atk
-    state = GameState(players={"A": PlayerState(life=10, creatures=[atk]), "B": PlayerState(life=20, creatures=[blk])})
+    state = GameState(players={"A": PlayerState(life=10, creatures=[atk]), "B": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     result = sim.simulate()
     assert blk.minus1_counters == 2
@@ -107,7 +113,7 @@ def test_lifelink_infect_vs_creature():
     blk = CombatCreature("Bear", 3, 3, "B")
     atk.blocked_by.append(blk)
     blk.blocking = atk
-    state = GameState(players={"A": PlayerState(life=10, creatures=[atk]), "B": PlayerState(life=20, creatures=[blk])})
+    state = GameState(players={"A": PlayerState(life=10, creatures=[atk]), "B": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     result = sim.simulate()
     assert result.lifegain["A"] == 3
@@ -121,7 +127,7 @@ def test_infect_with_afflict_still_causes_life_loss():
     blk = CombatCreature("Guard", 2, 2, "B")
     atk.blocked_by.append(blk)
     blk.blocking = atk
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=20, creatures=[blk])})
+    state = GameState(players={"A": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[atk]), "B": PlayerState(life=STARTING_LIFE_TOTAL, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     result = sim.simulate()
     assert state.players["B"].life == 19


### PR DESCRIPTION
## Summary
- centralize starting life value as `STARTING_LIFE_TOTAL`
- use the new constant throughout simulator and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685668961ba8832a9df4939d28eac6da