### PR TITLE
Refactor ability constants

### DIFF
--- a/magic_combat/abilities.py
+++ b/magic_combat/abilities.py
@@ -1,0 +1,57 @@
+"""Shared ability name mappings for random generation and display."""
+
+from __future__ import annotations
+
+# Mapping from attribute names on :class:`CombatCreature` to human readable names
+BOOL_NAMES = {
+    "flying": "Flying",
+    "reach": "Reach",
+    "menace": "Menace",
+    "fear": "Fear",
+    "shadow": "Shadow",
+    "horsemanship": "Horsemanship",
+    "skulk": "Skulk",
+    "unblockable": "Unblockable",
+    "daunt": "Daunt",
+    "vigilance": "Vigilance",
+    "first_strike": "First strike",
+    "double_strike": "Double strike",
+    "deathtouch": "Deathtouch",
+    "trample": "Trample",
+    "lifelink": "Lifelink",
+    "wither": "Wither",
+    "infect": "Infect",
+    "indestructible": "Indestructible",
+    "melee": "Melee",
+    "training": "Training",
+    "mentor": "Mentor",
+    "battalion": "Battalion",
+    "dethrone": "Dethrone",
+    "undying": "Undying",
+    "persist": "Persist",
+    "intimidate": "Intimidate",
+    "defender": "Defender",
+    "provoke": "Provoke",
+}
+
+INT_NAMES = {
+    "toxic": "Toxic",
+    "bushido": "Bushido",
+    "flanking": "Flanking",
+    "rampage": "Rampage",
+    "exalted_count": "Exalted",
+    "battle_cry_count": "Battle cry",
+    "frenzy": "Frenzy",
+    "afflict": "Afflict",
+}
+
+# Convenience sets of ability attribute names used for random generation
+BOOL_ATTRIBUTES = set(BOOL_NAMES.keys())
+INT_ATTRIBUTES = set(INT_NAMES.keys())
+
+__all__ = [
+    "BOOL_NAMES",
+    "INT_NAMES",
+    "BOOL_ATTRIBUTES",
+    "INT_ATTRIBUTES",
+]

--- a/magic_combat/random_creature.py
+++ b/magic_combat/random_creature.py
@@ -10,49 +10,10 @@ import numpy as np
 
 from .creature import CombatCreature, Color
 from .scryfall_loader import cards_to_creatures
+from .abilities import BOOL_ATTRIBUTES as _BOOL_ABILITIES, INT_ATTRIBUTES as _INT_ABILITIES
 
 
-_BOOL_ABILITIES = {
-    "flying",
-    "reach",
-    "menace",
-    "fear",
-    "shadow",
-    "horsemanship",
-    "skulk",
-    "unblockable",
-    "daunt",
-    "vigilance",
-    "first_strike",
-    "double_strike",
-    "deathtouch",
-    "trample",
-    "lifelink",
-    "wither",
-    "infect",
-    "indestructible",
-    "melee",
-    "training",
-    "mentor",
-    "battalion",
-    "dethrone",
-    "undying",
-    "persist",
-    "intimidate",
-    "defender",
-    "provoke",
-}
 
-_INT_ABILITIES = {
-    "toxic",
-    "bushido",
-    "flanking",
-    "rampage",
-    "exalted_count",
-    "battle_cry_count",
-    "frenzy",
-    "afflict",
-}
 
 
 def compute_card_statistics(cards: Iterable[dict]) -> Dict[str, object]:

--- a/scripts/random_combat.py
+++ b/scripts/random_combat.py
@@ -26,49 +26,9 @@ from magic_combat import (
     PlayerState,
 )
 from magic_combat.damage import _blocker_value
+from magic_combat.abilities import BOOL_NAMES as _BOOL_ABILITIES, INT_NAMES as _INT_ABILITIES
 
-# Ability name mappings for pretty printing
-_BOOL_ABILITIES = {
-    "flying": "Flying",
-    "reach": "Reach",
-    "menace": "Menace",
-    "fear": "Fear",
-    "shadow": "Shadow",
-    "horsemanship": "Horsemanship",
-    "skulk": "Skulk",
-    "unblockable": "Unblockable",
-    "daunt": "Daunt",
-    "vigilance": "Vigilance",
-    "first_strike": "First strike",
-    "double_strike": "Double strike",
-    "deathtouch": "Deathtouch",
-    "trample": "Trample",
-    "lifelink": "Lifelink",
-    "wither": "Wither",
-    "infect": "Infect",
-    "indestructible": "Indestructible",
-    "melee": "Melee",
-    "training": "Training",
-    "mentor": "Mentor",
-    "battalion": "Battalion",
-    "dethrone": "Dethrone",
-    "undying": "Undying",
-    "persist": "Persist",
-    "intimidate": "Intimidate",
-    "defender": "Defender",
-    "provoke": "Provoke",
-}
-
-_INT_ABILITIES = {
-    "toxic": "Toxic",
-    "bushido": "Bushido",
-    "flanking": "Flanking",
-    "rampage": "Rampage",
-    "exalted_count": "Exalted",
-    "battle_cry_count": "Battle cry",
-    "frenzy": "Frenzy",
-    "afflict": "Afflict",
-}
+# Ability name mappings for pretty printing come from ``magic_combat.abilities``
 
 
 def describe_abilities(creature) -> str:


### PR DESCRIPTION
## Summary
- centralize ability names in `abilities.py`
- use the shared constants in random creature generation and the random combat script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685850a02e98832a8f83f3761e79a297