### PR TITLE
Refactor LLM evaluator to share scenario generation

### DIFF
--- a/magic_combat/__init__.py
+++ b/magic_combat/__init__.py
@@ -29,6 +29,13 @@ from .random_creature import (
     assign_random_counters,
     assign_random_tapped,
 )
+from .random_scenario import (
+    ensure_cards,
+    build_value_map,
+    sample_balanced,
+    generate_balanced_creatures,
+    generate_random_scenario,
+)
 from .create_llm_prompt import create_llm_prompt, parse_block_assignments
 
 __all__ = [
@@ -55,6 +62,11 @@ __all__ = [
     "generate_random_creature",
     "assign_random_counters",
     "assign_random_tapped",
+    "ensure_cards",
+    "build_value_map",
+    "sample_balanced",
+    "generate_balanced_creatures",
+    "generate_random_scenario",
     "apply_attacker_blocking_bonuses",
     "apply_blocker_bushido",
     "parse_block_assignments",

--- a/magic_combat/random_scenario.py
+++ b/magic_combat/random_scenario.py
@@ -1,0 +1,245 @@
+"""Utilities for creating random combat scenarios."""
+
+from __future__ import annotations
+
+import copy
+import os
+import random
+from typing import Dict, Iterable, List, Tuple
+
+import numpy as np
+
+from . import (
+    CombatSimulator,
+    GameState,
+    PlayerState,
+    cards_to_creatures,
+    card_to_creature,
+    fetch_french_vanilla_cards,
+    load_cards,
+    save_cards,
+    assign_random_counters,
+    assign_random_tapped,
+    generate_random_creature,
+)
+from .damage import _blocker_value
+from .blocking_ai import decide_optimal_blocks, decide_simple_blocks
+
+__all__ = [
+    "ensure_cards",
+    "build_value_map",
+    "sample_balanced",
+    "generate_balanced_creatures",
+    "generate_random_scenario",
+]
+
+
+def ensure_cards(path: str) -> List[dict]:
+    """Load card data, downloading it if necessary."""
+    if not os.path.exists(path):
+        try:
+            cards = fetch_french_vanilla_cards()
+        except Exception as exc:  # pragma: no cover - network failure
+            raise SystemExit(f"Failed to download card data: {exc}")
+        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+        save_cards(cards, path)
+    return load_cards(path)
+
+
+def build_value_map(cards: Iterable[dict]) -> Dict[int, float]:
+    """Return a mapping of card index to combat value."""
+    values: Dict[int, float] = {}
+    for idx, card in enumerate(cards):
+        try:
+            creature = card_to_creature(card, "A")
+        except ValueError:
+            continue
+        values[idx] = _blocker_value(creature)
+    if not values:
+        raise ValueError("No usable creatures found in card data")
+    return values
+
+
+def sample_balanced(
+    cards: List[dict], values: Dict[int, float], n_att: int, n_blk: int
+) -> Tuple[List[int], List[int]]:
+    """Select attackers and blockers with roughly equal value."""
+    idxs = list(values.keys())
+    if n_att + n_blk > len(idxs):
+        raise ValueError("Not enough cards to sample from")
+
+    best: Tuple[List[int], List[int]] | None = None
+    best_diff = float("inf")
+
+    for _ in range(1000):
+        att_idx = random.sample(idxs, n_att)
+        remaining = [i for i in idxs if i not in att_idx]
+        blk_idx = random.sample(remaining, n_blk)
+
+        att_val = sum(values[i] for i in att_idx)
+        blk_val = sum(values[i] for i in blk_idx)
+        avg = (att_val + blk_val) / 2 or 1
+        diff = abs(att_val - blk_val) / avg
+
+        if diff < best_diff:
+            best = (att_idx, blk_idx)
+            best_diff = diff
+
+        if diff <= 0.25:
+            return att_idx, blk_idx
+
+    if best is None:
+        raise ValueError("Failed to sample creatures")
+    raise ValueError("Unable to generate balanced creature sets")
+
+
+def generate_balanced_creatures(
+    stats: Dict[str, object], n_att: int, n_blk: int
+) -> Tuple[List, List]:
+    """Generate two sets of creatures with roughly equal value."""
+    best: Tuple[List, List] | None = None
+    best_diff = float("inf")
+
+    for _ in range(1000):
+        attackers = [generate_random_creature(stats, controller="A") for _ in range(n_att)]
+        blockers = [generate_random_creature(stats, controller="B") for _ in range(n_blk)]
+
+        att_val = sum(_blocker_value(c) for c in attackers)
+        blk_val = sum(_blocker_value(c) for c in blockers)
+        avg = (att_val + blk_val) / 2 or 1
+        diff = abs(att_val - blk_val) / avg
+
+        if diff < best_diff:
+            best = (attackers, blockers)
+            best_diff = diff
+
+        if diff <= 0.25:
+            return attackers, blockers
+
+    if best is None:
+        raise ValueError("Failed to generate creatures")
+    raise ValueError("Unable to generate balanced creature sets")
+
+
+def generate_random_scenario(
+    cards: List[dict],
+    values: Dict[int, float],
+    stats: Dict[str, object] | None = None,
+    *,
+    generated_cards: bool = False,
+    max_iterations: int = int(1e6),
+    unique_optimal: bool = False,
+) -> Tuple[GameState, List, List, dict, dict]:
+    """Return a non-trivial random combat scenario.
+
+    The returned ``GameState`` reflects the optimal blocks used to validate the
+    scenario.  ``attackers`` and ``blockers`` are cleared of any assignments so
+    they can be reused.  ``provoke_map`` and ``mentor_map`` describe any special
+    attacker interactions and should be supplied when simulating combat.
+    """
+
+    valid_len = len(values)
+    attempts = 0
+    while True:
+        attempts += 1
+        if attempts > 100:
+            raise RuntimeError("Unable to generate valid scenario")
+
+        n_atk = int(np.random.geometric(1 / 2.5))
+        n_blk = int(np.random.geometric(1 / 2.5))
+        n_atk = max(1, min(n_atk, valid_len // 2))
+        n_blk = max(1, min(n_blk, valid_len // 2))
+
+        try:
+            if generated_cards:
+                attackers, blockers = generate_balanced_creatures(stats, n_atk, n_blk)
+            else:
+                atk_idx, blk_idx = sample_balanced(cards, values, n_atk, n_blk)
+                attackers = cards_to_creatures((cards[j] for j in atk_idx), "A")
+                blockers = cards_to_creatures((cards[j] for j in blk_idx), "B")
+        except ValueError:
+            continue
+
+        assign_random_counters(attackers + blockers)
+        assign_random_tapped(blockers)
+
+        poison_relevant = any(c.infect or c.toxic for c in attackers + blockers)
+
+        state = GameState(
+            players={
+                "A": PlayerState(
+                    life=random.randint(1, 20),
+                    creatures=attackers,
+                    poison=random.randint(0, 9) if poison_relevant else 0,
+                ),
+                "B": PlayerState(
+                    life=random.randint(1, 20),
+                    creatures=blockers,
+                    poison=random.randint(0, 9) if poison_relevant else 0,
+                ),
+            }
+        )
+
+        provoke_map = {
+            atk: random.choice(blockers)
+            for atk in attackers
+            if atk.provoke
+        }
+        for blk in provoke_map.values():
+            blk.tapped = False
+
+        mentor_map = {}
+        for mentor in attackers:
+            if mentor.mentor:
+                targets = [
+                    c
+                    for c in attackers
+                    if c is not mentor and c.effective_power() < mentor.effective_power()
+                ]
+                if targets:
+                    mentor_map[mentor] = random.choice(targets)
+
+        simple_atk = copy.deepcopy(attackers)
+        simple_blk = copy.deepcopy(blockers)
+        simple_state = copy.deepcopy(state)
+        try:
+            decide_simple_blocks(
+                simple_atk,
+                simple_blk,
+                game_state=simple_state,
+                provoke_map=provoke_map,
+            )
+            sim_check = CombatSimulator(simple_atk, simple_blk, game_state=simple_state)
+            sim_check.validate_blocking()
+            atk_map = {id(a): i for i, a in enumerate(simple_atk)}
+            simple_assignment = tuple(
+                atk_map.get(id(b.blocking), None) for b in simple_blk
+            )
+        except ValueError:
+            simple_assignment = None
+
+        try:
+            _, opt_count = decide_optimal_blocks(
+                attackers,
+                blockers,
+                game_state=state,
+                provoke_map=provoke_map,
+                max_iterations=max_iterations,
+            )
+            if unique_optimal and opt_count != 1:
+                continue
+        except (ValueError, RuntimeError):
+            continue
+
+        opt_map = {id(a): i for i, a in enumerate(attackers)}
+        optimal_assignment = tuple(opt_map.get(id(b.blocking), None) for b in blockers)
+
+        if simple_assignment is not None and simple_assignment == optimal_assignment:
+            continue
+
+        start_state = copy.deepcopy(state)
+        for atk in attackers:
+            atk.blocked_by.clear()
+        for blk in blockers:
+            blk.blocking = None
+        return start_state, attackers, blockers, provoke_map, mentor_map

--- a/scripts/evaluate_random_combat_scenarios.py
+++ b/scripts/evaluate_random_combat_scenarios.py
@@ -38,30 +38,28 @@ async def evaluate_random_scenarios(n: int, cards_path: str) -> None:
     from magic_combat import (
         load_cards,
         compute_card_statistics,
-        generate_random_creature,
-        assign_random_counters,
-        assign_random_tapped,
         decide_optimal_blocks,
-        GameState,
-        PlayerState,
+        generate_random_scenario,
+        build_value_map,
     )
     from magic_combat.create_llm_prompt import create_llm_prompt, parse_block_assignments
 
     cards = load_cards(cards_path)
     stats = compute_card_statistics(cards)
+    values = build_value_map(cards)
 
     for idx in range(n):
-        attackers = [generate_random_creature(stats, controller="A") for _ in range(2)]
-        blockers = [generate_random_creature(stats, controller="B") for _ in range(2)]
-
-        assign_random_counters(attackers + blockers)
-        assign_random_tapped(blockers)
-
-        state = GameState(
-            players={
-                "A": PlayerState(life=20, creatures=attackers),
-                "B": PlayerState(life=20, creatures=blockers),
-            }
+        (
+            state,
+            attackers,
+            blockers,
+            _,
+            _,
+        ) = generate_random_scenario(
+            cards,
+            values,
+            stats,
+            generated_cards=True,
         )
 
         # Determine optimal blocks for comparison

--- a/scripts/random_combat.py
+++ b/scripts/random_combat.py
@@ -2,7 +2,6 @@
 """Generate and resolve random combat scenarios."""
 
 import argparse
-import os
 import random
 import copy
 from typing import Dict, List
@@ -10,20 +9,13 @@ from typing import Dict, List
 import numpy as np
 
 from magic_combat import (
-    cards_to_creatures,
-    card_to_creature,
-    load_cards,
-    save_cards,
-    fetch_french_vanilla_cards,
     compute_card_statistics,
-    generate_random_creature,
-    assign_random_counters,
-    assign_random_tapped,
-    decide_optimal_blocks,
-    decide_simple_blocks,
     CombatSimulator,
     GameState,
     PlayerState,
+    ensure_cards,
+    build_value_map,
+    generate_random_scenario,
 )
 from magic_combat.damage import _blocker_value
 from magic_combat.abilities import BOOL_NAMES as _BOOL_ABILITIES, INT_NAMES as _INT_ABILITIES
@@ -75,105 +67,6 @@ def print_player_state(label: str, ps: PlayerState, destroyed: List) -> None:
         print("  no creatures")
 
 
-def ensure_cards(path: str) -> List[dict]:
-    """Load card data, downloading it if necessary."""
-    if not os.path.exists(path):
-        print(f"Downloading card data to {path}...")
-        try:
-            cards = fetch_french_vanilla_cards()
-        except Exception as exc:
-            raise SystemExit(f"Failed to download card data: {exc}")
-        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
-        save_cards(cards, path)
-    return load_cards(path)
-
-
-def build_value_map(cards: List[dict]) -> Dict[int, float]:
-    """Return a mapping of card index to combat value.
-
-    Cards with invalid stats (e.g. ``"*"`` toughness) are skipped.
-    """
-    values: Dict[int, float] = {}
-    for idx, card in enumerate(cards):
-        try:
-            creature = card_to_creature(card, "A")
-        except ValueError as exc:  # toughness/power may be invalid
-            print(f"Skipping {card.get('name', '?')}: {exc}")
-            continue
-        values[idx] = _blocker_value(creature)
-    if not values:
-        raise ValueError("No usable creatures found in card data")
-    return values
-
-
-def sample_balanced(
-    cards: List[dict], values: Dict[int, float], n_att: int, n_blk: int
-) -> tuple[List[int], List[int]]:
-    """Select creatures for each side with roughly equal total value.
-
-    If no sufficiently balanced pairing is found after many attempts, a
-    ``ValueError`` is raised so the caller can try different creature
-    counts.  This prevents wildly unbalanced scenarios such as a single
-    small attacker facing an entire army of blockers.
-    """
-
-    idxs = list(values.keys())
-    if n_att + n_blk > len(idxs):
-        raise ValueError("Not enough cards to sample from")
-
-    best: tuple[list[int], list[int]] | None = None
-    best_diff = float("inf")
-
-    for _ in range(1000):
-        att_idx = random.sample(idxs, n_att)
-        remaining = [i for i in idxs if i not in att_idx]
-        blk_idx = random.sample(remaining, n_blk)
-
-        att_val = sum(values[i] for i in att_idx)
-        blk_val = sum(values[i] for i in blk_idx)
-        avg = (att_val + blk_val) / 2 or 1
-        diff = abs(att_val - blk_val) / avg
-
-        if diff < best_diff:
-            best = (att_idx, blk_idx)
-            best_diff = diff
-
-        if diff <= 0.25:
-            return att_idx, blk_idx
-
-    # No sufficiently balanced selection found
-    if best is None:
-        raise ValueError("Failed to sample creatures")
-    raise ValueError("Unable to generate balanced creature sets")
-
-
-def generate_balanced_creatures(
-    stats: Dict[str, object], n_att: int, n_blk: int
-) -> tuple[List, List]:
-    """Generate two sets of creatures with roughly equal value."""
-
-    best: tuple[list, list] | None = None
-    best_diff = float("inf")
-
-    for _ in range(1000):
-        attackers = [generate_random_creature(stats, controller="A") for _ in range(n_att)]
-        blockers = [generate_random_creature(stats, controller="B") for _ in range(n_blk)]
-
-        att_val = sum(_blocker_value(c) for c in attackers)
-        blk_val = sum(_blocker_value(c) for c in blockers)
-        avg = (att_val + blk_val) / 2 or 1
-        diff = abs(att_val - blk_val) / avg
-
-        if diff < best_diff:
-            best = (attackers, blockers)
-            best_diff = diff
-
-        if diff <= 0.25:
-            return attackers, blockers
-
-    if best is None:
-        raise ValueError("Failed to generate creatures")
-    raise ValueError("Unable to generate balanced creature sets")
 
 
 def main() -> None:
@@ -222,126 +115,30 @@ def main() -> None:
     cards = ensure_cards(args.cards)
     values = build_value_map(cards)
     stats = compute_card_statistics(cards) if args.generated_cards else None
-    valid_len = len(values)
 
     for i in range(args.iterations):
-        attempts = 0
-        while True:
-            attempts += 1
-            if attempts > 100:
-                raise RuntimeError("Unable to generate valid scenario")
-
-            n_atk = int(np.random.geometric(1 / 2.5))
-            n_blk = int(np.random.geometric(1 / 2.5))
-            n_atk = max(1, min(n_atk, valid_len // 2))
-            n_blk = max(1, min(n_blk, valid_len // 2))
-
-            try:
-                if args.generated_cards:
-                    attackers, blockers = generate_balanced_creatures(stats, n_atk, n_blk)
-                else:
-                    atk_idx, blk_idx = sample_balanced(cards, values, n_atk, n_blk)
-                    attackers = cards_to_creatures((cards[j] for j in atk_idx), "A")
-                    blockers = cards_to_creatures((cards[j] for j in blk_idx), "B")
-            except ValueError:
-                continue
-
-            assign_random_counters(attackers + blockers)
-            assign_random_tapped(blockers)
-
-            poison_relevant = any(c.infect or c.toxic for c in attackers + blockers)
-
-            state = GameState(
-                players={
-                    "A": PlayerState(
-                        life=random.randint(1, 20),
-                        creatures=attackers,
-                        poison=random.randint(0, 9) if poison_relevant else 0,
-                    ),
-                    "B": PlayerState(
-                        life=random.randint(1, 20),
-                        creatures=blockers,
-                        poison=random.randint(0, 9) if poison_relevant else 0,
-                    ),
-                }
-            )
-
-            provoke_map = {
-                atk: random.choice(blockers)
-                for atk in attackers
-                if atk.provoke
-            }
-            for blk in provoke_map.values():
-                blk.tapped = False
-
-            mentor_map = {}
-            for mentor in attackers:
-                if mentor.mentor:
-                    targets = [
-                        c
-                        for c in attackers
-                        if c is not mentor and c.effective_power() < mentor.effective_power()
-                    ]
-                    if targets:
-                        mentor_map[mentor] = random.choice(targets)
-
-            # Compute simple heuristic assignment on copies
-            simple_atk = copy.deepcopy(attackers)
-            simple_blk = copy.deepcopy(blockers)
-            simple_state = copy.deepcopy(state)
-            try:
-                decide_simple_blocks(
-                    simple_atk,
-                    simple_blk,
-                    game_state=simple_state,
-                    provoke_map=provoke_map,
-                )
-                sim_check = CombatSimulator(simple_atk, simple_blk, game_state=simple_state)
-                sim_check.validate_blocking()
-                atk_map = {id(a): i for i, a in enumerate(simple_atk)}
-                simple_assignment = tuple(
-                    atk_map.get(id(b.blocking), None) for b in simple_blk
-                )
-            except ValueError:
-                simple_assignment = None
-
-            try:
-                iters, opt_count = decide_optimal_blocks(
-                    attackers,
-                    blockers,
-                    game_state=state,
-                    provoke_map=provoke_map,
-                    max_iterations=args.max_iterations,
-                )
-                if args.unique_optimal and opt_count != 1:
-                    print(
-                        f"Skipping scenario {i+1}_{attempts}: {opt_count} optimal assignments"
-                    )
-                    continue
-            except (ValueError, RuntimeError):
-                continue
-
-            opt_map = {id(a): i for i, a in enumerate(attackers)}
-            optimal_assignment = tuple(
-                opt_map.get(id(b.blocking), None) for b in blockers
-            )
-            if (
-                simple_assignment is not None
-                and simple_assignment == optimal_assignment
-            ):
-                print(f'Skipping scenario {i+1}_{attempts}: too easy')
-                continue
-
-            start_state = copy.deepcopy(state)
-            sim = CombatSimulator(
-                attackers,
-                blockers,
-                game_state=state,
-                provoke_map=provoke_map,
-                mentor_map=mentor_map,
-            )
-            result = sim.simulate()
-            break
+        (
+            start_state,
+            attackers,
+            blockers,
+            provoke_map,
+            mentor_map,
+        ) = generate_random_scenario(
+            cards,
+            values,
+            stats,
+            generated_cards=args.generated_cards,
+            max_iterations=args.max_iterations,
+            unique_optimal=args.unique_optimal,
+        )
+        state = copy.deepcopy(start_state)
+        result = CombatSimulator(
+            attackers,
+            blockers,
+            game_state=state,
+            provoke_map=provoke_map,
+            mentor_map=mentor_map,
+        ).simulate()
 
         print(f"\n=== Scenario {i+1} ===")
         print("Starting life totals:")


### PR DESCRIPTION
## Summary
- centralize random combat scenario generation in `random_scenario.py`
- use new utility in `random_combat.py` and `evaluate_random_combat_scenarios.py`
- expose helper functions via package init

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858eb4cba3c832a912ae68483f08b40