### PR TITLE
Add Scryfall download script

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,10 @@ from magic_combat import fetch_french_vanilla_cards, save_cards
 cards = fetch_french_vanilla_cards()
 save_cards(cards, "data/cards.json")
 ```
+
+Alternatively, a small helper script ``scripts/download_cards.py`` can be run
+from the repository root to perform the download:
+
+```bash
+python scripts/download_cards.py data/cards.json
+```

--- a/scripts/download_cards.py
+++ b/scripts/download_cards.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+"""Fetch sample creature data from Scryfall and save it as JSON.
+
+This script downloads all "French vanilla" creature cards recognized by
+:func:`magic_combat.scryfall_loader.fetch_french_vanilla_cards` and writes the
+result to a JSON file. The output path can be specified as an argument, and the
+parent directory will be created if it does not already exist.
+"""
+
+import argparse
+import os
+
+from magic_combat import fetch_french_vanilla_cards, save_cards
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Download French vanilla creature data from Scryfall"
+    )
+    parser.add_argument(
+        "output",
+        nargs="?",
+        default="data/cards.json",
+        help="Location of the JSON file to write",
+    )
+    args = parser.parse_args()
+
+    cards = fetch_french_vanilla_cards()
+    os.makedirs(os.path.dirname(args.output) or ".", exist_ok=True)
+    save_cards(cards, args.output)
+    print(f"Saved {len(cards)} cards to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/download_cards.py
+++ b/scripts/download_cards.py
@@ -9,6 +9,10 @@ parent directory will be created if it does not already exist.
 
 import argparse
 import os
+import sys
+
+# Allow running this script without installing the package
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from magic_combat import fetch_french_vanilla_cards, save_cards
 


### PR DESCRIPTION
## Summary
- add a helper script to download French vanilla creature data
- document script usage in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68574641d250832a8a4fd86c20893f97