### PR TITLE
Refactor parsing utils and add counter test

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ magic_combat/creature.py     ``CombatCreature`` data model
 magic_combat/damage.py       Damage assignment strategies
 magic_combat/simulator.py    ``CombatSimulator`` and ``CombatResult`` classes
 magic_combat/utils.py        Small utility helpers used internally
+magic_combat/parsing.py      Parsing helpers for card data
 magic_combat/random_creature.py Utilities for sampling creatures
 ```
 

--- a/magic_combat/parsing.py
+++ b/magic_combat/parsing.py
@@ -1,0 +1,125 @@
+"""Utility helpers for parsing card data and abilities."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Set
+
+from .creature import Color
+
+# Mapping from short mana cost letters to :class:`Color` enums
+_COLOR_MAP = {
+    "W": Color.WHITE,
+    "U": Color.BLUE,
+    "B": Color.BLACK,
+    "R": Color.RED,
+    "G": Color.GREEN,
+}
+
+_COLOR_NAME_MAP = {
+    "white": Color.WHITE,
+    "blue": Color.BLUE,
+    "black": Color.BLACK,
+    "red": Color.RED,
+    "green": Color.GREEN,
+}
+
+
+def parse_colors(mana_cost: str) -> Set[Color]:
+    """Return the set of colors appearing in ``mana_cost``."""
+    colors: Set[Color] = set()
+    if not mana_cost:
+        return colors
+    for symbol in re.findall(r"{([^{}]+)}", mana_cost):
+        for part in symbol.split("/"):
+            col = _COLOR_MAP.get(part)
+            if col:
+                colors.add(col)
+    return colors
+
+
+def parse_value(text: str, keyword: str) -> int:
+    """Extract the numeric value following ``keyword`` in ``text``."""
+    match = re.search(rf"{keyword}\s*(\d+)", text)
+    if match:
+        return int(match.group(1))
+    return 1
+
+
+def parse_protection(text: str) -> Set[Color]:
+    """Return a set of colors from "protection from" clauses."""
+    colors: Set[Color] = set()
+    for match in re.findall(r"protection from ([^.,\n]+)", text, flags=re.I):
+        parts = re.split(r"\s*and from\s*", match)
+        for part in parts:
+            color = _COLOR_NAME_MAP.get(part.strip().lower())
+            if color:
+                colors.add(color)
+    return colors
+
+
+# Mapping of Scryfall keyword text to :class:`CombatCreature` fields
+_BOOLEAN_KEYWORDS = {
+    "Flying": "flying",
+    "Reach": "reach",
+    "Menace": "menace",
+    "Fear": "fear",
+    "Shadow": "shadow",
+    "Horsemanship": "horsemanship",
+    "Skulk": "skulk",
+    "Vigilance": "vigilance",
+    "First strike": "first_strike",
+    "Double strike": "double_strike",
+    "Deathtouch": "deathtouch",
+    "Trample": "trample",
+    "Lifelink": "lifelink",
+    "Wither": "wither",
+    "Infect": "infect",
+    "Indestructible": "indestructible",
+    "Melee": "melee",
+    "Training": "training",
+    "Mentor": "mentor",
+    "Battalion": "battalion",
+    "Dethrone": "dethrone",
+    "Undying": "undying",
+    "Persist": "persist",
+    "Intimidate": "intimidate",
+    "Daunt": "daunt",
+    "Defender": "defender",
+    "Provoke": "provoke",
+}
+
+# Keywords that include an integer value in the rules text
+_VALUE_KEYWORDS = {
+    "Bushido": "bushido",
+    "Rampage": "rampage",
+    "Frenzy": "frenzy",
+    "Toxic": "toxic",
+    "Afflict": "afflict",
+}
+
+# Keywords that stack when repeated
+_STACKABLE_KEYWORDS = {
+    "Exalted": "exalted_count",
+    "Battle cry": "battle_cry_count",
+    "Flanking": "flanking",
+}
+
+
+def apply_keyword_attributes(keywords: Set[str], oracle_text: str) -> Dict[str, Any]:
+    """Return attribute overrides for ``CombatCreature`` based on keywords."""
+    attrs: Dict[str, Any] = {}
+
+    for key in keywords:
+        if key in _BOOLEAN_KEYWORDS:
+            attrs[_BOOLEAN_KEYWORDS[key]] = True
+        elif key in _STACKABLE_KEYWORDS:
+            field = _STACKABLE_KEYWORDS[key]
+            attrs[field] = attrs.get(field, 0) + 1
+        elif key in _VALUE_KEYWORDS:
+            attrs[_VALUE_KEYWORDS[key]] = parse_value(oracle_text, key)
+    prot = parse_protection(oracle_text)
+    if prot:
+        attrs["protection_colors"] = prot
+    return attrs
+

--- a/magic_combat/scryfall_loader.py
+++ b/magic_combat/scryfall_loader.py
@@ -1,9 +1,13 @@
 import json
 from typing import List, Dict, Any, Iterable
 
-import re
-
-from .creature import CombatCreature, Color
+from .creature import CombatCreature
+from .parsing import (
+    parse_colors as _parse_colors,
+    parse_protection as _parse_protection,
+    parse_value as _parse_value,
+    apply_keyword_attributes,
+)
 
 
 import requests
@@ -95,53 +99,6 @@ def load_cards(path: str) -> List[Dict[str, Any]]:
         return json.load(fh)
 
 
-_COLOR_MAP = {
-    "W": Color.WHITE,
-    "U": Color.BLUE,
-    "B": Color.BLACK,
-    "R": Color.RED,
-    "G": Color.GREEN,
-}
-
-_COLOR_NAME_MAP = {
-    "white": Color.WHITE,
-    "blue": Color.BLUE,
-    "black": Color.BLACK,
-    "red": Color.RED,
-    "green": Color.GREEN,
-}
-
-
-def _parse_colors(mana_cost: str) -> set[Color]:
-    """Extract the set of colors appearing in ``mana_cost``."""
-    colors: set[Color] = set()
-    if not mana_cost:
-        return colors
-    for symbol in re.findall(r"{([^{}]+)}", mana_cost):
-        for part in symbol.split("/"):
-            col = _COLOR_MAP.get(part)
-            if col:
-                colors.add(col)
-    return colors
-
-
-def _parse_value(text: str, keyword: str) -> int:
-    match = re.search(rf"{keyword}\\s*(\d+)", text)
-    if match:
-        return int(match.group(1))
-    return 1
-
-
-def _parse_protection(text: str) -> set[Color]:
-    """Return a set of colors from "protection from" clauses."""
-    colors: set[Color] = set()
-    for match in re.findall(r"protection from ([^.,\n]+)", text, flags=re.I):
-        parts = re.split(r"\s*and from\s*", match)
-        for part in parts:
-            color = _COLOR_NAME_MAP.get(part.strip().lower())
-            if color:
-                colors.add(color)
-    return colors
 
 
 def card_to_creature(card: Dict[str, Any], controller: str) -> CombatCreature:
@@ -169,81 +126,7 @@ def card_to_creature(card: Dict[str, Any], controller: str) -> CombatCreature:
         "colors": _parse_colors(mana_cost),
     }
 
-    if "Flying" in keywords:
-        kwargs["flying"] = True
-    if "Reach" in keywords:
-        kwargs["reach"] = True
-    if "Menace" in keywords:
-        kwargs["menace"] = True
-    if "Fear" in keywords:
-        kwargs["fear"] = True
-    if "Shadow" in keywords:
-        kwargs["shadow"] = True
-    if "Horsemanship" in keywords:
-        kwargs["horsemanship"] = True
-    if "Skulk" in keywords:
-        kwargs["skulk"] = True
-    if "Vigilance" in keywords:
-        kwargs["vigilance"] = True
-    if "First strike" in keywords:
-        kwargs["first_strike"] = True
-    if "Double strike" in keywords:
-        kwargs["double_strike"] = True
-    if "Deathtouch" in keywords:
-        kwargs["deathtouch"] = True
-    if "Trample" in keywords:
-        kwargs["trample"] = True
-    if "Lifelink" in keywords:
-        kwargs["lifelink"] = True
-    if "Wither" in keywords:
-        kwargs["wither"] = True
-    if "Infect" in keywords:
-        kwargs["infect"] = True
-    if "Indestructible" in keywords:
-        kwargs["indestructible"] = True
-
-    if "Bushido" in keywords:
-        kwargs["bushido"] = _parse_value(oracle_text, "Bushido")
-    if "Flanking" in keywords:
-        kwargs["flanking"] = kwargs.get("flanking", 0) + 1
-    if "Rampage" in keywords:
-        kwargs["rampage"] = _parse_value(oracle_text, "Rampage")
-    if "Exalted" in keywords:
-        kwargs["exalted_count"] = kwargs.get("exalted_count", 0) + 1
-    if "Battle cry" in keywords:
-        kwargs["battle_cry_count"] = kwargs.get("battle_cry_count", 0) + 1
-    if "Melee" in keywords:
-        kwargs["melee"] = True
-    if "Training" in keywords:
-        kwargs["training"] = True
-    if "Mentor" in keywords:
-        kwargs["mentor"] = True
-    if "Frenzy" in keywords:
-        kwargs["frenzy"] = _parse_value(oracle_text, "Frenzy")
-    if "Battalion" in keywords:
-        kwargs["battalion"] = True
-    if "Dethrone" in keywords:
-        kwargs["dethrone"] = True
-    if "Undying" in keywords:
-        kwargs["undying"] = True
-    if "Persist" in keywords:
-        kwargs["persist"] = True
-    if "Intimidate" in keywords:
-        kwargs["intimidate"] = True
-    if "Daunt" in keywords:
-        kwargs["daunt"] = True
-    if "Defender" in keywords:
-        kwargs["defender"] = True
-    if "Afflict" in keywords:
-        kwargs["afflict"] = _parse_value(oracle_text, "Afflict")
-    if "Toxic" in keywords:
-        kwargs["toxic"] = _parse_value(oracle_text, "Toxic")
-    if "Provoke" in keywords:
-        kwargs["provoke"] = True
-
-    prot_colors = _parse_protection(oracle_text)
-    if prot_colors:
-        kwargs["protection_colors"] = prot_colors
+    kwargs.update(apply_keyword_attributes(keywords, oracle_text))
 
     return CombatCreature(**kwargs)
 

--- a/tests/test_counters.py
+++ b/tests/test_counters.py
@@ -138,3 +138,13 @@ def test_annihilation_multiple_pairs():
     sim.simulate()
     assert blk.plus1_counters == 0
     assert blk.minus1_counters == 1
+
+
+def test_apply_counter_annihilation():
+    """CR 704.5q: +1/+1 and -1/-1 counters annihilate one another."""
+    cr = CombatCreature("Test", 2, 2, "A")
+    cr.plus1_counters = 3
+    cr.minus1_counters = 1
+    cr.apply_counter_annihilation()
+    assert cr.plus1_counters == 2
+    assert cr.minus1_counters == 0


### PR DESCRIPTION
## Summary
- extract parsing helpers into new `parsing` module
- simplify `card_to_creature` using the new helpers
- document new module in README
- test counter annihilation directly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685790e0e368832a927d85afafc3d6e9