### PR TITLE
Add unique optimal scenario filter

### DIFF
--- a/magic_combat/blocking_ai.py
+++ b/magic_combat/blocking_ai.py
@@ -123,7 +123,7 @@ def decide_optimal_blocks(
     """
 
     if not blockers:
-        return 0
+        return 0, 1
 
     counter = IterationCounter(max_iterations)
 
@@ -131,6 +131,7 @@ def decide_optimal_blocks(
 
     best: Optional[Tuple[Optional[int], ...]] = None
     best_score: Optional[Tuple] = None
+    optimal_count = 0
 
     for assignment in product(*options):
         score = _evaluate_assignment(
@@ -143,6 +144,9 @@ def decide_optimal_blocks(
         if best_score is None or score < best_score:
             best_score = score
             best = tuple(assignment)
+            optimal_count = 1
+        elif score == best_score:
+            optimal_count += 1
 
     # Apply the chosen assignment to the real objects
     for atk in attackers:
@@ -157,7 +161,7 @@ def decide_optimal_blocks(
                 blk.blocking = atk
                 atk.blocked_by.append(blk)
 
-    return counter.count
+    return counter.count, optimal_count
 
 
 def _can_block(attacker: CombatCreature, blocker: CombatCreature) -> bool:

--- a/scripts/random_combat.py
+++ b/scripts/random_combat.py
@@ -247,6 +247,11 @@ def main() -> None:
         action="store_true",
         help="Use randomly generated creatures instead of real cards",
     )
+    parser.add_argument(
+        "--unique-optimal",
+        action="store_true",
+        help="Skip scenarios without a single optimal blocking set",
+    )
     args = parser.parse_args()
 
     random.seed(args.seed)
@@ -334,12 +339,17 @@ def main() -> None:
                 simple_assignment = None
 
             try:
-                decide_optimal_blocks(
+                iters, opt_count = decide_optimal_blocks(
                     attackers,
                     blockers,
                     game_state=state,
                     max_iterations=args.max_iterations,
                 )
+                if args.unique_optimal and opt_count != 1:
+                    print(
+                        f"Skipping scenario {i+1}_{attempts}: {opt_count} optimal assignments"
+                    )
+                    continue
             except (ValueError, RuntimeError):
                 continue
 


### PR DESCRIPTION
## Summary
- count how many blocking assignments are optimal in the blocking AI
- return that count from `decide_optimal_blocks`
- add `--unique-optimal` option in `random_combat` to require a single optimal blocking set

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68579e150f00832aa57dab3848af3540