### PR TITLE
Add Scryfall download script

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,11 @@ from magic_combat import fetch_french_vanilla_cards, save_cards
 cards = fetch_french_vanilla_cards()
 save_cards(cards, "data/cards.json")
 ```
+
+Alternatively you can run the ``download_cards.py`` script from this
+repository to fetch the data from the command line::
+
+    python download_cards.py data/cards.json
+
+This will query Scryfall for the supported French vanilla creatures and
+store them in the specified JSON file.

--- a/download_cards.py
+++ b/download_cards.py
@@ -1,0 +1,22 @@
+import argparse
+
+from magic_combat.scryfall_loader import fetch_french_vanilla_cards, save_cards
+
+
+def main() -> None:
+    """Download French vanilla creature data and save it to JSON."""
+    parser = argparse.ArgumentParser(
+        description="Fetch French vanilla creatures from Scryfall and save to JSON"
+    )
+    parser.add_argument(
+        "output",
+        help="Path to output JSON file where card data will be written",
+    )
+    args = parser.parse_args()
+
+    cards = fetch_french_vanilla_cards()
+    save_cards(cards, args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `download_cards.py` script to fetch French vanilla creatures
- document how to use the script in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68574641d250832a8a4fd86c20893f97