### PR TITLE
Support counters in random combat

### DIFF
--- a/magic_combat/random_creature.py
+++ b/magic_combat/random_creature.py
@@ -156,3 +156,21 @@ def generate_random_creature(
         elif ability == "protection":
             kwargs["protection_colors"] = {random.choice(list(Color))}
     return CombatCreature(**kwargs)
+
+
+
+def assign_random_counters(creatures: Iterable[CombatCreature], *, rng: random.Random | None = None) -> None:
+    """Add random +1/+1 or -1/-1 counters to ``creatures``.
+
+    A creature receives at most one kind of counter and never enough -1/-1
+    counters to reduce its toughness below zero.
+    """
+    rng = rng or random
+    for cr in creatures:
+        roll = rng.random()
+        if roll < 0.1:
+            cr.plus1_counters = rng.randint(1, 2)
+        elif roll < 0.2:
+            max_minus = min(2, cr.toughness)
+            if max_minus > 0:
+                cr.minus1_counters = rng.randint(1, max_minus)

--- a/scripts/random_combat.py
+++ b/scripts/random_combat.py
@@ -17,6 +17,7 @@ from magic_combat import (
     fetch_french_vanilla_cards,
     compute_card_statistics,
     generate_random_creature,
+    assign_random_counters,
     decide_optimal_blocks,
     decide_simple_blocks,
     CombatSimulator,
@@ -283,6 +284,8 @@ def main() -> None:
                     blockers = cards_to_creatures((cards[j] for j in blk_idx), "B")
             except ValueError:
                 continue
+
+            assign_random_counters(attackers + blockers)
 
             poison_relevant = any(c.infect or c.toxic for c in attackers + blockers)
 

--- a/tests/test_random_counters.py
+++ b/tests/test_random_counters.py
@@ -1,0 +1,14 @@
+import random
+from magic_combat import CombatCreature
+from magic_combat.random_creature import assign_random_counters
+
+
+def test_assign_random_counters_valid():
+    """CR 704.5q says +1/+1 and -1/-1 counters annihilate each other."""
+    rng = random.Random(123)
+    creatures = [CombatCreature("A", 2, 2, "A"), CombatCreature("B", 3, 1, "B")]
+    assign_random_counters(creatures, rng=rng)
+    for c in creatures:
+        assert not (c.plus1_counters and c.minus1_counters)
+        assert c.toughness - c.minus1_counters >= 0
+


### PR DESCRIPTION
## Summary
- allow specifying counters for random creatures
- randomly assign +1/+1 or -1/-1 counters in `random_combat`
- test that random counter generation never produces invalid creatures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68582fe0da50832aa7d14487c20347a3