### PR TITLE
Update toxic rule references

### DIFF
--- a/tests/abilities/test_interactions.py
+++ b/tests/abilities/test_interactions.py
@@ -136,7 +136,7 @@ def test_dethrone_adds_counter():
 
 
 def test_toxic_damage_adds_poison():
-    """CR 702.??: Toxic gives poison counters in addition to damage."""
+    """CR 702.180a: Toxic gives poison counters in addition to damage."""
     atk = CombatCreature("Viper", 1, 1, "A", toxic=2)
     defender = CombatCreature("Dummy", 0, 1, "B")
     sim = CombatSimulator([atk], [defender])

--- a/tests/abilities/test_lifelink.py
+++ b/tests/abilities/test_lifelink.py
@@ -139,7 +139,7 @@ def test_deathtouch_lifelink_blocker():
 
 
 def test_toxic_lifelink_unblocked():
-    """CR 702.15a & 702.??: Toxic adds poison counters while lifelink gains life from the damage."""
+    """CR 702.15a & 702.180a: Toxic adds poison counters while lifelink gains life from the damage."""
     atk = CombatCreature("Viper", 1, 1, "A", toxic=2, lifelink=True)
     defender = CombatCreature("Dummy", 0, 1, "B")
     sim = CombatSimulator([atk], [defender])

--- a/tests/abilities/test_more_abilities.py
+++ b/tests/abilities/test_more_abilities.py
@@ -277,7 +277,7 @@ def test_rampage_with_battle_cry_and_multiple_blockers():
 
 
 def test_toxic_trample_excess_poison():
-    """CR 702.19b & 702.??: Trample with toxic assigns excess damage and poison counters."""
+    """CR 702.19b & 702.180a: Trample with toxic assigns excess damage and poison counters."""
     atk = CombatCreature("Serpent", 3, 3, "A", trample=True, toxic=2)
     blk = CombatCreature("Wall", 1, 1, "B")
     link_block(atk, blk)
@@ -288,7 +288,7 @@ def test_toxic_trample_excess_poison():
 
 
 def test_multiple_toxic_attackers_stack_poison():
-    """CR 702.??: Each instance of toxic adds poison counters to the defending player."""
+    """CR 702.180a: Each instance of toxic adds poison counters to the defending player."""
     t1 = CombatCreature("Snake1", 1, 1, "A", toxic=1)
     t2 = CombatCreature("Snake2", 2, 2, "A", toxic=2)
     defender = CombatCreature("Dummy", 0, 1, "B")

--- a/tests/abilities/test_poison.py
+++ b/tests/abilities/test_poison.py
@@ -86,7 +86,7 @@ def test_infect_kills_persist_creature_without_return():
 
 
 def test_infect_and_toxic_stack_poison():
-    """CR 702.90b & 702.??: Infect and toxic add poison counters together."""
+    """CR 702.90b & 702.180a: Infect and toxic add poison counters together."""
     atk = CombatCreature("Venomous", 2, 2, "A", infect=True, toxic=1)
     defender = CombatCreature("Dummy", 0, 1, "B")
     state = GameState(players={"A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]), "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[defender])})

--- a/tests/combat/test_game_loss_scenarios.py
+++ b/tests/combat/test_game_loss_scenarios.py
@@ -38,7 +38,7 @@ def test_afflict_and_trample_combined_lethal():
 
 
 def test_toxic_three_poison_counters_causes_loss():
-    """CR 702.??? & 104.3c: Toxic gives that many poison counters; a player with ten or more poison counters loses."""
+    """CR 702.180a & 104.3c: Toxic gives that many poison counters; a player with ten or more poison counters loses."""
     atk = CombatCreature("Stinger", 1, 1, "A", toxic=3)
     defender = CombatCreature("Dummy", 0, 1, "B")
     state = GameState(players={"A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]), "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[defender], poison=8)})

--- a/tests/poison/test_poison_extra.py
+++ b/tests/poison/test_poison_extra.py
@@ -93,7 +93,7 @@ def test_infect_kills_undying_but_it_returns():
 
 
 def test_infect_and_toxic_stack_poison():
-    """CR 702.90b & 702.??: Infect and toxic both add poison counters."""
+    """CR 702.90b & 702.180a: Infect and toxic both add poison counters."""
     atk = CombatCreature("Super Toxic", 1, 1, "A", infect=True, toxic=2)
     defender = CombatCreature("Dummy", 0, 1, "B")
     sim = CombatSimulator([atk], [defender])


### PR DESCRIPTION
## Summary
- correct rule numbers for toxic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858e8edb818832a8c2d7523f66ab000