### PR TITLE
Fix unused variable in provoke test

### DIFF
--- a/tests/test_provoke.py
+++ b/tests/test_provoke.py
@@ -276,4 +276,4 @@ def test_provoke_target_cannot_block():
     blk = CombatCreature("Bear", 2, 2, "B")
     sim = CombatSimulator([atk], [blk], provoke_map={atk: blk})
     sim.validate_blocking()
-    result = sim.simulate()
+    sim.simulate()


### PR DESCRIPTION
## Summary
- remove unused `result` variable from `tests/test_provoke.py`

## Testing
- `flake8 tests/test_provoke.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685850eb6e48832a847e07c4724feb51