### PR TITLE
Remove unused defender_player and imports

### DIFF
--- a/magic_combat/__init__.py
+++ b/magic_combat/__init__.py
@@ -1,10 +1,11 @@
 """Core package for the Magic Combat simulator."""
 
-from .creature import CombatCreature, Color
+# ruff: noqa: E402
 
 # Default life total used when initializing ``PlayerState`` instances
 DEFAULT_STARTING_LIFE = 20
 
+from .creature import CombatCreature, Color
 from .simulator import CombatResult, CombatSimulator
 from .damage import DamageAssignmentStrategy, OptimalDamageStrategy
 from .blocking_ai import decide_optimal_blocks, decide_simple_blocks

--- a/magic_combat/gamestate.py
+++ b/magic_combat/gamestate.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Game state representation for the combat simulator."""
+
+from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Dict, List

--- a/magic_combat/simulator.py
+++ b/magic_combat/simulator.py
@@ -5,8 +5,7 @@ from typing import Dict, List, Optional
 
 from .creature import CombatCreature, Color
 from .damage import DamageAssignmentStrategy, OptimalDamageStrategy
-from .gamestate import GameState, PlayerState, has_player_lost
-from . import DEFAULT_STARTING_LIFE
+from .gamestate import GameState, has_player_lost
 from .utils import ensure_player_state, _can_block
 
 @dataclass
@@ -210,8 +209,6 @@ class CombatSimulator:
         (CR 702.111) and others that grant bonuses or counters before damage
         is assigned.
         """
-        defender_player = self._get_defending_player()
-
         attackers_by_controller: Dict[str, List[CombatCreature]] = {}
         for atk in self.attackers:
             attackers_by_controller.setdefault(atk.controller, []).append(atk)

--- a/magic_combat/utils.py
+++ b/magic_combat/utils.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - for type checking only
+    from .creature import CombatCreature
+
 def check_non_negative(value: int, name: str) -> None:
     """Validate that ``value`` is not negative.
 


### PR DESCRIPTION
## Summary
- clean up imports in `simulator.py`
- drop unused `defender_player` assignment
- reorder `gamestate` module header
- ensure type hints resolve in `utils`
- keep `DEFAULT_STARTING_LIFE` defined early and disable E402 on module

## Testing
- `ruff check magic_combat`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685857d95ae8832abc8bdc3987afe513