### PR TITLE
Remove scipy from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 pytest>=7.0
 requests
 numpy
-scipy
 openai


### PR DESCRIPTION
## Summary
- drop unused `scipy` dependency from `requirements.txt`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858e960bd7c832a9568c0f18a945bec