### PR TITLE
Fix provoke blocking validation

### DIFF
--- a/magic_combat/simulator.py
+++ b/magic_combat/simulator.py
@@ -172,6 +172,30 @@ class CombatSimulator:
                 if attacker.protection_colors & blocker.colors:
                     raise ValueError("Attacker has protection from blocker's color")
 
+    def _can_block(self, attacker: CombatCreature, blocker: CombatCreature) -> bool:
+        """Return ``True`` if ``blocker`` can legally block ``attacker``."""
+        if attacker.unblockable:
+            return False
+        if attacker.flying and not (blocker.flying or blocker.reach):
+            return False
+        if attacker.shadow and not blocker.shadow:
+            return False
+        if attacker.horsemanship and not blocker.horsemanship:
+            return False
+        if attacker.skulk and blocker.effective_power() > attacker.effective_power():
+            return False
+        if attacker.daunt and blocker.effective_power() <= 2:
+            return False
+        if attacker.fear and not (blocker.artifact or Color.BLACK in blocker.colors):
+            return False
+        if attacker.intimidate and not (
+            blocker.artifact or (attacker.colors & blocker.colors)
+        ):
+            return False
+        if attacker.protection_colors & blocker.colors:
+            return False
+        return True
+
     def _check_provoke(self) -> None:
         """Verify provoke targets are blocking as required."""
         for attacker, target in self.provoke_map.items():
@@ -179,7 +203,7 @@ class CombatSimulator:
                 raise ValueError("Provoke attacker not in combat")
             if target not in self.defenders:
                 raise ValueError("Provoke target not defending creature")
-            if target.blocking is not attacker:
+            if self._can_block(attacker, target) and target.blocking is not attacker:
                 raise ValueError("Provoke target failed to block")
 
     def _check_mentor(self) -> None:

--- a/tests/test_daunt.py
+++ b/tests/test_daunt.py
@@ -131,8 +131,7 @@ def test_daunt_provoke_small_blocker_fails():
     atk = CombatCreature("Taunter", 3, 3, "A", daunt=True)
     blk = CombatCreature("Guard", 2, 2, "B")
     sim = CombatSimulator([atk], [blk], provoke_map={atk: blk})
-    with pytest.raises(ValueError):
-        sim.validate_blocking()
+    sim.validate_blocking()
 
 
 # 12

--- a/tests/test_provoke.py
+++ b/tests/test_provoke.py
@@ -268,3 +268,12 @@ def test_provoke_wither_applies_counters():
     result = sim.simulate()
     assert blk.minus1_counters == 2
     assert blk in result.creatures_destroyed
+
+
+def test_provoke_target_cannot_block():
+    """CR 702.40a: The chosen creature blocks if able; otherwise nothing happens."""
+    atk = CombatCreature("Dragon", 3, 3, "A", flying=True, provoke=True)
+    blk = CombatCreature("Bear", 2, 2, "B")
+    sim = CombatSimulator([atk], [blk], provoke_map={atk: blk})
+    sim.validate_blocking()
+    result = sim.simulate()


### PR DESCRIPTION
## Summary
- allow provoked creature to skip blocking if unable to block legally
- cover provoke when blocker can't block with a new test
- adjust daunt+provoke test for the new behavior

## Testing
- `pytest -q`
- `PYTHONPATH=. python scripts/random_combat.py --seed 23 --cards tests/example_test_cards.json --iterations 1`

------
https://chatgpt.com/codex/tasks/task_e_68579aa08854832abd604f84b2ae2ad6