### PR TITLE
Fix import list

### DIFF
--- a/magic_combat/scryfall_loader.py
+++ b/magic_combat/scryfall_loader.py
@@ -4,8 +4,6 @@ from typing import List, Dict, Any, Iterable
 from .creature import CombatCreature
 from .parsing import (
     parse_colors as _parse_colors,
-    parse_protection as _parse_protection,
-    parse_value as _parse_value,
     apply_keyword_attributes,
 )
 

--- a/tests/test_scryfall_loader.py
+++ b/tests/test_scryfall_loader.py
@@ -2,11 +2,11 @@ from pathlib import Path
 
 from magic_combat.scryfall_loader import (
     _parse_colors,
-    _parse_protection,
     load_cards,
     card_to_creature,
     cards_to_creatures,
 )
+from magic_combat.parsing import parse_protection as _parse_protection
 from magic_combat.creature import Color
 
 DATA_PATH = Path(__file__).with_name("example_test_cards.json")


### PR DESCRIPTION
## Summary
- remove unused parse helpers from scryfall_loader
- update tests to import protection parser from parsing module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685850dd6ed8832aa03e80cdbacc0ef0