### PR TITLE
Fix optimal_count logic

### DIFF
--- a/tests/combat/test_block_ai.py
+++ b/tests/combat/test_block_ai.py
@@ -395,3 +395,19 @@ def test_iteration_limit_allows_fast_run():
     duration = time.perf_counter() - start
     assert duration < 2
 
+
+def test_ai_optimal_count_ignores_tiebreaker():
+    """CR 509.1a: The defending player chooses how creatures block."""
+    a1 = CombatCreature("A1", 2, 2, "A")
+    a2 = CombatCreature("A2", 2, 2, "A")
+    b1 = CombatCreature("B1", 2, 2, "B")
+    b2 = CombatCreature("B2", 2, 2, "B")
+    state = GameState(
+        players={
+            "A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[a1, a2]),
+            "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[b1, b2]),
+        }
+    )
+    _, opt = decide_optimal_blocks([a1, a2], [b1, b2], game_state=state)
+    assert opt == 2
+


### PR DESCRIPTION
## Summary
- clarify docs for `decide_optimal_blocks`
- update `optimal_count` logic so only numerical criteria are compared
- test that `optimal_count` ignores the tie-breaking criterion
- ensure optimal_count only resets when numeric portion improves

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6857b3b94d58832aa3c82a464a67b3ad