### PR TITLE
Add Scryfall card conversion helpers

### DIFF
--- a/magic_combat/__init__.py
+++ b/magic_combat/__init__.py
@@ -10,7 +10,13 @@ from .damage import DamageAssignmentStrategy, MostCreaturesKilledStrategy
 from .blocking_ai import decide_optimal_blocks
 from .utils import calculate_mana_value
 from .gamestate import GameState, PlayerState, has_player_lost
-from .scryfall_loader import fetch_french_vanilla_cards, load_cards, save_cards
+from .scryfall_loader import (
+    fetch_french_vanilla_cards,
+    load_cards,
+    save_cards,
+    card_to_creature,
+    cards_to_creatures,
+)
 
 __all__ = [
     "CombatCreature",
@@ -28,4 +34,6 @@ __all__ = [
     "fetch_french_vanilla_cards",
     "load_cards",
     "save_cards",
+    "card_to_creature",
+    "cards_to_creatures",
 ]

--- a/magic_combat/creature.py
+++ b/magic_combat/creature.py
@@ -66,7 +66,7 @@ class CombatCreature:
     intimidate: bool = False
     defender: bool = False
     afflict: int = 0
-    provoke_target: Optional["CombatCreature"] = field(default=None, repr=False)
+    provoke: bool = False
 
     # --- Special Protections ---
     protection_colors: Set[Color] = field(default_factory=set)
@@ -85,6 +85,9 @@ class CombatCreature:
     # --- Temporary stat modifiers (until end of turn) ---
     temp_power: int = field(default=0, repr=False)
     temp_toughness: int = field(default=0, repr=False)
+
+    # Allow use as dictionary keys by object identity
+    __hash__ = object.__hash__
 
     def __post_init__(self) -> None:
         check_non_negative(self.power, "power")

--- a/magic_combat/scryfall_loader.py
+++ b/magic_combat/scryfall_loader.py
@@ -1,5 +1,10 @@
 import json
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Iterable
+
+import re
+
+from .creature import CombatCreature, Color
+
 
 import requests
 
@@ -88,3 +93,158 @@ def load_cards(path: str) -> List[Dict[str, Any]]:
     """Load card data from ``path``."""
     with open(path, "r", encoding="utf8") as fh:
         return json.load(fh)
+
+
+_COLOR_MAP = {
+    "W": Color.WHITE,
+    "U": Color.BLUE,
+    "B": Color.BLACK,
+    "R": Color.RED,
+    "G": Color.GREEN,
+}
+
+_COLOR_NAME_MAP = {
+    "white": Color.WHITE,
+    "blue": Color.BLUE,
+    "black": Color.BLACK,
+    "red": Color.RED,
+    "green": Color.GREEN,
+}
+
+
+def _parse_colors(mana_cost: str) -> set[Color]:
+    """Extract the set of colors appearing in ``mana_cost``."""
+    colors: set[Color] = set()
+    if not mana_cost:
+        return colors
+    for symbol in re.findall(r"{([^{}]+)}", mana_cost):
+        for part in symbol.split("/"):
+            col = _COLOR_MAP.get(part)
+            if col:
+                colors.add(col)
+    return colors
+
+
+def _parse_value(text: str, keyword: str) -> int:
+    match = re.search(rf"{keyword}\\s*(\d+)", text)
+    if match:
+        return int(match.group(1))
+    return 1
+
+
+def _parse_protection(text: str) -> set[Color]:
+    """Return a set of colors from "protection from" clauses."""
+    colors: set[Color] = set()
+    for match in re.findall(r"protection from ([^.,\n]+)", text, flags=re.I):
+        parts = re.split(r"\s*and from\s*", match)
+        for part in parts:
+            color = _COLOR_NAME_MAP.get(part.strip().lower())
+            if color:
+                colors.add(color)
+    return colors
+
+
+def card_to_creature(card: Dict[str, Any], controller: str) -> CombatCreature:
+    """Convert a single card dictionary into a :class:`CombatCreature`."""
+
+    name = card.get("name", "")
+    try:
+        power = int(card.get("power", 0))
+    except (TypeError, ValueError):
+        power = 0
+    try:
+        toughness = int(card.get("toughness", 0))
+    except (TypeError, ValueError):
+        toughness = 0
+    mana_cost = card.get("mana_cost") or ""
+    oracle_text = card.get("oracle_text") or ""
+    keywords = set(card.get("keywords", []))
+
+    kwargs: Dict[str, Any] = {
+        "name": name,
+        "power": power,
+        "toughness": toughness,
+        "controller": controller,
+        "mana_cost": mana_cost,
+        "colors": _parse_colors(mana_cost),
+    }
+
+    if "Flying" in keywords:
+        kwargs["flying"] = True
+    if "Reach" in keywords:
+        kwargs["reach"] = True
+    if "Menace" in keywords:
+        kwargs["menace"] = True
+    if "Fear" in keywords:
+        kwargs["fear"] = True
+    if "Shadow" in keywords:
+        kwargs["shadow"] = True
+    if "Horsemanship" in keywords:
+        kwargs["horsemanship"] = True
+    if "Skulk" in keywords:
+        kwargs["skulk"] = True
+    if "Vigilance" in keywords:
+        kwargs["vigilance"] = True
+    if "First strike" in keywords:
+        kwargs["first_strike"] = True
+    if "Double strike" in keywords:
+        kwargs["double_strike"] = True
+    if "Deathtouch" in keywords:
+        kwargs["deathtouch"] = True
+    if "Trample" in keywords:
+        kwargs["trample"] = True
+    if "Lifelink" in keywords:
+        kwargs["lifelink"] = True
+    if "Wither" in keywords:
+        kwargs["wither"] = True
+    if "Infect" in keywords:
+        kwargs["infect"] = True
+    if "Indestructible" in keywords:
+        kwargs["indestructible"] = True
+
+    if "Bushido" in keywords:
+        kwargs["bushido"] = _parse_value(oracle_text, "Bushido")
+    if "Flanking" in keywords:
+        kwargs["flanking"] = kwargs.get("flanking", 0) + 1
+    if "Rampage" in keywords:
+        kwargs["rampage"] = _parse_value(oracle_text, "Rampage")
+    if "Exalted" in keywords:
+        kwargs["exalted_count"] = kwargs.get("exalted_count", 0) + 1
+    if "Battle cry" in keywords:
+        kwargs["battle_cry_count"] = kwargs.get("battle_cry_count", 0) + 1
+    if "Melee" in keywords:
+        kwargs["melee"] = True
+    if "Training" in keywords:
+        kwargs["training"] = True
+    if "Frenzy" in keywords:
+        kwargs["frenzy"] = _parse_value(oracle_text, "Frenzy")
+    if "Battalion" in keywords:
+        kwargs["battalion"] = True
+    if "Dethrone" in keywords:
+        kwargs["dethrone"] = True
+    if "Undying" in keywords:
+        kwargs["undying"] = True
+    if "Persist" in keywords:
+        kwargs["persist"] = True
+    if "Intimidate" in keywords:
+        kwargs["intimidate"] = True
+    if "Defender" in keywords:
+        kwargs["defender"] = True
+    if "Afflict" in keywords:
+        kwargs["afflict"] = _parse_value(oracle_text, "Afflict")
+    if "Toxic" in keywords:
+        kwargs["toxic"] = _parse_value(oracle_text, "Toxic")
+    if "Provoke" in keywords:
+        kwargs["provoke"] = True
+
+    prot_colors = _parse_protection(oracle_text)
+    if prot_colors:
+        kwargs["protection_colors"] = prot_colors
+
+    return CombatCreature(**kwargs)
+
+
+def cards_to_creatures(cards: Iterable[Dict[str, Any]], controller: str) -> List[CombatCreature]:
+    """Convert an iterable of card dicts into :class:`CombatCreature` objects."""
+
+    return [card_to_creature(c, controller) for c in cards]

--- a/magic_combat/simulator.py
+++ b/magic_combat/simulator.py
@@ -38,6 +38,7 @@ class CombatSimulator:
         defenders: List[CombatCreature],
         strategy: Optional[DamageAssignmentStrategy] = None,
         game_state: Optional["GameState"] = None,
+        provoke_map: Optional[Dict[CombatCreature, CombatCreature]] = None,
     ):
         """Store combatants taking part in the current combat phase."""
 
