### PR TITLE
Add tapped defenders to random combat

### DIFF
--- a/magic_combat/__init__.py
+++ b/magic_combat/__init__.py
@@ -17,7 +17,12 @@ from .scryfall_loader import (
     card_to_creature,
     cards_to_creatures,
 )
-from .random_creature import compute_card_statistics, generate_random_creature
+from .random_creature import (
+    compute_card_statistics,
+    generate_random_creature,
+    assign_random_counters,
+    assign_random_tapped,
+)
 
 __all__ = [
     "CombatCreature",
@@ -40,4 +45,6 @@ __all__ = [
     "cards_to_creatures",
     "compute_card_statistics",
     "generate_random_creature",
+    "assign_random_counters",
+    "assign_random_tapped",
 ]

--- a/magic_combat/random_creature.py
+++ b/magic_combat/random_creature.py
@@ -174,3 +174,21 @@ def assign_random_counters(creatures: Iterable[CombatCreature], *, rng: random.R
             max_minus = min(2, cr.toughness)
             if max_minus > 0:
                 cr.minus1_counters = rng.randint(1, max_minus)
+
+
+def assign_random_tapped(
+    creatures: Iterable[CombatCreature], *, rng: random.Random | None = None, prob: float = 0.3
+) -> None:
+    """Randomly tap creatures without vigilance.
+
+    CR 302.2 states that tapped creatures can't attack or block. Vigilance
+    (CR 702.21b) keeps a creature from tapping when it attacks, so vigilant
+    defenders remain untapped here.
+    """
+
+    rng = rng or random
+    for cr in creatures:
+        if cr.vigilance:
+            cr.tapped = False
+        elif rng.random() < prob:
+            cr.tapped = True

--- a/scripts/random_combat.py
+++ b/scripts/random_combat.py
@@ -18,6 +18,7 @@ from magic_combat import (
     compute_card_statistics,
     generate_random_creature,
     assign_random_counters,
+    assign_random_tapped,
     decide_optimal_blocks,
     decide_simple_blocks,
     CombatSimulator,
@@ -286,6 +287,7 @@ def main() -> None:
                 continue
 
             assign_random_counters(attackers + blockers)
+            assign_random_tapped(blockers)
 
             poison_relevant = any(c.infect or c.toxic for c in attackers + blockers)
 
@@ -309,6 +311,8 @@ def main() -> None:
                 for atk in attackers
                 if atk.provoke
             }
+            for blk in provoke_map.values():
+                blk.tapped = False
 
             mentor_map = {}
             for mentor in attackers:

--- a/tests/test_random_tapped.py
+++ b/tests/test_random_tapped.py
@@ -1,0 +1,17 @@
+import random
+from magic_combat import CombatCreature
+from magic_combat.random_creature import assign_random_tapped
+
+
+def test_assign_random_tapped_respects_vigilance():
+    """CR 302.2 & 702.21b: Tapped creatures can't block and vigilance keeps them untapped."""
+    rng = random.Random(42)
+    creatures = [
+        CombatCreature("A", 2, 2, "B"),
+        CombatCreature("B", 2, 2, "B", vigilance=True),
+        CombatCreature("C", 2, 2, "B"),
+    ]
+    assign_random_tapped(creatures, rng=rng, prob=1.0)
+    assert creatures[0].tapped
+    assert not creatures[1].tapped
+    assert creatures[2].tapped


### PR DESCRIPTION
## Summary
- export `assign_random_counters` and new `assign_random_tapped`
- support randomly tapped defenders in `random_combat` script
- implement `assign_random_tapped` helper
- test tapping respects vigilance

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858354d0b80832abdbc5017d4ab6500