### PR TITLE
Improve random combat generator

### DIFF
--- a/scripts/random_combat.py
+++ b/scripts/random_combat.py
@@ -21,6 +21,67 @@ from magic_combat import (
 )
 from magic_combat.damage import _blocker_value
 
+# Ability name mappings for pretty printing
+_BOOL_ABILITIES = {
+    "flying": "Flying",
+    "reach": "Reach",
+    "menace": "Menace",
+    "fear": "Fear",
+    "shadow": "Shadow",
+    "horsemanship": "Horsemanship",
+    "skulk": "Skulk",
+    "unblockable": "Unblockable",
+    "daunt": "Daunt",
+    "vigilance": "Vigilance",
+    "first_strike": "First strike",
+    "double_strike": "Double strike",
+    "deathtouch": "Deathtouch",
+    "trample": "Trample",
+    "lifelink": "Lifelink",
+    "wither": "Wither",
+    "infect": "Infect",
+    "indestructible": "Indestructible",
+    "melee": "Melee",
+    "training": "Training",
+    "mentor": "Mentor",
+    "battalion": "Battalion",
+    "dethrone": "Dethrone",
+    "undying": "Undying",
+    "persist": "Persist",
+    "intimidate": "Intimidate",
+    "defender": "Defender",
+    "provoke": "Provoke",
+}
+
+_INT_ABILITIES = {
+    "toxic": "Toxic",
+    "bushido": "Bushido",
+    "flanking": "Flanking",
+    "rampage": "Rampage",
+    "exalted_count": "Exalted",
+    "battle_cry_count": "Battle cry",
+    "frenzy": "Frenzy",
+    "afflict": "Afflict",
+}
+
+
+def describe_abilities(creature) -> str:
+    """Return a comma-separated string of the creature's keyword abilities."""
+    parts: List[str] = []
+    for attr, name in _BOOL_ABILITIES.items():
+        if getattr(creature, attr, False):
+            parts.append(name)
+    for attr, name in _INT_ABILITIES.items():
+        val = getattr(creature, attr, 0)
+        if val:
+            parts.append(f"{name} {val}")
+    if creature.protection_colors:
+        colors = ", ".join(c.name.capitalize() for c in creature.protection_colors)
+        parts.append(f"Protection from {colors}")
+    if creature.artifact:
+        parts.append("Artifact")
+    return ", ".join(parts) if parts else "none"
+
 
 def ensure_cards(path: str) -> List[dict]:
     """Load card data, downloading it if necessary."""
@@ -90,61 +151,94 @@ def main() -> None:
         default="data/cards.json",
         help="Path to card data JSON",
     )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed controlling sampling",
+    )
     args = parser.parse_args()
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
 
     cards = ensure_cards(args.cards)
     values = build_value_map(cards)
     valid_len = len(values)
 
     for i in range(args.iterations):
-        n_atk = int(np.random.geometric(1 / 2.5))
-        n_blk = int(np.random.geometric(1 / 2.5))
-        n_atk = max(1, min(n_atk, valid_len // 2))
-        n_blk = max(1, min(n_blk, valid_len // 2))
+        attempts = 0
+        while True:
+            attempts += 1
+            if attempts > 100:
+                raise RuntimeError("Unable to generate valid scenario")
 
-        atk_idx, blk_idx = sample_balanced(cards, values, n_atk, n_blk)
-        attackers = cards_to_creatures((cards[i] for i in atk_idx), "A")
-        blockers = cards_to_creatures((cards[i] for i in blk_idx), "B")
+            n_atk = int(np.random.geometric(1 / 2.5))
+            n_blk = int(np.random.geometric(1 / 2.5))
+            n_atk = max(1, min(n_atk, valid_len // 2))
+            n_blk = max(1, min(n_blk, valid_len // 2))
 
-        poison_relevant = any(c.infect or c.toxic for c in attackers + blockers)
+            atk_idx, blk_idx = sample_balanced(cards, values, n_atk, n_blk)
+            attackers = cards_to_creatures((cards[j] for j in atk_idx), "A")
+            blockers = cards_to_creatures((cards[j] for j in blk_idx), "B")
 
-        state = GameState(
-            players={
-                "A": PlayerState(
-                    life=random.randint(1, 20),
-                    creatures=attackers,
-                    poison=random.randint(0, 9) if poison_relevant else 0,
-                ),
-                "B": PlayerState(
-                    life=random.randint(1, 20),
-                    creatures=blockers,
-                    poison=random.randint(0, 9) if poison_relevant else 0,
-                ),
+            poison_relevant = any(c.infect or c.toxic for c in attackers + blockers)
+
+            state = GameState(
+                players={
+                    "A": PlayerState(
+                        life=random.randint(1, 20),
+                        creatures=attackers,
+                        poison=random.randint(0, 9) if poison_relevant else 0,
+                    ),
+                    "B": PlayerState(
+                        life=random.randint(1, 20),
+                        creatures=blockers,
+                        poison=random.randint(0, 9) if poison_relevant else 0,
+                    ),
+                }
+            )
+
+            provoke_map = {
+                atk: random.choice(blockers)
+                for atk in attackers
+                if atk.provoke
             }
-        )
 
-        provoke_map = {
-            atk: random.choice(blockers)
-            for atk in attackers
-            if atk.provoke
-        }
+            mentor_map = {}
+            for mentor in attackers:
+                if mentor.mentor:
+                    targets = [
+                        c
+                        for c in attackers
+                        if c is not mentor and c.effective_power() < mentor.effective_power()
+                    ]
+                    if targets:
+                        mentor_map[mentor] = random.choice(targets)
+
+            try:
+                decide_optimal_blocks(attackers, blockers, game_state=state)
+                sim = CombatSimulator(
+                    attackers,
+                    blockers,
+                    game_state=state,
+                    provoke_map=provoke_map,
+                    mentor_map=mentor_map,
+                )
+                result = sim.simulate()
+            except ValueError:
+                continue
+            break
 
         print("Attackers")
         for atk in attackers:
-            print(atk)
+            print(f"{atk} -- {describe_abilities(atk)}")
         print("Blockers")
         for blk in blockers:
-            print(blk)
-        
-        
-        decide_optimal_blocks(attackers, blockers, game_state=state)
-        sim = CombatSimulator(
-            attackers,
-            blockers,
-            game_state=state,
-            provoke_map=provoke_map,
-        )
-        result = sim.simulate()
+            print(f"{blk} -- {describe_abilities(blk)}")
+
+        prov_map_display = {a.name: b.name for a, b in provoke_map.items()} if provoke_map else None
+        mentor_map_display = {m.name: t.name for m, t in mentor_map.items()} if mentor_map else None
 
         print(f"\n=== Scenario {i+1} ===")
         print("Attackers:")
@@ -155,9 +249,10 @@ def main() -> None:
         for blk in blockers:
             target = blk.blocking.name if blk.blocking else "none"
             print(f"  {blk} -> {target}")
-        if provoke_map:
-            prov = {a.name: b.name for a, b in provoke_map.items()}
-            print("Provoke targets:", prov)
+        if prov_map_display:
+            print("Provoke targets:", prov_map_display)
+        if mentor_map_display:
+            print("Mentor targets:", mentor_map_display)
         print("Outcome:", result)
 
 


### PR DESCRIPTION
## Summary
- print active keyword abilities for each creature in `random_combat`
- support fixed random seeds and mentor targeting
- resample scenarios on illegal setups

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857805e5d80832aad923065c545f35b