### PR TITLE
Add poison loss threshold constant

### DIFF
--- a/magic_combat/__init__.py
+++ b/magic_combat/__init__.py
@@ -4,6 +4,8 @@ from .creature import CombatCreature, Color
 
 # Default life total used when initializing ``PlayerState`` instances
 DEFAULT_STARTING_LIFE = 20
+# Poison counter threshold at which a player loses the game
+POISON_LOSS_THRESHOLD = 10
 
 from .simulator import CombatResult, CombatSimulator
 from .damage import DamageAssignmentStrategy, OptimalDamageStrategy
@@ -43,6 +45,7 @@ __all__ = [
     "has_player_lost",
     "calculate_mana_value",
     "DEFAULT_STARTING_LIFE",
+    "POISON_LOSS_THRESHOLD",
     "fetch_french_vanilla_cards",
     "load_cards",
     "save_cards",

--- a/magic_combat/blocking_ai.py
+++ b/magic_combat/blocking_ai.py
@@ -9,7 +9,7 @@ from .creature import CombatCreature
 from .damage import _blocker_value
 from .gamestate import GameState
 from .limits import IterationCounter
-from . import DEFAULT_STARTING_LIFE
+from . import DEFAULT_STARTING_LIFE, POISON_LOSS_THRESHOLD
 from .utils import _can_block
 from .block_utils import evaluate_block_assignment
 
@@ -96,7 +96,7 @@ def _perform_chump_blocks(
         if not available:
             break
         dmg, psn = remaining_threat()
-        if life <= dmg or poison + psn >= 10:
+        if life <= dmg or poison + psn >= POISON_LOSS_THRESHOLD:
             choices = [b for b in available if _can_block(atk, b)]
             if not choices:
                 continue

--- a/magic_combat/gamestate.py
+++ b/magic_combat/gamestate.py
@@ -8,6 +8,7 @@ from typing import Dict, List
 from .utils import check_non_negative
 
 from .creature import CombatCreature
+from . import POISON_LOSS_THRESHOLD
 
 
 @dataclass
@@ -35,4 +36,4 @@ def has_player_lost(state: GameState, player: str) -> bool:
     ps = state.players.get(player)
     if ps is None:
         return False
-    return ps.life <= 0 or ps.poison >= 10
+    return ps.life <= 0 or ps.poison >= POISON_LOSS_THRESHOLD

--- a/tests/abilities/test_poison.py
+++ b/tests/abilities/test_poison.py
@@ -6,6 +6,7 @@ from magic_combat import (
     GameState,
     PlayerState,
     DEFAULT_STARTING_LIFE,
+    POISON_LOSS_THRESHOLD,
     has_player_lost,
 )
 from tests.conftest import link_block
@@ -114,7 +115,7 @@ def test_player_loses_at_ten_poison():
     state = GameState(players={"A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]), "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[defender], poison=9)})
     sim = CombatSimulator([atk], [defender], game_state=state)
     sim.simulate()
-    assert state.players["B"].poison == 10
+    assert state.players["B"].poison == POISON_LOSS_THRESHOLD
     assert has_player_lost(state, "B")
     assert "B" in sim.players_lost
 

--- a/tests/combat/test_game_loss_scenarios.py
+++ b/tests/combat/test_game_loss_scenarios.py
@@ -5,6 +5,7 @@ from magic_combat import (
     GameState,
     PlayerState,
     DEFAULT_STARTING_LIFE,
+    POISON_LOSS_THRESHOLD,
     has_player_lost,
 )
 from tests.conftest import link_block
@@ -56,7 +57,7 @@ def test_infect_and_toxic_exactly_ten_poison():
     state = GameState(players={"A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]), "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[defender], poison=6)})
     sim = CombatSimulator([atk], [defender], game_state=state)
     sim.simulate()
-    assert state.players["B"].poison == 10
+    assert state.players["B"].poison == POISON_LOSS_THRESHOLD
     assert has_player_lost(state, "B")
     assert "B" in sim.players_lost
 
@@ -121,7 +122,7 @@ def test_lifelink_cannot_prevent_poison_loss():
     sim = CombatSimulator([atk], [defender], game_state=state)
     sim.simulate()
     assert state.players["A"].life == 6
-    assert state.players["B"].poison == 10
+    assert state.players["B"].poison == POISON_LOSS_THRESHOLD
     assert has_player_lost(state, "B")
     assert "B" in sim.players_lost
 

--- a/tests/combat/test_gamestate.py
+++ b/tests/combat/test_gamestate.py
@@ -5,6 +5,7 @@ from magic_combat import (
     GameState,
     PlayerState,
     DEFAULT_STARTING_LIFE,
+    POISON_LOSS_THRESHOLD,
     has_player_lost,
 )
 from tests.conftest import link_block
@@ -148,7 +149,7 @@ def test_double_strike_infect_can_cause_loss():
     )
     sim = CombatSimulator([atk], [defender], game_state=state)
     result = sim.simulate()
-    assert state.players["B"].poison == 10
+    assert state.players["B"].poison == POISON_LOSS_THRESHOLD
     assert has_player_lost(state, "B")
     assert "B" in sim.players_lost
     assert result.poison_counters["B"] == 2

--- a/tests/combat/test_life_poison.py
+++ b/tests/combat/test_life_poison.py
@@ -5,6 +5,7 @@ from magic_combat import (
     GameState,
     PlayerState,
     DEFAULT_STARTING_LIFE,
+    POISON_LOSS_THRESHOLD,
     has_player_lost,
 )
 from tests.conftest import link_block
@@ -23,7 +24,7 @@ def test_infect_lifelink_poison_lethal():
     sim = CombatSimulator([atk], [defender], game_state=state)
     result = sim.simulate()
     assert state.players["B"].life == 20
-    assert state.players["B"].poison == 10
+    assert state.players["B"].poison == POISON_LOSS_THRESHOLD
     assert result.lifegain["A"] == 2
     assert has_player_lost(state, "B")
     assert "B" in sim.players_lost


### PR DESCRIPTION
## Summary
- define `POISON_LOSS_THRESHOLD` alongside `DEFAULT_STARTING_LIFE`
- use the new constant in `has_player_lost` and chump blocking logic
- update tests to import and check against the constant

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858e937834c832abf924d7ab5a1bed6