### PR TITLE
Centralize keyword names

### DIFF
--- a/magic_combat/keywords.py
+++ b/magic_combat/keywords.py
@@ -1,0 +1,64 @@
+"""Shared keyword ability mappings used for parsing and data loading."""
+
+from __future__ import annotations
+
+# Mapping of Scryfall keyword names to ``CombatCreature`` boolean attributes
+BOOLEAN_KEYWORDS = {
+    "Flying": "flying",
+    "Reach": "reach",
+    "Menace": "menace",
+    "Fear": "fear",
+    "Shadow": "shadow",
+    "Horsemanship": "horsemanship",
+    "Skulk": "skulk",
+    "Vigilance": "vigilance",
+    "First strike": "first_strike",
+    "Double strike": "double_strike",
+    "Deathtouch": "deathtouch",
+    "Trample": "trample",
+    "Lifelink": "lifelink",
+    "Wither": "wither",
+    "Infect": "infect",
+    "Indestructible": "indestructible",
+    "Melee": "melee",
+    "Training": "training",
+    "Mentor": "mentor",
+    "Battalion": "battalion",
+    "Dethrone": "dethrone",
+    "Undying": "undying",
+    "Persist": "persist",
+    "Intimidate": "intimidate",
+    "Daunt": "daunt",
+    "Defender": "defender",
+    "Provoke": "provoke",
+}
+
+# Keywords that include an integer value in their rules text
+VALUE_KEYWORDS = {
+    "Bushido": "bushido",
+    "Rampage": "rampage",
+    "Frenzy": "frenzy",
+    "Toxic": "toxic",
+    "Afflict": "afflict",
+}
+
+# Keywords that stack when repeated
+STACKABLE_KEYWORDS = {
+    "Exalted": "exalted_count",
+    "Battle cry": "battle_cry_count",
+    "Flanking": "flanking",
+}
+
+# Convenience set of all supported Scryfall keyword names
+ALLOWED_KEYWORDS = (
+    set(BOOLEAN_KEYWORDS.keys())
+    | set(VALUE_KEYWORDS.keys())
+    | set(STACKABLE_KEYWORDS.keys())
+)
+
+__all__ = [
+    "BOOLEAN_KEYWORDS",
+    "VALUE_KEYWORDS",
+    "STACKABLE_KEYWORDS",
+    "ALLOWED_KEYWORDS",
+]

--- a/magic_combat/parsing.py
+++ b/magic_combat/parsing.py
@@ -5,6 +5,12 @@ from __future__ import annotations
 import re
 from typing import Any, Dict, Set
 
+from .keywords import (
+    BOOLEAN_KEYWORDS as _BOOLEAN_KEYWORDS,
+    VALUE_KEYWORDS as _VALUE_KEYWORDS,
+    STACKABLE_KEYWORDS as _STACKABLE_KEYWORDS,
+)
+
 from .creature import Color
 
 # Mapping from short mana cost letters to :class:`Color` enums
@@ -58,52 +64,7 @@ def parse_protection(text: str) -> Set[Color]:
     return colors
 
 
-# Mapping of Scryfall keyword text to :class:`CombatCreature` fields
-_BOOLEAN_KEYWORDS = {
-    "Flying": "flying",
-    "Reach": "reach",
-    "Menace": "menace",
-    "Fear": "fear",
-    "Shadow": "shadow",
-    "Horsemanship": "horsemanship",
-    "Skulk": "skulk",
-    "Vigilance": "vigilance",
-    "First strike": "first_strike",
-    "Double strike": "double_strike",
-    "Deathtouch": "deathtouch",
-    "Trample": "trample",
-    "Lifelink": "lifelink",
-    "Wither": "wither",
-    "Infect": "infect",
-    "Indestructible": "indestructible",
-    "Melee": "melee",
-    "Training": "training",
-    "Mentor": "mentor",
-    "Battalion": "battalion",
-    "Dethrone": "dethrone",
-    "Undying": "undying",
-    "Persist": "persist",
-    "Intimidate": "intimidate",
-    "Daunt": "daunt",
-    "Defender": "defender",
-    "Provoke": "provoke",
-}
-
-# Keywords that include an integer value in the rules text
-_VALUE_KEYWORDS = {
-    "Bushido": "bushido",
-    "Rampage": "rampage",
-    "Frenzy": "frenzy",
-    "Toxic": "toxic",
-    "Afflict": "afflict",
-}
-
-# Keywords that stack when repeated
-_STACKABLE_KEYWORDS = {
-    "Exalted": "exalted_count",
-    "Battle cry": "battle_cry_count",
-    "Flanking": "flanking",
-}
+# Keyword mappings are shared in :mod:`magic_combat.keywords`
 
 
 def apply_keyword_attributes(keywords: Set[str], oracle_text: str) -> Dict[str, Any]:

--- a/magic_combat/scryfall_loader.py
+++ b/magic_combat/scryfall_loader.py
@@ -6,6 +6,7 @@ from .parsing import (
     parse_colors as _parse_colors,
     apply_keyword_attributes,
 )
+from .keywords import ALLOWED_KEYWORDS
 
 
 import requests
@@ -14,41 +15,7 @@ SCRYFALL_API = "https://api.scryfall.com/cards/search"
 QUERY = "is:frenchvanilla t:creature"
 
 # Keyword abilities supported by :class:`~magic_combat.creature.CombatCreature`.
-ALLOWED_KEYWORDS = {
-    "Flying",
-    "Reach",
-    "Menace",
-    "Fear",
-    "Shadow",
-    "Horsemanship",
-    "Skulk",
-    "Vigilance",
-    "First strike",
-    "Double strike",
-    "Deathtouch",
-    "Trample",
-    "Lifelink",
-    "Wither",
-    "Infect",
-    "Toxic",
-    "Indestructible",
-    "Bushido",
-    "Flanking",
-    "Rampage",
-    "Exalted",
-    "Battle cry",
-    "Melee",
-    "Training",
-    "Frenzy",
-    "Battalion",
-    "Dethrone",
-    "Undying",
-    "Persist",
-    "Intimidate",
-    "Defender",
-    "Afflict",
-    "Provoke",
-}
+# The names come from :mod:`magic_combat.keywords`.
 
 
 def fetch_french_vanilla_cards() -> List[Dict[str, Any]]:


### PR DESCRIPTION
## Summary
- centralize supported Scryfall keyword names in a new module
- update `parsing` and `scryfall_loader` to import this shared data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685857fe7124832aa940c23fd39b82ec