### PR TITLE
Add scryfall card fetch utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 .pytest_cache/
 .coverage
+data/cards.json

--- a/README.md
+++ b/README.md
@@ -48,3 +48,18 @@ sim = CombatSimulator([attacker], [blocker])
 result = sim.simulate()
 print(result.creatures_destroyed)
 ```
+
+## Downloading sample card data
+
+The :func:`fetch_french_vanilla_cards` utility searches Scryfall for
+"French vanilla" creatures. These are creature cards whose rules text
+contains only keyword abilities recognized by ``CombatCreature``. The
+resulting data can be stored locally using :func:`save_cards` and later
+loaded with :func:`load_cards`.
+
+```python
+from magic_combat import fetch_french_vanilla_cards, save_cards
+
+cards = fetch_french_vanilla_cards()
+save_cards(cards, "data/cards.json")
+```

--- a/magic_combat/__init__.py
+++ b/magic_combat/__init__.py
@@ -9,6 +9,7 @@ from .simulator import CombatResult, CombatSimulator
 from .damage import DamageAssignmentStrategy, MostCreaturesKilledStrategy
 from .blocking_ai import decide_optimal_blocks
 from .gamestate import GameState, PlayerState, has_player_lost
+from .scryfall_loader import fetch_french_vanilla_cards, load_cards, save_cards
 
 __all__ = [
     "CombatCreature",
@@ -22,4 +23,7 @@ __all__ = [
     "PlayerState",
     "has_player_lost",
     "DEFAULT_STARTING_LIFE",
+    "fetch_french_vanilla_cards",
+    "load_cards",
+    "save_cards",
 ]

--- a/magic_combat/scryfall_loader.py
+++ b/magic_combat/scryfall_loader.py
@@ -1,0 +1,90 @@
+import json
+from typing import List, Dict, Any
+
+import requests
+
+SCRYFALL_API = "https://api.scryfall.com/cards/search"
+QUERY = "is:frenchvanilla t:creature"
+
+# Keyword abilities supported by :class:`~magic_combat.creature.CombatCreature`.
+ALLOWED_KEYWORDS = {
+    "Flying",
+    "Reach",
+    "Menace",
+    "Fear",
+    "Shadow",
+    "Horsemanship",
+    "Skulk",
+    "Vigilance",
+    "First strike",
+    "Double strike",
+    "Deathtouch",
+    "Trample",
+    "Lifelink",
+    "Wither",
+    "Infect",
+    "Toxic",
+    "Indestructible",
+    "Bushido",
+    "Flanking",
+    "Rampage",
+    "Exalted",
+    "Battle cry",
+    "Melee",
+    "Training",
+    "Frenzy",
+    "Battalion",
+    "Dethrone",
+    "Undying",
+    "Persist",
+    "Intimidate",
+    "Defender",
+    "Afflict",
+    "Provoke",
+}
+
+
+def fetch_french_vanilla_cards() -> List[Dict[str, Any]]:
+    """Return a list of creature cards with only keyword abilities.
+
+    Uses the Scryfall API's ``is:frenchvanilla`` query to find cards whose
+    rules text contains only keyword abilities and no additional abilities.
+    """
+    url = SCRYFALL_API
+    params = {"q": QUERY}
+    cards: List[Dict[str, Any]] = []
+    while url:
+        resp = requests.get(url, params=params)
+        resp.raise_for_status()
+        data = resp.json()
+        for c in data.get("data", []):
+            if c.get("object") != "card":
+                continue
+            keywords = c.get("keywords", [])
+            if not all(k in ALLOWED_KEYWORDS for k in keywords):
+                continue
+            cards.append(
+                {
+                    "name": c["name"],
+                    "mana_cost": c.get("mana_cost"),
+                    "power": c.get("power"),
+                    "toughness": c.get("toughness"),
+                    "oracle_text": c.get("oracle_text"),
+                    "keywords": keywords,
+                }
+            )
+        url = data.get("next_page")
+        params = None
+    return cards
+
+
+def save_cards(cards: List[Dict[str, Any]], path: str) -> None:
+    """Save ``cards`` to ``path`` as JSON."""
+    with open(path, "w", encoding="utf8") as fh:
+        json.dump(cards, fh, indent=2, ensure_ascii=False)
+
+
+def load_cards(path: str) -> List[Dict[str, Any]]:
+    """Load card data from ``path``."""
+    with open(path, "r", encoding="utf8") as fh:
+        return json.load(fh)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pytest>=7.0
+requests


### PR DESCRIPTION
## Summary
- create `scryfall_loader` module for downloading "French vanilla" creature cards from Scryfall
- expose loader/saver helpers
- update README with example usage
- ignore downloaded card data
- require `requests` in requirements
- filter Scryfall cards so only keyword abilities supported by `CombatCreature` are included

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6857409c3524832aa34b5aff2fb713ce