### PR TITLE
Add complex combat and fuzz tests

### DIFF
--- a/tests/combat/test_block_damage_extra.py
+++ b/tests/combat/test_block_damage_extra.py
@@ -1,0 +1,93 @@
+import random
+from itertools import product
+
+import pytest
+
+from magic_combat import (
+    CombatCreature,
+    CombatSimulator,
+    GameState,
+    PlayerState,
+    decide_optimal_blocks,
+)
+from magic_combat.blocking_ai import _evaluate_assignment, _can_block
+from magic_combat.limits import IterationCounter
+from tests.conftest import link_block
+
+
+def test_optimal_damage_prefers_high_value_blocker():
+    """CR 510.1a: The attacking player chooses damage assignment order."""
+    atk = CombatCreature("Crusher", 4, 4, "A", trample=True)
+    small = CombatCreature("Squire", 2, 2, "B")
+    big = CombatCreature("Knight", 3, 3, "B")
+    link_block(atk, small, big)
+    sim = CombatSimulator([atk], [small, big])
+    result = sim.simulate()
+    dead = {c.name for c in result.creatures_destroyed}
+    assert dead == {"Knight", "Crusher"}
+    assert small not in result.creatures_destroyed
+    assert result.damage_to_players.get("B", 0) == 0
+
+
+def test_ai_uses_deathtouch_on_biggest_attacker():
+    """CR 702.2b: Any nonzero damage from a creature with deathtouch is lethal."""
+    giant = CombatCreature("Giant", 6, 6, "A")
+    goblin = CombatCreature("Goblin", 2, 2, "A")
+    snake = CombatCreature("Snake", 2, 2, "B", deathtouch=True)
+    knight = CombatCreature("Knight", 4, 4, "B")
+    state = GameState(
+        players={
+            "A": PlayerState(life=20, creatures=[giant, goblin]),
+            "B": PlayerState(life=20, creatures=[snake, knight]),
+        }
+    )
+    decide_optimal_blocks([giant, goblin], [snake, knight], game_state=state)
+    assert snake.blocking is giant
+    assert knight.blocking is goblin
+    sim = CombatSimulator([giant, goblin], [snake, knight], game_state=state)
+    result = sim.simulate()
+    dead = {c.name for c in result.creatures_destroyed}
+    assert dead == {"Giant", "Snake", "Goblin"}
+
+
+def _compute_best_assignment(atk, blk, state):
+    counter = IterationCounter(1000)
+    options = []
+    for b in blk:
+        opts = [None] + [i for i, a in enumerate(atk) if _can_block(a, b)]
+        options.append(opts)
+    best = None
+    best_score = None
+    for ass in product(*options):
+        score = _evaluate_assignment(atk, blk, ass, state, counter)
+        if best_score is None or score < best_score:
+            best_score = score
+            best = ass
+    return best
+
+
+@pytest.mark.parametrize("seed", [0, 1, 2, 3, 4])
+def test_fuzz_blocking_optimal(seed):
+    """CR 509.1a: The defending player chooses how creatures block."""
+    rng = random.Random(seed)
+    attackers = [
+        CombatCreature(f"A{i}", rng.randint(1, 5), rng.randint(1, 5), "A")
+        for i in range(2)
+    ]
+    blockers = [
+        CombatCreature(f"B{i}", rng.randint(1, 5), rng.randint(1, 5), "B")
+        for i in range(2)
+    ]
+    state = GameState(
+        players={
+            "A": PlayerState(life=20, creatures=list(attackers)),
+            "B": PlayerState(life=20, creatures=list(blockers)),
+        }
+    )
+    expected = _compute_best_assignment(attackers, blockers, state)
+    decide_optimal_blocks(attackers, blockers, game_state=state)
+    chosen = tuple(
+        attackers.index(b.blocking) if b.blocking is not None else None
+        for b in blockers
+    )
+    assert chosen == expected


### PR DESCRIPTION
## Summary
- add tests covering advanced damage assignment and blocking heuristics
- verify deathtouch blockers are assigned to high-value attackers
- fuzz combat scenarios with random seeds to ensure optimal decisions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685834ffdfd0832aad0a647078b15bd0