### PR TITLE
Support provoke in optimal block AI

### DIFF
--- a/magic_combat/blocking_ai.py
+++ b/magic_combat/blocking_ai.py
@@ -25,6 +25,7 @@ def _evaluate_assignment(
     assignment: Sequence[Optional[int]],
     state: Optional[GameState],
     counter: "IterationCounter",
+    provoke_map: Optional[dict[CombatCreature, CombatCreature]] = None,
 ) -> Tuple[int, float, int, int, int, Tuple[Optional[int], ...]]:
     """Simulate combat for a blocking assignment and score it."""
     atks = deepcopy(list(attackers))
@@ -41,6 +42,7 @@ def _evaluate_assignment(
         blks,
         game_state=deepcopy(state),
         strategy=OptimalDamageStrategy(counter),
+        provoke_map=provoke_map,
     )
     try:
         counter.increment()
@@ -106,6 +108,7 @@ def decide_optimal_blocks(
     game_state: Optional[GameState] = None,
     *,
     max_iterations: int = int(1e6),
+    provoke_map: Optional[dict[CombatCreature, CombatCreature]] = None,
 ) -> int:
     """Assign blockers to attackers using a heuristic evaluation.
 
@@ -140,6 +143,7 @@ def decide_optimal_blocks(
             assignment,
             game_state,
             counter,
+            provoke_map,
         )
         if best_score is None or score < best_score:
             best_score = score

--- a/scripts/random_combat.py
+++ b/scripts/random_combat.py
@@ -344,6 +344,7 @@ def main() -> None:
                     blockers,
                     game_state=state,
                     max_iterations=args.max_iterations,
+                    provoke_map=provoke_map,
                 )
                 if args.unique_optimal and opt_count != 1:
                     print(

--- a/tests/combat/test_block_ai.py
+++ b/tests/combat/test_block_ai.py
@@ -378,3 +378,20 @@ def test_iteration_limit_allows_fast_run():
     duration = time.perf_counter() - start
     assert duration < 2
 
+
+def test_optimal_ai_respects_provoke():
+    """CR 702.40a: Provoke requires the chosen creature to block if able."""
+    atk = CombatCreature("Taunter", 2, 2, "A", provoke=True)
+    blk = CombatCreature("Guard", 2, 2, "B")
+    state = GameState(
+        players={
+            "A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]),
+            "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[blk]),
+        }
+    )
+    decide_optimal_blocks([atk], [blk], game_state=state, provoke_map={atk: blk})
+    sim = CombatSimulator([atk], [blk], game_state=state, provoke_map={atk: blk})
+    sim.validate_blocking()
+    assert blk.blocking is atk
+    assert atk.blocked_by == [blk]
+


### PR DESCRIPTION
## Summary
- let `_evaluate_assignment` pass `provoke_map` to the simulator
- add `provoke_map` parameter to `decide_optimal_blocks`
- wire provoke into the random combat script
- test provoke handling for the optimal block AI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857af7ed940832a8bb4aa397c5877e5