@@ -50,6 +51,7 @@ class CombatSimulator:
         self._lifegain_applied: Dict[str, int] = {}
         self.assignment_strategy = strategy or MostCreaturesKilledStrategy()
         self.game_state = game_state
+        self.provoke_map: Dict[CombatCreature, CombatCreature] = provoke_map or {}
         self.players_lost: List[str] = []
 
         for attacker in attackers:
@@ -144,13 +146,13 @@ class CombatSimulator:
 
     def _check_provoke(self) -> None:
         """Verify provoke targets are blocking as required."""
-        for attacker in self.attackers:
-            if attacker.provoke_target is not None:
-                target = attacker.provoke_target
-                if target not in self.defenders:
-                    raise ValueError("Provoke target not defending creature")
-                if target.blocking is not attacker:
-                    raise ValueError("Provoke target failed to block")
+        for attacker, target in self.provoke_map.items():
+            if attacker not in self.attackers:
+                raise ValueError("Provoke attacker not in combat")
+            if target not in self.defenders:
+                raise ValueError("Provoke target not defending creature")
+            if target.blocking is not attacker:
+                raise ValueError("Provoke target failed to block")
 
     def validate_blocking(self):
         """Ensure blocking assignments are legal for this simplified simulator."""

--- a/tests/abilities/test_additional_keyword_abilities.py
+++ b/tests/abilities/test_additional_keyword_abilities.py
@@ -65,8 +65,7 @@ def test_provoke_forces_block():
     """CR 702.36a: Provoke makes the targeted creature block if able."""
     atk = CombatCreature("Taunter", 2, 2, "A")
     blocker = CombatCreature("Giant", 3, 3, "B")
