### PR TITLE
Introduce DEFAULT_STARTING_LIFE constant

### DIFF
--- a/magic_combat/__init__.py
+++ b/magic_combat/__init__.py
@@ -1,6 +1,10 @@
 """Core package for the Magic Combat simulator."""
 
 from .creature import CombatCreature, Color
+
+# Default life total used when initializing ``PlayerState`` instances
+DEFAULT_STARTING_LIFE = 20
+
 from .simulator import CombatResult, CombatSimulator
 from .damage import DamageAssignmentStrategy, MostCreaturesKilledStrategy
 from .gamestate import GameState, PlayerState, has_player_lost
@@ -15,4 +19,5 @@ __all__ = [
     "GameState",
     "PlayerState",
     "has_player_lost",
+    "DEFAULT_STARTING_LIFE",
 ]

--- a/magic_combat/simulator.py
+++ b/magic_combat/simulator.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Optional
 from .creature import CombatCreature, Color
 from .damage import DamageAssignmentStrategy, MostCreaturesKilledStrategy
 from .gamestate import GameState, PlayerState, has_player_lost
+from . import DEFAULT_STARTING_LIFE
 
 @dataclass
 class CombatResult:
@@ -238,7 +239,7 @@ class CombatSimulator:
             return
         max_life = max(ps.life for ps in self.game_state.players.values())
         defender_life = self.game_state.players.get(
-            defender_player, PlayerState(life=20, creatures=[], poison=0)
+            defender_player, PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[], poison=0)
         ).life
         for atk in self.attackers:
             if atk.dethrone and defender_life >= max_life:
@@ -254,7 +255,7 @@ class CombatSimulator:
                 self.player_damage[defender] = self.player_damage.get(defender, 0) + atk.afflict
                 if self.game_state is not None:
                     ps = self.game_state.players.setdefault(
-                        defender, PlayerState(life=20, creatures=[], poison=0)
+                        defender, PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[], poison=0)
                     )
                     ps.life -= atk.afflict
 
@@ -301,7 +302,7 @@ class CombatSimulator:
                 if self.game_state is not None:
                     ps = self.game_state.players.setdefault(
                         player,
-                        PlayerState(life=20, creatures=[], poison=0),
+                        PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[], poison=0),
                     )
                     ps.poison += amount
             else:
@@ -309,7 +310,7 @@ class CombatSimulator:
                 if self.game_state is not None:
                     ps = self.game_state.players.setdefault(
                         player,
-                        PlayerState(life=20, creatures=[], poison=0),
+                        PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[], poison=0),
                     )
                     ps.life -= amount
             if source.toxic:
@@ -317,7 +318,7 @@ class CombatSimulator:
                 if self.game_state is not None:
                     ps = self.game_state.players.setdefault(
                         player,
-                        PlayerState(life=20, creatures=[], poison=0),
+                        PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[], poison=0),
                     )
                     ps.poison += source.toxic
         if source.lifelink:
@@ -431,7 +432,7 @@ class CombatSimulator:
                 diff = gain - already
                 if diff:
                     ps = self.game_state.players.setdefault(
-                        player, PlayerState(life=20, creatures=[], poison=0)
+                        player, PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[], poison=0)
                     )
                     ps.life += diff
                     self._lifegain_applied[player] = gain

--- a/tests/abilities/test_additional_keyword_abilities.py
+++ b/tests/abilities/test_additional_keyword_abilities.py
@@ -1,6 +1,13 @@
 import pytest
 
-from magic_combat import CombatCreature, CombatSimulator, GameState, PlayerState, Color
+from magic_combat import (
+    CombatCreature,
+    CombatSimulator,
+    GameState,
+    PlayerState,
+    DEFAULT_STARTING_LIFE,
+    Color,
+)
 from tests.conftest import link_block
 
 
