### PR TITLE
Refactor blocking utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ magic_combat/simulator.py    ``CombatSimulator`` and ``CombatResult`` classes
 magic_combat/utils.py        Small utility helpers used internally
 magic_combat/parsing.py      Parsing helpers for card data
 magic_combat/random_creature.py Utilities for sampling creatures
+magic_combat/blocking_ai.py  Blocking heuristics and search
+magic_combat/block_utils.py  Utilities for evaluating block assignments
 ```
 
 ## Development

--- a/magic_combat/block_utils.py
+++ b/magic_combat/block_utils.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+"""Utility helpers for evaluating blocking assignments."""
+
+from copy import deepcopy
+from typing import Sequence, Optional, Tuple, Dict
+
+from .creature import CombatCreature
+from .gamestate import GameState
+from .limits import IterationCounter
+from .damage import OptimalDamageStrategy, score_combat_result
+from .simulator import CombatSimulator
+
+
+def evaluate_block_assignment(
+    attackers: Sequence[CombatCreature],
+    blockers: Sequence[CombatCreature],
+    assignment: Sequence[Optional[int]],
+    state: Optional[GameState],
+    counter: IterationCounter,
+    provoke_map: Optional[Dict[CombatCreature, CombatCreature]] = None,
+) -> Tuple[int, float, int, int, int, Tuple[Optional[int], ...]]:
+    """Simulate combat for ``assignment`` and return a scoring tuple."""
+    atks = deepcopy(list(attackers))
+    blks = deepcopy(list(blockers))
+    for idx, choice in enumerate(assignment):
+        if choice is not None:
+            blk = blks[idx]
+            atk = atks[choice]
+            blk.blocking = atk
+            atk.blocked_by.append(blk)
+
+    prov_copies: Dict[CombatCreature, CombatCreature] = {}
+    if provoke_map:
+        for atk, blk in provoke_map.items():
+            if atk in attackers and blk in blockers:
+                prov_copies[atks[attackers.index(atk)]] = blks[blockers.index(blk)]
+
+    sim = CombatSimulator(
+        atks,
+        blks,
+        game_state=deepcopy(state),
+        strategy=OptimalDamageStrategy(counter),
+        provoke_map=prov_copies or None,
+    )
+    try:
+        counter.increment()
+        result = sim.simulate()
+    except ValueError:
+        ass_key = tuple(len(attackers) if choice is None else choice for choice in assignment)
+        return (
+            1,
+            float("inf"),
+            -len(atks) - len(blks),
+            -float("inf"),
+            float("inf"),
+            float("inf"),
+            ass_key,
+        )
+
+    defender = blks[0].controller if blks else "defender"
+    attacker_player = atks[0].controller if atks else "attacker"
+    ass_key = tuple(len(attackers) if choice is None else choice for choice in assignment)
+    score = score_combat_result(result, attacker_player, defender) + (ass_key,)
+    return score

--- a/tests/combat/test_block_damage_extra.py
+++ b/tests/combat/test_block_damage_extra.py
@@ -10,7 +10,8 @@ from magic_combat import (
     PlayerState,
     decide_optimal_blocks,
 )
-from magic_combat.blocking_ai import _evaluate_assignment, _can_block
+from magic_combat.block_utils import evaluate_block_assignment
+from magic_combat.blocking_ai import _can_block
 from magic_combat.limits import IterationCounter
 from tests.conftest import link_block
 
@@ -59,7 +60,7 @@ def _compute_best_assignment(atk, blk, state):
     best = None
     best_score = None
     for ass in product(*options):
-        score = _evaluate_assignment(atk, blk, ass, state, counter)
+        score = evaluate_block_assignment(atk, blk, ass, state, counter)
         if best_score is None or score < best_score:
             best_score = score
             best = ass

--- a/tests/combat/test_random_card_blocks.py
+++ b/tests/combat/test_random_card_blocks.py
@@ -12,7 +12,8 @@ from magic_combat import (
 )
 from itertools import product
 
-from magic_combat.blocking_ai import _evaluate_assignment, _can_block
+from magic_combat.block_utils import evaluate_block_assignment
+from magic_combat.blocking_ai import _can_block
 from magic_combat.limits import IterationCounter
 
 DATA_PATH = Path(__file__).resolve().parent.parent / "example_test_cards.json"
@@ -27,7 +28,7 @@ def _compute_best_assignment(atk, blk, state):
     best = None
     best_score = None
     for ass in product(*options):
-        score = _evaluate_assignment(atk, blk, ass, state, counter)
+        score = evaluate_block_assignment(atk, blk, ass, state, counter)
         if best_score is None or score < best_score:
             best_score = score
             best = ass

--- a/tests/core/test_block_utils.py
+++ b/tests/core/test_block_utils.py
@@ -1,0 +1,18 @@
+from magic_combat import CombatCreature
+from magic_combat.gamestate import GameState, PlayerState
+from magic_combat.block_utils import evaluate_block_assignment
+from magic_combat.limits import IterationCounter
+
+
+def test_evaluate_block_assignment_simple():
+    """CR 510.2: Combat damage is dealt simultaneously."""
+    atk = CombatCreature("A", 2, 2, "A")
+    blk = CombatCreature("B", 2, 2, "B")
+    state = GameState(
+        players={
+            "A": PlayerState(life=20, creatures=[atk]),
+            "B": PlayerState(life=20, creatures=[blk]),
+        }
+    )
+    score = evaluate_block_assignment([atk], [blk], [0], state, IterationCounter(10))
+    assert score == (0, 0.0, 0, 0, 0, 0, (0,))


### PR DESCRIPTION
## Summary
- extract evaluation logic into `block_utils.evaluate_block_assignment`
- adjust `blocking_ai` to use new helper
- document the new module
- test the helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858e545f828832abedba5230a304afa