### PR TITLE
Fix player lost check iteration

### DIFF
--- a/magic_combat/simulator.py
+++ b/magic_combat/simulator.py
@@ -93,7 +93,7 @@ class CombatSimulator:
     def _check_players_lost(self) -> None:
         """Record any players who have lost the game."""
         if self.game_state is not None:
-            for player in list(self.game_state.players.keys()):
+            for player in self.game_state.players:
                 if has_player_lost(self.game_state, player) and player not in self.players_lost:
                     self.players_lost.append(player)
 


### PR DESCRIPTION
## Summary
- iterate directly over GameState.players when detecting lost players

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858509bbc80832aa3ebac38c7513ab1