@@ -79,7 +86,7 @@ def test_dethrone_adds_counter():
     """CR 702.103a: Dethrone grants a +1/+1 counter when attacking the player with the most life."""
     atk = CombatCreature("Challenger", 2, 2, "A", dethrone=True)
     defender = CombatCreature("Dummy", 0, 1, "B")
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=25, creatures=[defender])})
+    state = GameState(players={"A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]), "B": PlayerState(life=25, creatures=[defender])})
     sim = CombatSimulator([atk], [defender], game_state=state)
     sim.simulate()
     assert atk.plus1_counters == 1

--- a/tests/abilities/test_complex_ability_combos.py
+++ b/tests/abilities/test_complex_ability_combos.py
@@ -5,6 +5,7 @@ from magic_combat import (
     CombatSimulator,
     GameState,
     PlayerState,
+    DEFAULT_STARTING_LIFE,
     Color,
 )
 from tests.conftest import link_block
@@ -54,8 +55,8 @@ def test_double_strike_infect_toxic_lifelink():
     defender = CombatCreature("Dummy", 0, 1, "B")
     state = GameState(
         players={
-            "A": PlayerState(life=20, creatures=[attacker]),
-            "B": PlayerState(life=20, creatures=[defender]),
+            "A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[attacker]),
+            "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[defender]),
         }
     )
     sim = CombatSimulator([attacker], [defender], game_state=state)

--- a/tests/abilities/test_deathtouch.py
+++ b/tests/abilities/test_deathtouch.py
@@ -1,6 +1,12 @@
 import pytest
 
-from magic_combat import CombatCreature, CombatSimulator, GameState, PlayerState
+from magic_combat import (
+    CombatCreature,
+    CombatSimulator,
+    GameState,
+    PlayerState,
+    DEFAULT_STARTING_LIFE,
+)
 from tests.conftest import link_block
 
 
@@ -44,7 +50,7 @@ def test_deathtouch_lifelink_gain_life():
     atk = CombatCreature("Vampire", 1, 1, "A", deathtouch=True, lifelink=True)
     blk = CombatCreature("Bear", 2, 2, "B")
     link_block(atk, blk)
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=20, creatures=[blk])})
+    state = GameState(players={"A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]), "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     result = sim.simulate()
     assert blk in result.creatures_destroyed

--- a/tests/abilities/test_poison.py
+++ b/tests/abilities/test_poison.py
@@ -1,6 +1,13 @@
 import pytest
 
-from magic_combat import CombatCreature, CombatSimulator, GameState, PlayerState, has_player_lost
+from magic_combat import (
+    CombatCreature,
+    CombatSimulator,
+    GameState,
+    PlayerState,
+    DEFAULT_STARTING_LIFE,
+    has_player_lost,
+)
 from tests.conftest import link_block
 
 
@@ -20,7 +27,7 @@ def test_infect_lifelink_vs_creature():
     atk = CombatCreature("Toxic Healer", 2, 2, "A", infect=True, lifelink=True)
     blk = CombatCreature("Guard", 2, 2, "B")
     link_block(atk, blk)
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=20, creatures=[blk])})
+    state = GameState(players={"A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]), "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     result = sim.simulate()
     assert blk.minus1_counters == 2
@@ -33,7 +40,7 @@ def test_trample_infect_lifelink_poison_and_life():
     atk = CombatCreature("Plague Rhino", 3, 3, "A", infect=True, lifelink=True, trample=True)
     blk = CombatCreature("Chump", 1, 1, "B")
     link_block(atk, blk)
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=20, creatures=[blk])})
+    state = GameState(players={"A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]), "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     result = sim.simulate()
     assert blk.minus1_counters == 1
@@ -82,7 +89,7 @@ def test_infect_and_toxic_stack_poison():
     """CR 702.90b & 702.??: Infect and toxic add poison counters together."""
     atk = CombatCreature("Venomous", 2, 2, "A", infect=True, toxic=1)
     defender = CombatCreature("Dummy", 0, 1, "B")
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=20, creatures=[defender])})
+    state = GameState(players={"A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]), "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[defender])})
     sim = CombatSimulator([atk], [defender], game_state=state)
     result = sim.simulate()
     assert state.players["B"].poison == 3
@@ -104,7 +111,7 @@ def test_player_loses_at_ten_poison():
     """CR 104.3c: A player with ten or more poison counters loses the game."""
     atk = CombatCreature("Infector", 1, 1, "A", infect=True)
     defender = CombatCreature("Dummy", 0, 1, "B")
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=20, creatures=[defender], poison=9)})
+    state = GameState(players={"A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]), "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[defender], poison=9)})
     sim = CombatSimulator([atk], [defender], game_state=state)
     sim.simulate()
     assert state.players["B"].poison == 10
