### PR TITLE
Improve damage assignment ordering

### DIFF
--- a/magic_combat/__init__.py
+++ b/magic_combat/__init__.py
@@ -6,7 +6,11 @@ from .creature import CombatCreature, Color
 DEFAULT_STARTING_LIFE = 20
 
 from .simulator import CombatResult, CombatSimulator
-from .damage import DamageAssignmentStrategy, MostCreaturesKilledStrategy
+from .damage import (
+    DamageAssignmentStrategy,
+    MostCreaturesKilledStrategy,
+    OptimalDamageStrategy,
+)
 from .blocking_ai import decide_optimal_blocks
 from .utils import calculate_mana_value
 from .gamestate import GameState, PlayerState, has_player_lost
@@ -25,6 +29,7 @@ __all__ = [
     "CombatSimulator",
     "DamageAssignmentStrategy",
     "MostCreaturesKilledStrategy",
+    "OptimalDamageStrategy",
     "decide_optimal_blocks",
     "GameState",
     "PlayerState",

--- a/magic_combat/simulator.py
+++ b/magic_combat/simulator.py
@@ -4,7 +4,11 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
 from .creature import CombatCreature, Color
-from .damage import DamageAssignmentStrategy, MostCreaturesKilledStrategy
+from .damage import (
+    DamageAssignmentStrategy,
+    MostCreaturesKilledStrategy,
+    OptimalDamageStrategy,
+)
 from .gamestate import GameState, PlayerState, has_player_lost
 from . import DEFAULT_STARTING_LIFE
 from .utils import ensure_player_state
@@ -50,7 +54,7 @@ class CombatSimulator:
         self.poison_counters: Dict[str, int] = {}
         self.lifegain: Dict[str, int] = {}
         self._lifegain_applied: Dict[str, int] = {}
-        self.assignment_strategy = strategy or MostCreaturesKilledStrategy()
+        self.assignment_strategy = strategy or OptimalDamageStrategy()
         self.game_state = game_state
         self.provoke_map: Dict[CombatCreature, CombatCreature] = provoke_map or {}
         self.mentor_map: Dict[CombatCreature, CombatCreature] = mentor_map or {}

--- a/tests/combat/test_basic_combat.py
+++ b/tests/combat/test_basic_combat.py
@@ -119,3 +119,15 @@ def test_multiple_attackers_damage_added():
     assert result.damage_to_players["B"] == 4
     assert result.creatures_destroyed == []
 
+
+def test_damage_order_prefers_value_over_kills():
+    """CR 510.1a: The attacking player chooses damage assignment order."""
+    attacker = CombatCreature("Warrior", 5, 5, "A")
+    big = CombatCreature("Big", 4, 4, "B")
+    small1 = CombatCreature("S1", 1, 1, "B")
+    small2 = CombatCreature("S2", 1, 1, "B")
+    link_block(attacker, big, small1, small2)
+    sim = CombatSimulator([attacker], [big, small1, small2])
+    result = sim.simulate()
+    dead = {c.name for c in result.creatures_destroyed}
+    assert dead == {"Warrior", "Big", "S1"}


### PR DESCRIPTION
## Summary
- add `OptimalDamageStrategy` for choosing damage order like the block AI scoring
- use the new strategy as the default in `CombatSimulator`
- export `OptimalDamageStrategy`
- test the value-based damage ordering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685788e0e6c0832a9814dccc5f97a65e