-    atk.provoke_target = blocker
-    sim = CombatSimulator([atk], [blocker])
+    sim = CombatSimulator([atk], [blocker], provoke_map={atk: blocker})
     # blocker not assigned to block -> should error
     with pytest.raises(ValueError):
         sim.validate_blocking()

--- a/tests/abilities/test_complex_ability_combos.py
+++ b/tests/abilities/test_complex_ability_combos.py
@@ -99,8 +99,7 @@ def test_provoke_and_menace_insufficient_blockers():
     attacker = CombatCreature("Taunting Brute", 2, 2, "A", menace=True)
     blocker = CombatCreature("Goblin", 2, 2, "B")
     link_block(attacker, blocker)
-    attacker.provoke_target = blocker
-    sim = CombatSimulator([attacker], [blocker])
+    sim = CombatSimulator([attacker], [blocker], provoke_map={attacker: blocker})
     with pytest.raises(ValueError):
         sim.validate_blocking()
 

--- a/tests/abilities/test_more_keyword_interactions.py
+++ b/tests/abilities/test_more_keyword_interactions.py
@@ -233,9 +233,8 @@ def test_provoke_battalion_no_bonus_without_three_attackers():
     provoker = CombatCreature("Leader", 2, 2, "A", battalion=True)
     ally = CombatCreature("Ally", 2, 2, "A")
     blocker = CombatCreature("Guard", 2, 2, "B")
-    provoker.provoke_target = blocker
     link_block(provoker, blocker)
-    sim = CombatSimulator([provoker, ally], [blocker])
+    sim = CombatSimulator([provoker, ally], [blocker], provoke_map={provoker: blocker})
     result = sim.simulate()
     assert provoker in result.creatures_destroyed
     assert blocker in result.creatures_destroyed

--- a/tests/test_provoke.py
+++ b/tests/test_provoke.py
@@ -7,10 +7,9 @@ def test_provoke_target_blocks_successfully():
     """CR 702.40a: Provoke forces the chosen creature to block if able."""
     atk = CombatCreature("Taunter", 2, 2, "A")
     blk = CombatCreature("Guard", 2, 2, "B")
-    atk.provoke_target = blk
     atk.blocked_by.append(blk)
     blk.blocking = atk
-    sim = CombatSimulator([atk], [blk])
+    sim = CombatSimulator([atk], [blk], provoke_map={atk: blk})
     sim.validate_blocking()
     result = sim.simulate()
     assert atk in result.creatures_destroyed
@@ -21,8 +20,7 @@ def test_provoke_target_must_block():
     """CR 702.40a: Provoke requires the chosen creature to block if able."""
     atk = CombatCreature("Taunter", 2, 2, "A")
     blk = CombatCreature("Guard", 2, 2, "B")
-    atk.provoke_target = blk
-    sim = CombatSimulator([atk], [blk])
+    sim = CombatSimulator([atk], [blk], provoke_map={atk: blk})
     with pytest.raises(ValueError):
         sim.validate_blocking()
 
@@ -32,8 +30,7 @@ def test_provoke_target_not_defender():
     atk = CombatCreature("Taunter", 2, 2, "A")
     defender = CombatCreature("Blocker", 2, 2, "B")
     other = CombatCreature("Bystander", 2, 2, "C")
