### PR TITLE
Implement random creature generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ magic_combat/creature.py     ``CombatCreature`` data model
 magic_combat/damage.py       Damage assignment strategies
 magic_combat/simulator.py    ``CombatSimulator`` and ``CombatResult`` classes
 magic_combat/utils.py        Small utility helpers used internally
+magic_combat/random_creature.py Utilities for sampling creatures
 ```
 
 ## Development
@@ -69,4 +70,18 @@ from the repository root to perform the download:
 
 ```bash
 python scripts/download_cards.py data/cards.json
+```
+
+## Random creature generation
+
+Once you have downloaded card data, you can build statistics for the real
+creature distribution and sample new creatures from it:
+
+```python
+from magic_combat import load_cards, compute_card_statistics, generate_random_creature
+
+cards = load_cards("data/cards.json")
+stats = compute_card_statistics(cards)
+creature = generate_random_creature(stats)
+print(creature)
 ```

--- a/magic_combat/__init__.py
+++ b/magic_combat/__init__.py
@@ -17,6 +17,7 @@ from .scryfall_loader import (
     card_to_creature,
     cards_to_creatures,
 )
+from .random_creature import compute_card_statistics, generate_random_creature
 
 __all__ = [
     "CombatCreature",
@@ -36,4 +37,6 @@ __all__ = [
     "save_cards",
     "card_to_creature",
     "cards_to_creatures",
+    "compute_card_statistics",
+    "generate_random_creature",
 ]

--- a/magic_combat/random_creature.py
+++ b/magic_combat/random_creature.py
@@ -1,0 +1,158 @@
+"""Utilities for generating random creatures based on card statistics."""
+
+from __future__ import annotations
+
+import random
+from collections import Counter, defaultdict
+from typing import Iterable, Dict, Tuple
+
+import numpy as np
+
+from .creature import CombatCreature, Color
+from .scryfall_loader import cards_to_creatures
+
+
+_BOOL_ABILITIES = {
+    "flying",
+    "reach",
+    "menace",
+    "fear",
+    "shadow",
+    "horsemanship",
+    "skulk",
+    "unblockable",
+    "daunt",
+    "vigilance",
+    "first_strike",
+    "double_strike",
+    "deathtouch",
+    "trample",
+    "lifelink",
+    "wither",
+    "infect",
+    "indestructible",
+    "melee",
+    "training",
+    "mentor",
+    "battalion",
+    "dethrone",
+    "undying",
+    "persist",
+    "intimidate",
+    "defender",
+    "provoke",
+}
+
+_INT_ABILITIES = {
+    "toxic",
+    "bushido",
+    "flanking",
+    "rampage",
+    "exalted_count",
+    "battle_cry_count",
+    "frenzy",
+    "afflict",
+}
+
+
+def compute_card_statistics(cards: Iterable[dict]) -> Dict[str, object]:
+    """Return first and second order statistics for ``cards``.
+
+    The returned mapping contains the mean and standard deviation of power and
+    toughness along with the observed probability of each ability and pairwise
+    ability co-occurrences.
+    """
+
+    creatures = cards_to_creatures(cards, "A")
+    powers: list[int] = []
+    toughnesses: list[int] = []
+    ability_counts: Counter[str] = Counter()
+    pair_counts: Dict[str, Counter[str]] = defaultdict(Counter)
+
+    for cr in creatures:
+        powers.append(cr.power)
+        toughnesses.append(cr.toughness)
+        present = []
+        for attr in _BOOL_ABILITIES:
+            if getattr(cr, attr, False):
+                present.append(attr)
+        for attr in _INT_ABILITIES:
+            if getattr(cr, attr, 0):
+                present.append(attr)
+        if cr.protection_colors:
+            present.append("protection")
+        ability_counts.update(present)
+        for i, a in enumerate(present):
+            for b in present[i + 1 :]:
+                pair = tuple(sorted((a, b)))
+                pair_counts[pair[0]][pair[1]] += 1
+                pair_counts[pair[1]][pair[0]] += 1
+
+    total = len(creatures) or 1
+    ability_prob = {a: ability_counts[a] / total for a in ability_counts}
+    pair_prob: Dict[Tuple[str, str], float] = {}
+    for a, inner in pair_counts.items():
+        for b, count in inner.items():
+            pair_prob[(a, b)] = count / total
+
+    stats = {
+        "power_mean": float(np.mean(powers) if powers else 0.0),
+        "power_std": float(np.std(powers) if powers else 1.0),
+        "toughness_mean": float(np.mean(toughnesses) if toughnesses else 0.0),
+        "toughness_std": float(np.std(toughnesses) if toughnesses else 1.0),
+        "ability_prob": ability_prob,
+        "pair_prob": pair_prob,
+    }
+    return stats
+
+
+def _conditional_probability(a: str, b: str, stats: Dict[str, object]) -> float:
+    pair_prob = stats["pair_prob"].get((min(a, b), max(a, b)), 0.0)
+    base = stats["ability_prob"].get(a, 0.0)
+    if base <= 0:
+        return 0.0
+    return min(1.0, pair_prob / base)
+
+
+def generate_random_creature(
+    stats: Dict[str, object], controller: str = "A", name: str | None = None
+) -> CombatCreature:
+    """Generate a random creature matching the provided statistics."""
+
+    if name is None:
+        name = f"Generated {random.randint(1, 9999)}"
+
+    mean_p = stats.get("power_mean", 0.0)
+    std_p = stats.get("power_std", 1.0)
+    mean_t = stats.get("toughness_mean", 0.0)
+    std_t = stats.get("toughness_std", 1.0)
+
+    power = max(0, int(round(random.gauss(mean_p, std_p))))
+    toughness = max(1, int(round(random.gauss(mean_t, std_t))))
+
+    chosen: set[str] = set()
+    abilities = list(stats.get("ability_prob", {}).keys())
+    random.shuffle(abilities)
+    for a in abilities:
+        if random.random() < stats["ability_prob"].get(a, 0.0):
+            chosen.add(a)
+            for b in abilities:
+                if b != a and b not in chosen:
+                    cond = _conditional_probability(a, b, stats)
+                    if cond and random.random() < cond:
+                        chosen.add(b)
+
+    kwargs: Dict[str, object] = {
+        "name": name,
+        "power": power,
+        "toughness": toughness,
+        "controller": controller,
+    }
+    for ability in chosen:
+        if ability in _BOOL_ABILITIES:
+            kwargs[ability] = True
+        elif ability in _INT_ABILITIES:
+            kwargs[ability] = 1
+        elif ability == "protection":
+            kwargs["protection_colors"] = {random.choice(list(Color))}
+    return CombatCreature(**kwargs)

--- a/tests/test_random_creature.py
+++ b/tests/test_random_creature.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+from magic_combat import (
+    load_cards,
+    compute_card_statistics,
+    generate_random_creature,
+    CombatCreature,
+)
+
+DATA_PATH = Path(__file__).with_name("example_test_cards.json")
+
+
+def test_compute_statistics_means():
+    """CR 109.3: Power and toughness are characteristics of creatures."""
+    cards = load_cards(str(DATA_PATH))
+    stats = compute_card_statistics(cards)
+    assert abs(stats["power_mean"] - 2.2) < 0.01
+    assert abs(stats["toughness_mean"] - 2.0) < 0.01
+
+
+def test_generate_random_creature_basic():
+    """CR 109.3: A creature has a name, power, toughness, and abilities."""
+    cards = load_cards(str(DATA_PATH))
+    stats = compute_card_statistics(cards)
+    creature = generate_random_creature(stats, controller="A")
+    assert isinstance(creature, CombatCreature)
+    assert isinstance(creature.power, int)
+    assert isinstance(creature.toughness, int)
+    assert creature.name


### PR DESCRIPTION
## Summary
- add utility for computing card statistics and sampling creatures
- expose generator from the package API
- document new functionality in the README
- add tests for the statistics and generator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685787d4908c832ab3f4910d6c6b75bf