### PR TITLE
Add random combat scenario helper

### DIFF
--- a/magic_combat/__init__.py
+++ b/magic_combat/__init__.py
@@ -11,6 +11,7 @@ from .blocking_ai import decide_optimal_blocks
 from .utils import calculate_mana_value
 from .gamestate import GameState, PlayerState, has_player_lost
 from .scryfall_loader import fetch_french_vanilla_cards, load_cards, save_cards
+from .random_setup import load_or_fetch_cards, card_to_creature, create_random_combat
 
 __all__ = [
     "CombatCreature",
@@ -28,4 +29,7 @@ __all__ = [
     "fetch_french_vanilla_cards",
     "load_cards",
     "save_cards",
+    "load_or_fetch_cards",
+    "card_to_creature",
+    "create_random_combat",
 ]

--- a/magic_combat/random_setup.py
+++ b/magic_combat/random_setup.py
@@ -1,0 +1,132 @@
+import os
+import random
+from typing import List, Dict, Any, Tuple
+
+from .creature import CombatCreature
+from .gamestate import GameState, PlayerState
+from .scryfall_loader import fetch_french_vanilla_cards, load_cards, save_cards
+from . import DEFAULT_STARTING_LIFE
+
+__all__ = ["load_or_fetch_cards", "card_to_creature", "create_random_combat"]
+
+
+def load_or_fetch_cards(path: str) -> List[Dict[str, Any]]:
+    """Load card data from ``path`` or download it if missing."""
+    if os.path.exists(path):
+        return load_cards(path)
+
+    cards = fetch_french_vanilla_cards()
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    save_cards(cards, path)
+    return cards
+
+
+# Mapping from Scryfall keyword strings to :class:`CombatCreature` attributes
+_SIMPLE_KEYWORDS = {
+    "Flying": "flying",
+    "Reach": "reach",
+    "Menace": "menace",
+    "Fear": "fear",
+    "Shadow": "shadow",
+    "Horsemanship": "horsemanship",
+    "Skulk": "skulk",
+    "Vigilance": "vigilance",
+    "First strike": "first_strike",
+    "Double strike": "double_strike",
+    "Deathtouch": "deathtouch",
+    "Trample": "trample",
+    "Lifelink": "lifelink",
+    "Wither": "wither",
+    "Infect": "infect",
+    "Indestructible": "indestructible",
+    "Melee": "melee",
+    "Training": "training",
+    "Battalion": "battalion",
+    "Dethrone": "dethrone",
+    "Undying": "undying",
+    "Persist": "persist",
+    "Intimidate": "intimidate",
+    "Defender": "defender",
+}
+
+_NUMERIC_KEYWORDS = {
+    "Toxic": "toxic",
+    "Bushido": "bushido",
+    "Flanking": "flanking",
+    "Rampage": "rampage",
+    "Exalted": "exalted_count",
+    "Battle cry": "battle_cry_count",
+    "Frenzy": "frenzy",
+    "Afflict": "afflict",
+}
+
+
+def _parse_numeric(keyword: str, card: Dict[str, Any]) -> int:
+    """Return numeric value for ``keyword`` using the card's oracle text."""
+    text = card.get("oracle_text", "")
+    for line in text.splitlines():
+        if line.startswith(f"{keyword} "):
+            try:
+                return int(line.split()[1])
+            except (IndexError, ValueError):
+                return 1
+    return 1
+
+
+def card_to_creature(card: Dict[str, Any], controller: str) -> CombatCreature:
+    """Convert a Scryfall card dictionary to a :class:`CombatCreature`."""
+    try:
+        power = int(card.get("power", 0))
+    except (TypeError, ValueError):
+        power = 0
+    try:
+        toughness = int(card.get("toughness", 1))
+    except (TypeError, ValueError):
+        toughness = 1
+
+    kwargs: Dict[str, Any] = {}
+    for kw in card.get("keywords", []):
+        if kw in _SIMPLE_KEYWORDS:
+            kwargs[_SIMPLE_KEYWORDS[kw]] = True
+        elif kw in _NUMERIC_KEYWORDS:
+            kwargs[_NUMERIC_KEYWORDS[kw]] = _parse_numeric(kw, card)
+        elif kw == "Provoke":
+            kwargs["provoke_target"] = None
+
+    return CombatCreature(
+        name=card.get("name", "Unknown"),
+        power=power,
+        toughness=toughness,
+        controller=controller,
+        mana_cost=card.get("mana_cost", ""),
+        **kwargs,
+    )
+
+
+def create_random_combat(
+    num_attackers: int,
+    num_blockers: int,
+    card_path: str,
+) -> Tuple[List[CombatCreature], List[CombatCreature], GameState]:
+    """Generate a random combat scenario.
+
+    The returned tuple contains the attackers, blockers and a ``GameState`` with
+    both players starting at :data:`DEFAULT_STARTING_LIFE`.
+    """
+    cards = load_or_fetch_cards(card_path)
+    if len(cards) < num_attackers + num_blockers:
+        raise ValueError("Not enough cards to create scenario")
+
+    atk_cards = random.sample(cards, num_attackers)
+    blk_cards = random.sample(cards, num_blockers)
+
+    attackers = [card_to_creature(c, "A") for c in atk_cards]
+    blockers = [card_to_creature(c, "B") for c in blk_cards]
+
+    state = GameState(
+        players={
+            "A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=attackers),
+            "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=blockers),
+        }
+    )
+    return attackers, blockers, state

--- a/tests/core/test_random_setup.py
+++ b/tests/core/test_random_setup.py
@@ -1,0 +1,19 @@
+import json
+from magic_combat import create_random_combat, DEFAULT_STARTING_LIFE
+
+
+def test_create_random_combat_initial_life(tmp_path):
+    """CR 103.1a: Each player begins the game with 20 life."""
+    sample = [
+        {"name": "Alpha", "mana_cost": "{1}", "power": "1", "toughness": "1", "oracle_text": "", "keywords": []},
+        {"name": "Bravo", "mana_cost": "{2}", "power": "2", "toughness": "2", "oracle_text": "Flying", "keywords": ["Flying"]},
+        {"name": "Charlie", "mana_cost": "{3}", "power": "3", "toughness": "3", "oracle_text": "First strike", "keywords": ["First strike"]},
+    ]
+    path = tmp_path / "cards.json"
+    path.write_text(json.dumps(sample))
+
+    atk, blk, state = create_random_combat(2, 1, card_path=str(path))
+    assert len(atk) == 2
+    assert len(blk) == 1
+    assert state.players["A"].life == DEFAULT_STARTING_LIFE
+    assert state.players["B"].life == DEFAULT_STARTING_LIFE


### PR DESCRIPTION
## Summary
- create `random_setup` module to generate random combat scenarios
- expose helper functions in `__init__`
- test creating a random scenario starting players at 20 life

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685749e49e00832aaef2e0154441eced