-    atk.provoke_target = other
-    sim = CombatSimulator([atk], [defender])
+    sim = CombatSimulator([atk], [defender], provoke_map={atk: other})
     with pytest.raises(ValueError):
         sim.validate_blocking()
 
@@ -42,10 +39,9 @@ def test_provoke_menace_single_blocker_fails():
     """CR 702.40a & 702.110b: Provoke doesn't override menace's two-blocker requirement."""
     atk = CombatCreature("Menacing", 2, 2, "A", menace=True)
     blk = CombatCreature("Goblin", 2, 2, "B")
-    atk.provoke_target = blk
     atk.blocked_by.append(blk)
     blk.blocking = atk
-    sim = CombatSimulator([atk], [blk])
+    sim = CombatSimulator([atk], [blk], provoke_map={atk: blk})
     with pytest.raises(ValueError):
         sim.validate_blocking()
 
@@ -55,11 +51,10 @@ def test_provoke_menace_two_blockers_ok():
     atk = CombatCreature("Menacing", 2, 2, "A", menace=True)
     blk1 = CombatCreature("Goblin1", 2, 2, "B")
     blk2 = CombatCreature("Goblin2", 2, 2, "B")
-    atk.provoke_target = blk1
     atk.blocked_by.extend([blk1, blk2])
     blk1.blocking = atk
     blk2.blocking = atk
-    sim = CombatSimulator([atk], [blk1, blk2])
+    sim = CombatSimulator([atk], [blk1, blk2], provoke_map={atk: blk1})
     sim.validate_blocking()
     result = sim.simulate()
     assert atk in result.creatures_destroyed
@@ -69,10 +64,9 @@ def test_provoke_unblockable_attacker():
     """CR 702.40a & 509.1b: Provoke can't force a block on an unblockable creature."""
     atk = CombatCreature("Sneak", 2, 2, "A", unblockable=True)
     blk = CombatCreature("Guard", 2, 2, "B")
-    atk.provoke_target = blk
     atk.blocked_by.append(blk)
     blk.blocking = atk
-    sim = CombatSimulator([atk], [blk])
+    sim = CombatSimulator([atk], [blk], provoke_map={atk: blk})
     with pytest.raises(ValueError):
         sim.validate_blocking()
 
@@ -81,10 +75,9 @@ def test_provoke_flying_needs_reach():
     """CR 702.40a & 702.9b: A provoked creature without flying or reach can't block a flyer."""
     atk = CombatCreature("Dragon", 3, 3, "A", flying=True)
     blk = CombatCreature("Bear", 2, 2, "B")
-    atk.provoke_target = blk
     atk.blocked_by.append(blk)
     blk.blocking = atk
-    sim = CombatSimulator([atk], [blk])
+    sim = CombatSimulator([atk], [blk], provoke_map={atk: blk})
     with pytest.raises(ValueError):
         sim.validate_blocking()
 
@@ -93,10 +86,9 @@ def test_provoke_flying_with_reach_success():
     """CR 702.40a & 702.9c: Reach lets a provoked creature block a flyer."""
     atk = CombatCreature("Dragon", 3, 3, "A", flying=True)
     blk = CombatCreature("Spider", 1, 4, "B", reach=True)
-    atk.provoke_target = blk
     atk.blocked_by.append(blk)
     blk.blocking = atk
-    sim = CombatSimulator([atk], [blk])
+    sim = CombatSimulator([atk], [blk], provoke_map={atk: blk})
     sim.validate_blocking()
     result = sim.simulate()
     assert atk not in result.creatures_destroyed
@@ -107,10 +99,9 @@ def test_provoke_skulk_high_power_blocker():
     """CR 702.40a & 702.72a: Skulk prevents blocks by higher-power creatures even if provoked."""
     atk = CombatCreature("Sneak", 1, 1, "A", skulk=True)
     blk = CombatCreature("Ogre", 3, 3, "B")
-    atk.provoke_target = blk
     atk.blocked_by.append(blk)
     blk.blocking = atk
-    sim = CombatSimulator([atk], [blk])
+    sim = CombatSimulator([atk], [blk], provoke_map={atk: blk})
     with pytest.raises(ValueError):
         sim.validate_blocking()
 
@@ -119,10 +110,9 @@ def test_provoke_protection_from_color():
     """CR 702.40a & 702.16b: Protection prevents the provoked creature from blocking."""
     atk = CombatCreature("Paladin", 2, 2, "A", protection_colors={Color.RED})
     blk = CombatCreature("Orc", 2, 2, "B", colors={Color.RED})
