### PR TITLE
Handle provoke targets in optimal blocking AI

### DIFF
--- a/scripts/random_combat.py
+++ b/scripts/random_combat.py
@@ -343,6 +343,7 @@ def main() -> None:
                     attackers,
                     blockers,
                     game_state=state,
+                    provoke_map=provoke_map,
                     max_iterations=args.max_iterations,
                 )
                 if args.unique_optimal and opt_count != 1:

--- a/tests/combat/test_block_ai.py
+++ b/tests/combat/test_block_ai.py
@@ -11,6 +11,23 @@ import pytest
 import time
 
 
+def test_optimal_ai_respects_provoke():
+    """CR 702.40a: Provoke requires the chosen creature to block if able."""
+    atk = CombatCreature("Taunter", 2, 2, "A", provoke=True)
+    blk = CombatCreature("Guard", 2, 2, "B")
+    state = GameState(
+        players={
+            "A": PlayerState(life=20, creatures=[atk]),
+            "B": PlayerState(life=20, creatures=[blk]),
+        }
+    )
+    decide_optimal_blocks([atk], [blk], game_state=state, provoke_map={atk: blk})
+    sim = CombatSimulator([atk], [blk], game_state=state, provoke_map={atk: blk})
+    sim.validate_blocking()
+    assert blk.blocking is atk
+    assert atk.blocked_by == [blk]
+
+
 def test_ai_blocks_to_prevent_lethal():
     """CR 104.3a: A player with 0 or less life loses the game."""
     atk = CombatCreature("Ogre", 3, 3, "A")


### PR DESCRIPTION
## Summary
- respect provoked blockers when determining optimal blocks
- wire provoke support through `decide_optimal_blocks` and simulator calls
- cover provoke logic in the optimal blocking tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857af7ed940832a8bb4aa397c5877e5