@@ -131,7 +138,7 @@ def test_infect_with_afflict_still_deals_life_loss():
     atk = CombatCreature("Torturer", 2, 2, "A", infect=True, afflict=2)
     blk = CombatCreature("Guard", 2, 2, "B")
     link_block(atk, blk)
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=20, creatures=[blk])})
+    state = GameState(players={"A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]), "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     result = sim.simulate()
     assert result.damage_to_players["B"] == 2
@@ -153,7 +160,7 @@ def test_infect_unblocked_lifelink_gains_life():
     """CR 702.15a & 702.90b: Lifelink triggers even when infect damage becomes poison counters."""
     atk = CombatCreature("Healer", 2, 2, "A", infect=True, lifelink=True)
     defender = CombatCreature("Dummy", 0, 1, "B")
-    state = GameState(players={"A": PlayerState(life=10, creatures=[atk]), "B": PlayerState(life=20, creatures=[defender])})
+    state = GameState(players={"A": PlayerState(life=10, creatures=[atk]), "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[defender])})
     sim = CombatSimulator([atk], [defender], game_state=state)
     result = sim.simulate()
     assert result.poison_counters["B"] == 2

--- a/tests/combat/test_combat_buffs.py
+++ b/tests/combat/test_combat_buffs.py
@@ -1,5 +1,11 @@
 import pytest
-from magic_combat import CombatCreature, CombatSimulator, GameState, PlayerState
+from magic_combat import (
+    CombatCreature,
+    CombatSimulator,
+    GameState,
+    PlayerState,
+    DEFAULT_STARTING_LIFE,
+)
 from tests.conftest import link_block
 
 
@@ -176,7 +182,7 @@ def test_dethrone_when_opponent_highest_life():
     """CR 702.103a: Dethrone gives a +1/+1 counter if the defending player has the most life."""
     atk = CombatCreature("Challenger", 2, 2, "A", dethrone=True)
     defender = CombatCreature("Dummy", 0, 1, "B")
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=25, creatures=[defender])})
+    state = GameState(players={"A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]), "B": PlayerState(life=25, creatures=[defender])})
     sim = CombatSimulator([atk], [defender], game_state=state)
     sim.simulate()
     assert atk.plus1_counters == 1
@@ -186,7 +192,7 @@ def test_dethrone_no_counter_when_not_highest():
     """CR 702.103a: No dethrone counter if defender doesn't have the most life."""
     atk = CombatCreature("Challenger", 2, 2, "A", dethrone=True)
     defender = CombatCreature("Dummy", 0, 1, "B")
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=15, creatures=[defender])})
+    state = GameState(players={"A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]), "B": PlayerState(life=15, creatures=[defender])})
     sim = CombatSimulator([atk], [defender], game_state=state)
     sim.simulate()
     assert atk.plus1_counters == 0

--- a/tests/combat/test_game_loss_scenarios.py
+++ b/tests/combat/test_game_loss_scenarios.py
@@ -1,5 +1,12 @@
 import pytest
-from magic_combat import CombatCreature, CombatSimulator, GameState, PlayerState, has_player_lost
+from magic_combat import (
+    CombatCreature,
+    CombatSimulator,
+    GameState,
+    PlayerState,
+    DEFAULT_STARTING_LIFE,
+    has_player_lost,
+)
 from tests.conftest import link_block
 
 
@@ -9,7 +16,7 @@ def test_afflict_lethal_when_blocked():
     atk = CombatCreature("Tormentor", 2, 2, "A", afflict=2)
     blk = CombatCreature("Guard", 2, 2, "B")
     link_block(atk, blk)
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=2, creatures=[blk])})
+    state = GameState(players={"A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]), "B": PlayerState(life=2, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     sim.simulate()
     assert state.players["B"].life == 0
@@ -22,7 +29,7 @@ def test_afflict_and_trample_combined_lethal():
     atk = CombatCreature("Rager", 2, 2, "A", afflict=2, trample=True)
     blk = CombatCreature("Chump", 1, 1, "B")
     link_block(atk, blk)
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=3, creatures=[blk])})
+    state = GameState(players={"A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]), "B": PlayerState(life=3, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     sim.simulate()
     assert state.players["B"].life == 0
@@ -34,7 +41,7 @@ def test_toxic_three_poison_counters_causes_loss():
     """CR 702.??? & 104.3c: Toxic gives that many poison counters; a player with ten or more poison counters loses."""
     atk = CombatCreature("Stinger", 1, 1, "A", toxic=3)
     defender = CombatCreature("Dummy", 0, 1, "B")
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=20, creatures=[defender], poison=8)})
+    state = GameState(players={"A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]), "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[defender], poison=8)})
     sim = CombatSimulator([atk], [defender], game_state=state)
     sim.simulate()
     assert state.players["B"].poison == 11
