### PR TITLE
Use DEFAULT_STARTING_LIFE in simple block AI

### DIFF
--- a/magic_combat/blocking_ai.py
+++ b/magic_combat/blocking_ai.py
@@ -12,6 +12,7 @@ from .gamestate import GameState
 from .simulator import CombatSimulator
 from .creature import Color
 from .limits import IterationCounter
+from . import DEFAULT_STARTING_LIFE
 
 
 def _creature_value(creature: CombatCreature) -> float:
@@ -213,7 +214,11 @@ def decide_simple_blocks(
         return
 
     defender = blockers[0].controller
-    life = game_state.players[defender].life if game_state else 20
+    life = (
+        game_state.players[defender].life
+        if game_state
+        else DEFAULT_STARTING_LIFE
+    )
     poison = game_state.players[defender].poison if game_state else 0
 
     available = list(blockers)


### PR DESCRIPTION
## Summary
- import `DEFAULT_STARTING_LIFE` in `blocking_ai`
- replace literal `20` with the constant when tracking life in `decide_simple_blocks`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685850c3fd24832ab2332ecb617f4e1e