### PR TITLE
Add simple blocking heuristic and scenario filter

### DIFF
--- a/magic_combat/__init__.py
+++ b/magic_combat/__init__.py
@@ -11,7 +11,7 @@ from .damage import (
     MostCreaturesKilledStrategy,
     OptimalDamageStrategy,
 )
-from .blocking_ai import decide_optimal_blocks
+from .blocking_ai import decide_optimal_blocks, decide_simple_blocks
 from .utils import calculate_mana_value
 from .gamestate import GameState, PlayerState, has_player_lost
 from .scryfall_loader import (
@@ -32,6 +32,7 @@ __all__ = [
     "MostCreaturesKilledStrategy",
     "OptimalDamageStrategy",
     "decide_optimal_blocks",
+    "decide_simple_blocks",
     "GameState",
     "PlayerState",
     "has_player_lost",

--- a/scripts/random_combat.py
+++ b/scripts/random_combat.py
@@ -272,6 +272,21 @@ def main() -> None:
                     if targets:
                         mentor_map[mentor] = random.choice(targets)
 
+            # Compute simple heuristic assignment on copies
+            simple_atk = copy.deepcopy(attackers)
+            simple_blk = copy.deepcopy(blockers)
+            simple_state = copy.deepcopy(state)
+            try:
+                decide_simple_blocks(simple_atk, simple_blk, game_state=simple_state)
+                sim_check = CombatSimulator(simple_atk, simple_blk, game_state=simple_state)
+                sim_check.validate_blocking()
+                atk_map = {id(a): i for i, a in enumerate(simple_atk)}
+                simple_assignment = tuple(
+                    atk_map.get(id(b.blocking), None) for b in simple_blk
+                )
+            except ValueError:
+                simple_assignment = None
+
             try:
                 decide_optimal_blocks(
                     attackers,
@@ -279,57 +294,67 @@ def main() -> None:
                     game_state=state,
                     max_iterations=args.max_iterations,
                 )
-                start_state = copy.deepcopy(state)
-                sim = CombatSimulator(
-                    attackers,
-                    blockers,
-                    game_state=state,
-                    provoke_map=provoke_map,
-                    mentor_map=mentor_map,
-                )
-                result = sim.simulate()
             except (ValueError, RuntimeError):
                 continue
+
+            opt_map = {id(a): i for i, a in enumerate(attackers)}
+            optimal_assignment = tuple(
+                opt_map.get(id(b.blocking), None) for b in blockers
+            )
+            if (
+                simple_assignment is not None
+                and simple_assignment == optimal_assignment
+            ):
+                continue
+
+            start_state = copy.deepcopy(state)
+            sim = CombatSimulator(
+                attackers,
+                blockers,
+                game_state=state,
+                provoke_map=provoke_map,
+                mentor_map=mentor_map,
+            )
+            result = sim.simulate()
             break
 
-        print(f"\n=== Scenario {i+1} ===")
-        print("Starting life totals:")
-        for p in ["A", "B"]:
-            ps = start_state.players[p]
-            print(f"  Player {p}: {ps.life} life, {ps.poison} poison")
+    print(f"\n=== Scenario {i+1} ===")
+    print("Starting life totals:")
+    for p in ["A", "B"]:
+        ps = start_state.players[p]
+        print(f"  Player {p}: {ps.life} life, {ps.poison} poison")
 
-        print("Attackers:")
-        for atk in start_state.players["A"].creatures:
-            print(f"  {summarize_creature(atk)}, {_blocker_value(atk)}")
-        print("Blockers:")
-        for blk in start_state.players["B"].creatures:
-            print(f"  {summarize_creature(blk)}, {_blocker_value(blk)}")
+    print("Attackers:")
+    for atk in start_state.players["A"].creatures:
+        print(f"  {summarize_creature(atk)}, {_blocker_value(atk)}")
+    print("Blockers:")
+    for blk in start_state.players["B"].creatures:
+        print(f"  {summarize_creature(blk)}, {_blocker_value(blk)}")
 
-        prov_map_display = {a.name: b.name for a, b in provoke_map.items()} if provoke_map else None
-        mentor_map_display = {m.name: t.name for m, t in mentor_map.items()} if mentor_map else None
+    prov_map_display = {a.name: b.name for a, b in provoke_map.items()} if provoke_map else None
+    mentor_map_display = {m.name: t.name for m, t in mentor_map.items()} if mentor_map else None
 
+    print("Block assignments:")
+    for atk in start_state.players["A"].creatures:
+        blocks = ", ".join(b.name for b in atk.blocked_by) or "unblocked"
+        print(f"  {atk.name} -> {blocks}")
+    for blk in start_state.players["B"].creatures:
+        target = blk.blocking.name if blk.blocking else "none"
+        print(f"  {blk.name} -> {target}")
+    if prov_map_display:
+        print("Provoke targets:", prov_map_display)
+    if mentor_map_display:
+        print("Mentor targets:", mentor_map_display)
 
-        print("Block assignments:")
-        for atk in start_state.players["A"].creatures:
-            blocks = ", ".join(b.name for b in atk.blocked_by) or "unblocked"
-            print(f"  {atk.name} -> {blocks}")
-        for blk in start_state.players["B"].creatures:
-            target = blk.blocking.name if blk.blocking else "none"
-            print(f"  {blk.name} -> {target}")
-        if prov_map_display:
-            print("Provoke targets:", prov_map_display)
-        if mentor_map_display:
-            print("Mentor targets:", mentor_map_display)
+    print("Outcome:")
+    print(result)
 
-        print("Outcome:")
-        print(result)
-
-        print("Final state:")
-        for p in ["A", "B"]:
-            print_player_state(f"Player {p}", state.players[p], result.creatures_destroyed)
-        if result.players_lost:
-            print("Players lost:", ", ".join(result.players_lost))
-        print()
+    print("Final state:")
+    for p in ["A", "B"]:
+        print_player_state(f"Player {p}", state.players[p], result.creatures_destroyed)
+    if result.players_lost:
+        print("Players lost:", ", ".join(result.players_lost))
+    print()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add quick non-searching blocking AI that trades and chump blocks
- export the new function from the package
- in `random_combat`, filter out cases where the quick AI matches the optimal blocks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685793c064e8832a8ec1854374920b78