### PR TITLE
Add command-line script for downloading card data

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,10 @@ from magic_combat import fetch_french_vanilla_cards, save_cards
 cards = fetch_french_vanilla_cards()
 save_cards(cards, "data/cards.json")
 ```
+
+For convenience you can also run ``fetch_cards.py`` from the repository
+root to download the card data directly:
+
+```bash
+python fetch_cards.py data/cards.json
+```

--- a/fetch_cards.py
+++ b/fetch_cards.py
@@ -1,0 +1,21 @@
+"""Convenience script to download card data from Scryfall."""
+
+import argparse
+from magic_combat import fetch_french_vanilla_cards, save_cards
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Download 'French vanilla' creatures from Scryfall and save as JSON"
+    )
+    parser.add_argument(
+        "output", nargs="?", default="cards.json", help="Path to output JSON file"
+    )
+    args = parser.parse_args()
+
+    cards = fetch_french_vanilla_cards()
+    save_cards(cards, args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `fetch_cards.py` script to run the Scryfall search and save the results
- document script usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68574641d250832a8a4fd86c20893f97