### PR TITLE
Add iteration limit for optimal combat sim

### DIFF
--- a/magic_combat/damage.py
+++ b/magic_combat/damage.py
@@ -2,6 +2,8 @@
 
 from typing import List, Tuple
 
+from .limits import IterationCounter
+
 from .creature import CombatCreature
 
 
@@ -123,6 +125,9 @@ class MostCreaturesKilledStrategy(DamageAssignmentStrategy):
 class OptimalDamageStrategy(DamageAssignmentStrategy):
     """Order blockers to maximize value destroyed similarly to optimal blocks."""
 
+    def __init__(self, counter: "IterationCounter | None" = None) -> None:
+        self.counter = counter
+
     def order_blockers(
         self, attacker: CombatCreature, blockers: List[CombatCreature]
     ) -> List[CombatCreature]:
@@ -152,6 +157,8 @@ class OptimalDamageStrategy(DamageAssignmentStrategy):
                     return self._order
             strat = _Fixed([clone_map[id(b)] for b in perm])
             sim = CombatSimulator([atk], blks, strategy=strat)
+            if self.counter is not None:
+                self.counter.increment()
             result = sim.simulate()
 
             attacker_player = attacker.controller

--- a/magic_combat/limits.py
+++ b/magic_combat/limits.py
@@ -1,0 +1,12 @@
+class IterationCounter:
+    """Track the number of simulated combats and enforce a maximum."""
+
+    def __init__(self, max_iterations: int = int(1e6)) -> None:
+        self.max_iterations = max_iterations
+        self.count = 0
+
+    def increment(self) -> None:
+        """Increment the counter and raise ``RuntimeError`` if the limit is exceeded."""
+        self.count += 1
+        if self.count > self.max_iterations:
+            raise RuntimeError("Maximum combat simulation iterations exceeded")

--- a/scripts/random_combat.py
+++ b/scripts/random_combat.py
@@ -204,6 +204,12 @@ def main() -> None:
         default=42,
         help="Random seed controlling sampling",
     )
+    parser.add_argument(
+        "--max-iterations",
+        type=int,
+        default=int(1e6),
+        help="Maximum combat simulations per scenario",
+    )
     args = parser.parse_args()
 
     random.seed(args.seed)
@@ -267,7 +273,12 @@ def main() -> None:
                         mentor_map[mentor] = random.choice(targets)
 
             try:
-                decide_optimal_blocks(attackers, blockers, game_state=state)
+                decide_optimal_blocks(
+                    attackers,
+                    blockers,
+                    game_state=state,
+                    max_iterations=args.max_iterations,
+                )
                 start_state = copy.deepcopy(state)
                 sim = CombatSimulator(
                     attackers,
@@ -277,7 +288,7 @@ def main() -> None:
                     mentor_map=mentor_map,
                 )
                 result = sim.simulate()
-            except ValueError:
+            except (ValueError, RuntimeError):
                 continue
             break
 


### PR DESCRIPTION
## Summary
- track how many times combat is simulated
- expose a max iteration parameter on `decide_optimal_blocks`
- update the random combat script to skip expensive scenarios
- ensure tests cover the new limit logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68578e42131c832aaaa41738305221d5