### PR TITLE
Add timeout option to Scryfall loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,15 +64,20 @@ loaded with :func:`load_cards`.
 ```python
 from magic_combat import fetch_french_vanilla_cards, save_cards
 
-cards = fetch_french_vanilla_cards()
+cards = fetch_french_vanilla_cards()  # optional ``timeout`` parameter
 save_cards(cards, "data/cards.json")
+
+# By default each request will wait up to 10 seconds; adjust ``timeout`` if
+# you need a different value.
 ```
 
 Alternatively, a small helper script ``scripts/download_cards.py`` can be run
-from the repository root to perform the download:
+from the repository root to perform the download.  It accepts an optional
+``--timeout`` argument matching :func:`fetch_french_vanilla_cards`:
 
 ```bash
 python scripts/download_cards.py data/cards.json
+# python scripts/download_cards.py --timeout 5 data/cards.json
 ```
 
 ## Random creature generation

--- a/magic_combat/scryfall_loader.py
+++ b/magic_combat/scryfall_loader.py
@@ -18,18 +18,24 @@ QUERY = "is:frenchvanilla t:creature"
 # The names come from :mod:`magic_combat.keywords`.
 
 
-def fetch_french_vanilla_cards() -> List[Dict[str, Any]]:
+def fetch_french_vanilla_cards(timeout: float = 10.0) -> List[Dict[str, Any]]:
     """Return a list of creature cards with only keyword abilities.
 
     Uses the Scryfall API's ``is:frenchvanilla`` query to find cards whose
     rules text contains only keyword abilities and no additional abilities.
+
+    Parameters
+    ----------
+    timeout:
+        Maximum number of seconds to wait for each HTTP request.  The default
+        of 10 seconds should be suitable for most use cases.
     """
     url = SCRYFALL_API
     params = {"q": QUERY}
     cards: List[Dict[str, Any]] = []
     with requests.Session() as session:
         while url:
-            resp = session.get(url, params=params)
+            resp = session.get(url, params=params, timeout=timeout)
             resp.raise_for_status()
             data = resp.json()
             for c in data.get("data", []):

--- a/scripts/download_cards.py
+++ b/scripts/download_cards.py
@@ -27,9 +27,15 @@ def main() -> None:
         default="data/cards.json",
         help="Location of the JSON file to write",
     )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=10.0,
+        help="Timeout for each HTTP request in seconds (default: 10)",
+    )
     args = parser.parse_args()
 
-    cards = fetch_french_vanilla_cards()
+    cards = fetch_french_vanilla_cards(timeout=args.timeout)
     os.makedirs(os.path.dirname(args.output) or ".", exist_ok=True)
     save_cards(cards, args.output)
     print(f"Saved {len(cards)} cards to {args.output}")


### PR DESCRIPTION
## Summary
- allow `fetch_french_vanilla_cards` to specify a request timeout (default 10s)
- expose the timeout option in `download_cards.py`
- document the new option in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858e95069cc832aba157d591c72dca8