@@ -46,7 +53,7 @@ def test_infect_and_toxic_exactly_ten_poison():
     """CR 702.90b & 104.3c: Infect and toxic together can give enough poison counters for a player to lose."""
     atk = CombatCreature("Toxic Infector", 2, 2, "A", infect=True, toxic=2)
     defender = CombatCreature("Dummy", 0, 1, "B")
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=20, creatures=[defender], poison=6)})
+    state = GameState(players={"A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]), "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[defender], poison=6)})
     sim = CombatSimulator([atk], [defender], game_state=state)
     sim.simulate()
     assert state.players["B"].poison == 10
@@ -58,7 +65,7 @@ def test_double_strike_infect_first_step_loss():
     """CR 702.4b, 702.90b & 104.3c: Double strike with infect can cause a player to lose after the first combat damage step."""
     atk = CombatCreature("Toxic Duelist", 1, 1, "A", infect=True, double_strike=True)
     defender = CombatCreature("Dummy", 0, 1, "B")
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=20, creatures=[defender], poison=9)})
+    state = GameState(players={"A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]), "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[defender], poison=9)})
     sim = CombatSimulator([atk], [defender], game_state=state)
     sim.simulate()
     assert state.players["B"].poison == 11
@@ -71,7 +78,7 @@ def test_double_strike_trample_overkill():
     atk = CombatCreature("Crusher", 3, 3, "A", double_strike=True, trample=True)
     blk = CombatCreature("Blocker", 1, 1, "B")
     link_block(atk, blk)
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=3, creatures=[blk])})
+    state = GameState(players={"A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]), "B": PlayerState(life=3, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     sim.simulate()
     assert state.players["B"].life == -2
@@ -84,7 +91,7 @@ def test_first_strike_blocker_barely_survives():
     atk = CombatCreature("Brute", 2, 2, "A")
     blk = CombatCreature("Savior", 2, 2, "B", first_strike=True)
     link_block(atk, blk)
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=1, creatures=[blk])})
+    state = GameState(players={"A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]), "B": PlayerState(life=1, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     sim.simulate()
     assert state.players["B"].life == 1
@@ -110,7 +117,7 @@ def test_lifelink_cannot_prevent_poison_loss():
     """CR 702.15a, 702.90b & 104.3c: Lifelink doesn't stop a player from losing to poison counters inflicted by infect."""
     atk = CombatCreature("Toxic Vampire", 1, 1, "A", infect=True, lifelink=True)
     defender = CombatCreature("Dummy", 0, 1, "B")
-    state = GameState(players={"A": PlayerState(life=5, creatures=[atk]), "B": PlayerState(life=20, creatures=[defender], poison=9)})
+    state = GameState(players={"A": PlayerState(life=5, creatures=[atk]), "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[defender], poison=9)})
     sim = CombatSimulator([atk], [defender], game_state=state)
     sim.simulate()
     assert state.players["A"].life == 6
@@ -124,7 +131,7 @@ def test_afflict_lethal_before_lifelink_can_save():
     atk = CombatCreature("Menace", 2, 2, "A", afflict=1)
     blk = CombatCreature("Healer", 2, 2, "B", lifelink=True)
     link_block(atk, blk)
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=1, creatures=[blk])})
+    state = GameState(players={"A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]), "B": PlayerState(life=1, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     sim.simulate()
     assert state.players["B"].life == 2

--- a/tests/combat/test_gamestate.py
+++ b/tests/combat/test_gamestate.py
@@ -4,6 +4,7 @@ from magic_combat import (
     CombatSimulator,
     GameState,
     PlayerState,
+    DEFAULT_STARTING_LIFE,
     has_player_lost,
 )
 from tests.conftest import link_block
@@ -15,7 +16,7 @@ def test_player_loses_when_life_zero():
     defender = CombatCreature("Dummy", 0, 1, "B")
     state = GameState(
         players={
-            "A": PlayerState(life=20, creatures=[atk]),
+            "A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]),
             "B": PlayerState(life=2, creatures=[defender]),
         }
     )
@@ -32,8 +33,8 @@ def test_player_loses_from_poison():
     defender = CombatCreature("Dummy", 0, 1, "B")
     state = GameState(
         players={
-            "A": PlayerState(life=20, creatures=[atk]),
-            "B": PlayerState(life=20, creatures=[defender], poison=9),
+            "A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]),
+            "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[defender], poison=9),
         }
     )
     sim = CombatSimulator([atk], [defender], game_state=state)
@@ -50,8 +51,8 @@ def test_trample_infect_assigns_excess_poison():
     link_block(atk, blk)
     state = GameState(
         players={
-            "A": PlayerState(life=20, creatures=[atk]),
-            "B": PlayerState(life=20, creatures=[blk]),
+            "A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]),
+            "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[blk]),
         }
     )
     sim = CombatSimulator([atk], [blk], game_state=state)
@@ -69,7 +70,7 @@ def test_infect_with_lifelink_grants_life():
     state = GameState(
         players={
             "A": PlayerState(life=10, creatures=[atk]),
-            "B": PlayerState(life=20, creatures=[defender]),
+            "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[defender]),
         }
     )
     sim = CombatSimulator([atk], [defender], game_state=state)
@@ -87,8 +88,8 @@ def test_wither_and_lifelink_vs_creature():
     link_block(atk, blk)
     state = GameState(
         players={
-            "A": PlayerState(life=20, creatures=[atk]),
-            "B": PlayerState(life=20, creatures=[blk]),
+            "A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]),
+            "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[blk]),
         }
     )
     sim = CombatSimulator([atk], [blk], game_state=state)
@@ -106,8 +107,8 @@ def test_deathtouch_trample_hits_player():
     link_block(atk, blk)
     state = GameState(
         players={
-            "A": PlayerState(life=20, creatures=[atk]),
-            "B": PlayerState(life=20, creatures=[blk]),
+            "A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]),
+            "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[blk]),
         }
     )
     sim = CombatSimulator([atk], [blk], game_state=state)
@@ -125,7 +126,7 @@ def test_double_strike_lifelink_twice():
     state = GameState(
         players={
             "A": PlayerState(life=10, creatures=[atk]),
-            "B": PlayerState(life=20, creatures=[defender]),
+            "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[defender]),
         }
     )
     sim = CombatSimulator([atk], [defender], game_state=state)
@@ -141,8 +142,8 @@ def test_double_strike_infect_can_cause_loss():
     defender = CombatCreature("Dummy", 0, 1, "B")
     state = GameState(
         players={
-            "A": PlayerState(life=20, creatures=[atk]),
-            "B": PlayerState(life=20, creatures=[defender], poison=8),
+            "A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]),
+            "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[defender], poison=8),
         }
     )
     sim = CombatSimulator([atk], [defender], game_state=state)

--- a/tests/combat/test_life_poison.py
+++ b/tests/combat/test_life_poison.py
@@ -1,5 +1,12 @@
 import pytest
-from magic_combat import CombatCreature, CombatSimulator, GameState, PlayerState, has_player_lost
+from magic_combat import (
+    CombatCreature,
+    CombatSimulator,
+    GameState,
+    PlayerState,
+    DEFAULT_STARTING_LIFE,
+    has_player_lost,
+)
 from tests.conftest import link_block
 
 
@@ -9,8 +16,8 @@ def test_infect_lifelink_poison_lethal():
     defender = CombatCreature("Dummy", 0, 1, "B")
     state = GameState(
         players={
-            "A": PlayerState(life=20, creatures=[atk]),
-            "B": PlayerState(life=20, creatures=[defender], poison=8),
+            "A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]),
+            "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[defender], poison=8),
         }
     )
     sim = CombatSimulator([atk], [defender], game_state=state)
@@ -28,7 +35,7 @@ def test_double_strike_lifelink_player_lethal():
     defender = CombatCreature("Dummy", 0, 1, "B")
     state = GameState(
         players={
-            "A": PlayerState(life=20, creatures=[atk]),
+            "A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]),
             "B": PlayerState(life=3, creatures=[defender]),
         }
     )
@@ -46,8 +53,8 @@ def test_infect_double_strike_lifelink_poison_lethal():
     defender = CombatCreature("Dummy", 0, 1, "B")
     state = GameState(
         players={
-            "A": PlayerState(life=20, creatures=[atk]),
-            "B": PlayerState(life=20, creatures=[defender], poison=9),
+            "A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]),
+            "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[defender], poison=9),
         }
     )
     sim = CombatSimulator([atk], [defender], game_state=state)
@@ -77,7 +84,7 @@ def test_trample_deathtouch_lifelink_lethal():
     link_block(atk, blk)
     state = GameState(
         players={
-            "A": PlayerState(life=20, creatures=[atk]),
+            "A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]),
             "B": PlayerState(life=2, creatures=[blk]),
         }
     )

--- a/tests/core/test_playerstate_validation.py
+++ b/tests/core/test_playerstate_validation.py
@@ -1,6 +1,6 @@
 import pytest
 
-from magic_combat import PlayerState
+from magic_combat import PlayerState, DEFAULT_STARTING_LIFE
 
 
 def test_negative_life_init():
@@ -12,4 +12,4 @@ def test_negative_life_init():
 def test_negative_poison_init():
     """CR 107.1: Numbers like poison counters can't be negative."""
     with pytest.raises(ValueError):
-        PlayerState(life=20, creatures=[], poison=-1)
+        PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[], poison=-1)

--- a/tests/poison/test_poison_extra.py
+++ b/tests/poison/test_poison_extra.py
@@ -1,5 +1,11 @@
 import pytest
-from magic_combat import CombatCreature, CombatSimulator, GameState, PlayerState
+from magic_combat import (
+    CombatCreature,
+    CombatSimulator,
+    GameState,
+    PlayerState,
+    DEFAULT_STARTING_LIFE,
+)
 from tests.conftest import link_block
 
 
@@ -19,7 +25,7 @@ def test_infect_lifelink_vs_blocker():
     atk = CombatCreature("Toxic Cleric", 2, 2, "A", infect=True, lifelink=True)
     blk = CombatCreature("Bear", 2, 2, "B")
     link_block(atk, blk)
-    state = GameState(players={"A": PlayerState(life=10, creatures=[atk]), "B": PlayerState(life=20, creatures=[blk])})
+    state = GameState(players={"A": PlayerState(life=10, creatures=[atk]), "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     result = sim.simulate()
     assert blk.minus1_counters == 2
@@ -100,7 +106,7 @@ def test_lifelink_infect_vs_creature():
     atk = CombatCreature("Toxic Healer", 3, 3, "A", infect=True, lifelink=True)
     blk = CombatCreature("Bear", 3, 3, "B")
     link_block(atk, blk)
-    state = GameState(players={"A": PlayerState(life=10, creatures=[atk]), "B": PlayerState(life=20, creatures=[blk])})
+    state = GameState(players={"A": PlayerState(life=10, creatures=[atk]), "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     result = sim.simulate()
     assert result.lifegain["A"] == 3
@@ -113,7 +119,7 @@ def test_infect_with_afflict_still_causes_life_loss():
     atk = CombatCreature("Tormentor", 2, 2, "A", infect=True, afflict=1)
     blk = CombatCreature("Guard", 2, 2, "B")
     link_block(atk, blk)
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=20, creatures=[blk])})
+    state = GameState(players={"A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]), "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     result = sim.simulate()
     assert state.players["B"].life == 19

--- a/tests/test_counters.py
+++ b/tests/test_counters.py
@@ -5,6 +5,7 @@ from magic_combat import (
     CombatSimulator,
     GameState,
     PlayerState,
+    DEFAULT_STARTING_LIFE,
 )
 from tests.conftest import link_block
 
@@ -46,7 +47,7 @@ def test_dethrone_counter_annihilates_existing_minus1():
     attacker = CombatCreature("Challenger", 2, 2, "A", dethrone=True)
     attacker.minus1_counters = 1
     defender = CombatCreature("Dummy", 0, 1, "B")
-    state = GameState(players={"A": PlayerState(life=20, creatures=[attacker]), "B": PlayerState(life=25, creatures=[defender])})
+    state = GameState(players={"A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[attacker]), "B": PlayerState(life=25, creatures=[defender])})
     sim = CombatSimulator([attacker], [defender], game_state=state)
     sim.simulate()
     assert attacker.plus1_counters == 0

--- a/tests/test_indestructible.py
+++ b/tests/test_indestructible.py
@@ -1,4 +1,10 @@
-from magic_combat import CombatCreature, CombatSimulator, GameState, PlayerState
+from magic_combat import (
+    CombatCreature,
+    CombatSimulator,
+    GameState,
+    PlayerState,
+    DEFAULT_STARTING_LIFE,
+)
 from tests.conftest import link_block
 
 
@@ -86,7 +92,7 @@ def test_indestructible_lifelink_gains_life():
     attacker = CombatCreature("Angel", 2, 2, "A", indestructible=True, lifelink=True)
     blocker = CombatCreature("Bear", 2, 2, "B")
     link_block(attacker, blocker)
-    state = GameState(players={"A": PlayerState(life=10, creatures=[attacker]), "B": PlayerState(life=20, creatures=[blocker])})
+    state = GameState(players={"A": PlayerState(life=10, creatures=[attacker]), "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[blocker])})
     sim = CombatSimulator([attacker], [blocker], game_state=state)
     result = sim.simulate()
     assert result.lifegain["A"] == 2

--- a/tests/test_poison_suite.py
+++ b/tests/test_poison_suite.py
@@ -1,5 +1,11 @@
 import pytest
-from magic_combat import CombatCreature, CombatSimulator, GameState, PlayerState
+from magic_combat import (
+    CombatCreature,
+    CombatSimulator,
+    GameState,
+    PlayerState,
+    DEFAULT_STARTING_LIFE,
+)
 from tests.conftest import link_block
 
 
@@ -19,7 +25,7 @@ def test_infect_lifelink_vs_blocker():
     atk = CombatCreature("Toxic Cleric", 2, 2, "A", infect=True, lifelink=True)
     blk = CombatCreature("Bear", 2, 2, "B")
     link_block(atk, blk)
-    state = GameState(players={"A": PlayerState(life=10, creatures=[atk]), "B": PlayerState(life=20, creatures=[blk])})
+    state = GameState(players={"A": PlayerState(life=10, creatures=[atk]), "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     result = sim.simulate()
     assert blk.minus1_counters == 2
@@ -100,7 +106,7 @@ def test_lifelink_infect_vs_creature():
     atk = CombatCreature("Toxic Healer", 3, 3, "A", infect=True, lifelink=True)
     blk = CombatCreature("Bear", 3, 3, "B")
     link_block(atk, blk)
-    state = GameState(players={"A": PlayerState(life=10, creatures=[atk]), "B": PlayerState(life=20, creatures=[blk])})
+    state = GameState(players={"A": PlayerState(life=10, creatures=[atk]), "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     result = sim.simulate()
     assert result.lifegain["A"] == 3
@@ -113,7 +119,7 @@ def test_infect_with_afflict_still_causes_life_loss():
     atk = CombatCreature("Tormentor", 2, 2, "A", infect=True, afflict=1)
     blk = CombatCreature("Guard", 2, 2, "B")
     link_block(atk, blk)
-    state = GameState(players={"A": PlayerState(life=20, creatures=[atk]), "B": PlayerState(life=20, creatures=[blk])})
+    state = GameState(players={"A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]), "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[blk])})
     sim = CombatSimulator([atk], [blk], game_state=state)
     result = sim.simulate()
     assert state.players["B"].life == 19


### PR DESCRIPTION
## Summary
- define `DEFAULT_STARTING_LIFE` in `magic_combat.__init__`
- use the constant when creating `PlayerState` objects
- update tests to import and reference the new constant

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68566a46d00c832aae6ecf9a4f315c78