### PR TITLE
Fix import order for DEFAULT_STARTING_LIFE

### DIFF
--- a/magic_combat/__init__.py
+++ b/magic_combat/__init__.py
@@ -1,10 +1,6 @@
 """Core package for the Magic Combat simulator."""
 
 from .creature import CombatCreature, Color
-
-# Default life total used when initializing ``PlayerState`` instances
-DEFAULT_STARTING_LIFE = 20
-
 from .simulator import CombatResult, CombatSimulator
 from .damage import DamageAssignmentStrategy, OptimalDamageStrategy
 from .blocking_ai import decide_optimal_blocks, decide_simple_blocks
@@ -23,6 +19,9 @@ from .random_creature import (
     assign_random_counters,
     assign_random_tapped,
 )
+
+# Default life total used when initializing ``PlayerState`` instances
+DEFAULT_STARTING_LIFE = 20
 
 __all__ = [
     "CombatCreature",

--- a/magic_combat/blocking_ai.py
+++ b/magic_combat/blocking_ai.py
@@ -11,7 +11,6 @@ from .damage import _blocker_value, OptimalDamageStrategy, score_combat_result
 from .gamestate import GameState
 from .simulator import CombatSimulator
 from .limits import IterationCounter
-from . import DEFAULT_STARTING_LIFE
 from .utils import _can_block
 
 
@@ -181,6 +180,8 @@ def decide_simple_blocks(
     provoke_map: Optional[dict[CombatCreature, CombatCreature]] = None,
 ) -> None:
     """Assign blocks using a simple non-searching heuristic."""
+
+    from . import DEFAULT_STARTING_LIFE
 
     for atk in attackers:
         atk.blocked_by.clear()

--- a/magic_combat/gamestate.py
+++ b/magic_combat/gamestate.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Game state representation for the combat simulator."""
+
+from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Dict, List

--- a/magic_combat/simulator.py
+++ b/magic_combat/simulator.py
@@ -5,8 +5,7 @@ from typing import Dict, List, Optional
 
 from .creature import CombatCreature, Color
 from .damage import DamageAssignmentStrategy, OptimalDamageStrategy
-from .gamestate import GameState, PlayerState, has_player_lost
-from . import DEFAULT_STARTING_LIFE
+from .gamestate import GameState, has_player_lost
 from .utils import ensure_player_state, _can_block
 
 @dataclass


### PR DESCRIPTION
## Summary
- place `DEFAULT_STARTING_LIFE` after imports in `__init__`
- reorder top of `gamestate.py` to silence E402
- remove unused `DEFAULT_STARTING_LIFE` and `PlayerState` imports in `simulator`
- avoid circular import by moving `DEFAULT_STARTING_LIFE` import inside `decide_simple_blocks`

## Testing
- `ruff check magic_combat --select E402`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685857cb1a54832aae93ca589ef14269