### PR TITLE
Fix provoke handling in simple block AI

### DIFF
--- a/magic_combat/blocking_ai.py
+++ b/magic_combat/blocking_ai.py
@@ -189,6 +189,7 @@ def decide_simple_blocks(
     attackers: List[CombatCreature],
     blockers: List[CombatCreature],
     game_state: Optional[GameState] = None,
+    provoke_map: Optional[dict[CombatCreature, CombatCreature]] = None,
 ) -> None:
     """Assign blocks using a simple non-searching heuristic."""
 
@@ -205,6 +206,12 @@ def decide_simple_blocks(
     poison = game_state.players[defender].poison if game_state else 0
 
     available = list(blockers)
+    if provoke_map:
+        for attacker, target in provoke_map.items():
+            if attacker in attackers and target in available and _can_block(attacker, target):
+                target.blocking = attacker
+                attacker.blocked_by.append(target)
+                available.remove(target)
     attackers_sorted = sorted(attackers, key=_creature_value, reverse=True)
 
     # First pass: take favorable 1:1 trades

--- a/scripts/random_combat.py
+++ b/scripts/random_combat.py
@@ -318,7 +318,12 @@ def main() -> None:
             simple_blk = copy.deepcopy(blockers)
             simple_state = copy.deepcopy(state)
             try:
-                decide_simple_blocks(simple_atk, simple_blk, game_state=simple_state)
+                decide_simple_blocks(
+                    simple_atk,
+                    simple_blk,
+                    game_state=simple_state,
+                    provoke_map=provoke_map,
+                )
                 sim_check = CombatSimulator(simple_atk, simple_blk, game_state=simple_state)
                 sim_check.validate_blocking()
                 atk_map = {id(a): i for i, a in enumerate(simple_atk)}

--- a/tests/combat/test_simple_block_ai.py
+++ b/tests/combat/test_simple_block_ai.py
@@ -1,0 +1,24 @@
+from magic_combat import (
+    CombatCreature,
+    CombatSimulator,
+    GameState,
+    PlayerState,
+    decide_simple_blocks,
+)
+
+
+def test_simple_ai_respects_provoke():
+    """CR 702.40a: Provoke requires the chosen creature to block if able."""
+    atk = CombatCreature("Taunter", 2, 2, "A", provoke=True)
+    blk = CombatCreature("Guard", 2, 2, "B")
+    state = GameState(
+        players={
+            "A": PlayerState(life=20, creatures=[atk]),
+            "B": PlayerState(life=20, creatures=[blk]),
+        }
+    )
+    decide_simple_blocks([atk], [blk], game_state=state, provoke_map={atk: blk})
+    sim = CombatSimulator([atk], [blk], game_state=state, provoke_map={atk: blk})
+    sim.validate_blocking()
+    assert blk.blocking is atk
+    assert atk.blocked_by == [blk]


### PR DESCRIPTION
## Summary
- handle `provoke_map` in `decide_simple_blocks`
- pass provoke information from `random_combat.py`
- add regression test for the simple blocking AI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685797578c6c832a8fa57eafd7e4da62