-    atk.provoke_target = blk
     atk.blocked_by.append(blk)
     blk.blocking = atk
-    sim = CombatSimulator([atk], [blk])
+    sim = CombatSimulator([atk], [blk], provoke_map={atk: blk})
     with pytest.raises(ValueError):
         sim.validate_blocking()
 
@@ -131,10 +121,9 @@ def test_provoke_afflict_damage_triggers():
     """CR 702.40a & 702.131a: A provoked attacker with afflict still causes life loss when blocked."""
     atk = CombatCreature("Tormentor", 2, 2, "A", afflict=2)
     blk = CombatCreature("Guard", 2, 2, "B")
-    atk.provoke_target = blk
     atk.blocked_by.append(blk)
     blk.blocking = atk
-    sim = CombatSimulator([atk], [blk])
+    sim = CombatSimulator([atk], [blk], provoke_map={atk: blk})
     result = sim.simulate()
     assert result.damage_to_players["B"] == 2
     assert atk in result.creatures_destroyed
@@ -145,10 +134,9 @@ def test_provoke_first_strike_kills_before_damage():
     """CR 702.7b & 702.40a: First strike damage is dealt before the provoked creature can respond."""
     atk = CombatCreature("Duelist", 2, 2, "A", first_strike=True)
     blk = CombatCreature("Guard", 2, 2, "B")
-    atk.provoke_target = blk
     atk.blocked_by.append(blk)
     blk.blocking = atk
-    sim = CombatSimulator([atk], [blk])
+    sim = CombatSimulator([atk], [blk], provoke_map={atk: blk})
     result = sim.simulate()
     assert blk in result.creatures_destroyed
     assert atk not in result.creatures_destroyed
@@ -158,10 +146,9 @@ def test_provoke_trample_excess_damage_to_player():
     """CR 702.19b & 702.40a: Trample assigns excess damage even when provoking a block."""
     atk = CombatCreature("Rhino", 4, 4, "A", trample=True)
     blk = CombatCreature("Wall", 1, 1, "B")
-    atk.provoke_target = blk
     atk.blocked_by.append(blk)
     blk.blocking = atk
-    sim = CombatSimulator([atk], [blk])
+    sim = CombatSimulator([atk], [blk], provoke_map={atk: blk})
     result = sim.simulate()
     assert result.damage_to_players["B"] == 3
     assert blk in result.creatures_destroyed
@@ -171,10 +158,9 @@ def test_provoke_bushido_bonus_saves_attacker():
     """CR 702.46a & 702.40a: Bushido grants +1/+1 when the provoked creature blocks."""
     atk = CombatCreature("Samurai", 2, 2, "A", bushido=1)
     blk = CombatCreature("Soldier", 2, 2, "B")
-    atk.provoke_target = blk
     atk.blocked_by.append(blk)
     blk.blocking = atk
-    sim = CombatSimulator([atk], [blk])
+    sim = CombatSimulator([atk], [blk], provoke_map={atk: blk})
     result = sim.simulate()
     assert blk in result.creatures_destroyed
     assert atk not in result.creatures_destroyed
@@ -185,11 +171,10 @@ def test_provoke_rampage_bonus_with_multiple_blockers():
     atk = CombatCreature("Warlord", 3, 3, "A", rampage=2)
     blk1 = CombatCreature("Guard1", 2, 2, "B")
     blk2 = CombatCreature("Guard2", 2, 2, "B")
-    atk.provoke_target = blk1
     atk.blocked_by.extend([blk1, blk2])
     blk1.blocking = atk
     blk2.blocking = atk
-    sim = CombatSimulator([atk], [blk1, blk2])
+    sim = CombatSimulator([atk], [blk1, blk2], provoke_map={atk: blk1})
     result = sim.simulate()
     assert blk1 in result.creatures_destroyed
     assert blk2 in result.creatures_destroyed
@@ -200,10 +185,9 @@ def test_provoke_flanking_debuffs_target():
     """CR 702.25a & 702.40a: Flanking gives the provoked creature -1/-1."""
     atk = CombatCreature("Lancer", 2, 2, "A", flanking=1)
     blk = CombatCreature("Knight", 2, 2, "B")
-    atk.provoke_target = blk
     atk.blocked_by.append(blk)
     blk.blocking = atk
-    sim = CombatSimulator([atk], [blk])
+    sim = CombatSimulator([atk], [blk], provoke_map={atk: blk})
     result = sim.simulate()
     assert blk in result.creatures_destroyed
     assert atk not in result.creatures_destroyed
