### PR TITLE
Add scryfall loader tests

### DIFF
--- a/tests/example_test_cards.json
+++ b/tests/example_test_cards.json
@@ -1,0 +1,82 @@
+[
+  {
+    "name": "Winged Drake",
+    "mana_cost": "{2}{U}",
+    "power": "2",
+    "toughness": "2",
+    "oracle_text": "Flying",
+    "keywords": ["Flying"]
+  },
+  {
+    "name": "Goblin Menace",
+    "mana_cost": "{1}{R}",
+    "power": "2",
+    "toughness": "2",
+    "oracle_text": "Menace",
+    "keywords": ["Menace"]
+  },
+  {
+    "name": "White Knight",
+    "mana_cost": "{W}{W}",
+    "power": "2",
+    "toughness": "2",
+    "oracle_text": "First strike\nProtection from black",
+    "keywords": ["First strike"]
+  },
+  {
+    "name": "Oak Guardian",
+    "mana_cost": "{3}{G}",
+    "power": "3",
+    "toughness": "3",
+    "oracle_text": "Reach",
+    "keywords": ["Reach"]
+  },
+  {
+    "name": "Samurai Elite",
+    "mana_cost": "{1}{R}{R}",
+    "power": "2",
+    "toughness": "2",
+    "oracle_text": "Bushido 2",
+    "keywords": ["Bushido"]
+  },
+  {
+    "name": "Frenzied Goblin",
+    "mana_cost": "{R}",
+    "power": "1",
+    "toughness": "1",
+    "oracle_text": "Frenzy 1",
+    "keywords": ["Frenzy"]
+  },
+  {
+    "name": "Toxic Lizard",
+    "mana_cost": "{2}{G}",
+    "power": "2",
+    "toughness": "1",
+    "oracle_text": "Toxic 2",
+    "keywords": ["Toxic"]
+  },
+  {
+    "name": "Elemental Beast",
+    "mana_cost": "{2}{G/U}{R}",
+    "power": "3",
+    "toughness": "3",
+    "oracle_text": "Trample",
+    "keywords": ["Trample"]
+  },
+  {
+    "name": "Undying Horror",
+    "mana_cost": "{2}{B}",
+    "power": "3",
+    "toughness": "2",
+    "oracle_text": "Undying",
+    "keywords": ["Undying"]
+  },
+  {
+    "name": "Spirit Guardian",
+    "mana_cost": "{3}{W}",
+    "power": "2",
+    "toughness": "2",
+    "oracle_text": "Persist\nProtection from red and from green",
+    "keywords": ["Persist"]
+  }
+]

--- a/tests/test_scryfall_loader.py
+++ b/tests/test_scryfall_loader.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+from magic_combat.scryfall_loader import (
+    _parse_colors,
+    _parse_protection,
+    load_cards,
+    card_to_creature,
+    cards_to_creatures,
+)
+from magic_combat.creature import Color
+
+DATA_PATH = Path(__file__).with_name("example_test_cards.json")
+
+
+def test_parse_colors_hybrid():
+    """CR 205.3d: The colors of an object are determined by the mana symbols in its cost."""
+    result = _parse_colors("{2}{G/U}{R}")
+    assert result == {Color.GREEN, Color.BLUE, Color.RED}
+
+
+def test_parse_protection_multi():
+    """CR 702.16b: Protection from red and from green covers both colors."""
+    result = _parse_protection("Protection from red and from green")
+    assert result == {Color.RED, Color.GREEN}
+
+
+def test_card_to_creature_basic():
+    """CR 205.3d: Converting a card uses its mana symbols to set its colors."""
+    cards = load_cards(str(DATA_PATH))
+    card = next(c for c in cards if c["name"] == "Winged Drake")
+    creature = card_to_creature(card, "A")
+    assert creature.flying
+    assert creature.colors == {Color.BLUE}
+
+
+def test_card_to_creature_protection_and_bushido():
+    """CR 702.16b & 702.46a: Protection and bushido keywords are recognized."""
+    cards = load_cards(str(DATA_PATH))
+    card = next(c for c in cards if c["name"] == "White Knight")
+    creature = card_to_creature(card, "B")
+    assert creature.first_strike
+    assert creature.protection_colors == {Color.BLACK}
+
+
+def test_cards_to_creatures_count():
+    """CR 205.3d: Cards converted to creatures keep their colors from mana symbols."""
+    cards = load_cards(str(DATA_PATH))
+    creatures = cards_to_creatures(cards, "A")
+    assert len(creatures) == 10
+    names = {c.name for c in creatures}
+    assert "Elemental Beast" in names
+


### PR DESCRIPTION
## Summary
- add example card data for tests
- test color parsing, protection parsing, and card conversion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685777ebff94832aa319079ab69cddfe