### PR TITLE
Add simple JSONL LLM cache

### DIFF
--- a/magic_combat/__init__.py
+++ b/magic_combat/__init__.py
@@ -37,6 +37,7 @@ from .random_scenario import (
     generate_random_scenario,
 )
 from .create_llm_prompt import create_llm_prompt, parse_block_assignments
+from .llm_cache import LLMCache, MockLLMCache
 
 __all__ = [
     "CombatCreature",
@@ -71,4 +72,6 @@ __all__ = [
     "apply_blocker_bushido",
     "parse_block_assignments",
     "create_llm_prompt",
+    "LLMCache",
+    "MockLLMCache",
 ]

--- a/magic_combat/llm_cache.py
+++ b/magic_combat/llm_cache.py
@@ -1,0 +1,73 @@
+import json
+from pathlib import Path
+from typing import Optional
+
+
+class LLMCache:
+    """Simple JSONL cache for LLM responses."""
+
+    def __init__(self, path: str) -> None:
+        self.path = Path(path)
+        self.entries = []
+        if self.path.exists():
+            with self.path.open() as f:
+                for line in f:
+                    line = line.strip()
+                    if line:
+                        self.entries.append(json.loads(line))
+
+    def get(self, prompt: str, model: str, seed: int, temperature: float) -> Optional[str]:
+        for entry in self.entries:
+            if (
+                entry.get("prompt") == prompt
+                and entry.get("model") == model
+                and entry.get("seed") == seed
+                and entry.get("temperature") == temperature
+            ):
+                return entry.get("response")
+        return None
+
+    def add(
+        self,
+        prompt: str,
+        model: str,
+        seed: int,
+        temperature: float,
+        response: str,
+    ) -> None:
+        entry = {
+            "prompt": prompt,
+            "model": model,
+            "seed": seed,
+            "temperature": temperature,
+            "response": response,
+        }
+        self.entries.append(entry)
+        with self.path.open("a") as f:
+            f.write(json.dumps(entry) + "\n")
+
+
+class MockLLMCache(LLMCache):
+    """In-memory cache for testing purposes."""
+
+    def __init__(self) -> None:
+        self.entries = []
+        self.path = None  # type: ignore[assignment]
+
+    def add(
+        self,
+        prompt: str,
+        model: str,
+        seed: int,
+        temperature: float,
+        response: str,
+    ) -> None:
+        entry = {
+            "prompt": prompt,
+            "model": model,
+            "seed": seed,
+            "temperature": temperature,
+            "response": response,
+        }
+        self.entries.append(entry)
+        # No file operations for mock cache

--- a/scripts/evaluate_random_combat_scenarios.py
+++ b/scripts/evaluate_random_combat_scenarios.py
@@ -1,10 +1,19 @@
 import asyncio
-from typing import List
+from typing import List, Optional
 
 import openai
+from magic_combat.llm_cache import LLMCache
 
 
-async def call_openai_model_single_prompt(prompt: str, client: openai.AsyncClient) -> str:
+async def call_openai_model_single_prompt(
+    prompt: str,
+    client: openai.AsyncClient,
+    *,
+    model: str = "gpt-4o",
+    temperature: float = 0.2,
+    seed: int = 0,
+    cache: Optional[LLMCache] = None,
+) -> str:
     """
     Call the OpenAI model with a single prompt and return the response.
 
@@ -15,19 +24,45 @@ async def call_openai_model_single_prompt(prompt: str, client: openai.AsyncClien
     Returns:
         str: The response from the OpenAI model.
     """
+    cached = None
+    if cache is not None:
+        cached = cache.get(prompt, model, seed, temperature)
+    if cached is not None:
+        return cached
+
     response = await client.chat.completions.create(
-        model="gpt-4o",
+        model=model,
         messages=[{"role": "user", "content": prompt}],
         max_tokens=1500,
-        temperature=0.2,
+        temperature=temperature,
     )
-    return response.choices[0].message.content.strip()
+    text = response.choices[0].message.content.strip()
+    if cache is not None:
+        cache.add(prompt, model, seed, temperature, text)
+    return text
 
 
-async def call_openai_model(prompts: List[str]) -> str:
+async def call_openai_model(
+    prompts: List[str],
+    *,
+    model: str = "gpt-4o",
+    temperature: float = 0.2,
+    seed: int = 0,
+    cache: Optional[LLMCache] = None,
+) -> str:
     client = openai.AsyncClient()
     try:
-        tasks = [call_openai_model_single_prompt(prompt, client) for prompt in prompts]
+        tasks = [
+            call_openai_model_single_prompt(
+                prompt,
+                client,
+                model=model,
+                temperature=temperature,
+                seed=seed,
+                cache=cache,
+            )
+            for prompt in prompts
+        ]
         responses = await asyncio.gather(*tasks)
         return "\n\n".join(responses)
     finally:


### PR DESCRIPTION
## Summary
- implement a JSONL cache for LLM responses
- expose cache via `LLMCache` and `MockLLMCache`
- let OpenAI helper functions use the cache
- test caching behaviour with a mock cache

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859b8162f5c832aa1398e7633e983fc