@@ -214,10 +198,9 @@ def test_provoke_training_counter_added():
     trainee = CombatCreature("Recruit", 2, 2, "A", training=True)
     ally = CombatCreature("Veteran", 3, 3, "A")
     blk = CombatCreature("Guard", 2, 2, "B")
-    trainee.provoke_target = blk
     trainee.blocked_by.append(blk)
     blk.blocking = trainee
-    sim = CombatSimulator([trainee, ally], [blk])
+    sim = CombatSimulator([trainee, ally], [blk], provoke_map={trainee: blk})
     result = sim.simulate()
     assert trainee.plus1_counters == 1
     assert blk in result.creatures_destroyed
@@ -228,10 +211,9 @@ def test_provoke_exalted_no_bonus_with_multiple_attackers():
     exalter = CombatCreature("Monk", 2, 2, "A", exalted_count=1)
     ally = CombatCreature("Helper", 3, 3, "A")
     blk = CombatCreature("Guard", 2, 2, "B")
-    exalter.provoke_target = blk
     exalter.blocked_by.append(blk)
     blk.blocking = exalter
-    sim = CombatSimulator([exalter, ally], [blk])
+    sim = CombatSimulator([exalter, ally], [blk], provoke_map={exalter: blk})
     result = sim.simulate()
     assert exalter in result.creatures_destroyed
     assert blk in result.creatures_destroyed
@@ -242,10 +224,11 @@ def test_provoke_allows_frenzy_attacker_unblocked():
     provoker = CombatCreature("Taunter", 2, 2, "A")
     frenzy_attacker = CombatCreature("Berserker", 2, 2, "A", frenzy=2)
     blk = CombatCreature("Guard", 2, 2, "B")
-    provoker.provoke_target = blk
     provoker.blocked_by.append(blk)
     blk.blocking = provoker
-    sim = CombatSimulator([provoker, frenzy_attacker], [blk])
+    sim = CombatSimulator(
+        [provoker, frenzy_attacker], [blk], provoke_map={provoker: blk}
+    )
     result = sim.simulate()
     assert result.damage_to_players["B"] == 4
 
@@ -255,10 +238,9 @@ def test_provoke_battle_cry_buffs_ally():
     leader = CombatCreature("Warcry", 2, 2, "A", battle_cry_count=1)
     ally = CombatCreature("Soldier", 2, 2, "A")
     blk = CombatCreature("Guard", 2, 2, "B")
-    leader.provoke_target = blk
     leader.blocked_by.append(blk)
     blk.blocking = leader
-    sim = CombatSimulator([leader, ally], [blk])
+    sim = CombatSimulator([leader, ally], [blk], provoke_map={leader: blk})
     result = sim.simulate()
     assert result.damage_to_players["B"] == 3
     assert blk in result.creatures_destroyed
@@ -268,10 +250,9 @@ def test_provoke_lifelink_attacker_gains_life():
     """CR 702.15a & 702.40a: Lifelink causes life gain when the provoker deals damage."""
     atk = CombatCreature("Vampire", 2, 2, "A", lifelink=True)
     blk = CombatCreature("Guard", 2, 2, "B")
-    atk.provoke_target = blk
     atk.blocked_by.append(blk)
     blk.blocking = atk
-    sim = CombatSimulator([atk], [blk])
+    sim = CombatSimulator([atk], [blk], provoke_map={atk: blk})
     result = sim.simulate()
     assert result.lifegain["A"] == 2
     assert blk in result.creatures_destroyed
@@ -281,10 +262,9 @@ def test_provoke_wither_applies_counters():
     """CR 702.90a & 702.40a: Wither deals damage as -1/-1 counters to the provoked creature."""
     atk = CombatCreature("Corrosive", 2, 2, "A", wither=True)
     blk = CombatCreature("Guard", 2, 2, "B")
-    atk.provoke_target = blk
     atk.blocked_by.append(blk)
     blk.blocking = atk
-    sim = CombatSimulator([atk], [blk])
+    sim = CombatSimulator([atk], [blk], provoke_map={atk: blk})
     result = sim.simulate()
     assert blk.minus1_counters == 2
     assert blk in result.creatures_destroyed


### PR DESCRIPTION
## Summary
- parse Scryfall card dictionaries into CombatCreature objects
- expose the conversion helpers from the package API
- parse provoke and protection abilities
- refactor provoke targeting to be passed into the combat simulator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68575fc50d84832a9f3f4f1500a62c5c