### PR TITLE
Adapt for openai 1.79.0

### DIFF
--- a/scripts/evaluate_random_combat_scenarios.py
+++ b/scripts/evaluate_random_combat_scenarios.py
@@ -15,7 +15,7 @@ from magic_combat.llm_cache import LLMCache
 
 async def call_openai_model_single_prompt(
     prompt: str,
-    client: openai.AsyncClient,
+    client: openai.AsyncOpenAI,
     *,
     model: str = "gpt-4o",
     temperature: float = 0.2,
@@ -27,7 +27,7 @@ async def call_openai_model_single_prompt(
 
     Args:
         prompt (str): The prompt to send to the OpenAI model.
-        client (openai.Client): The OpenAI client instance.
+        client (openai.AsyncOpenAI): The OpenAI client instance.
 
     Returns:
         str: The response from the OpenAI model.
@@ -58,7 +58,7 @@ async def call_openai_model(
     seed: int = 0,
     cache: Optional[LLMCache] = None,
 ) -> str:
-    client = openai.AsyncClient()
+    client = openai.AsyncOpenAI()
     try:
         tasks = [
             call_openai_model_single_prompt(

--- a/tests/test_llm_prompt.py
+++ b/tests/test_llm_prompt.py
@@ -35,7 +35,7 @@ class DummyChat:
 class DummyClient:
     def __init__(self):
         self.chat = DummyChat()
-    async def aclose(self):
+    async def close(self):
         pass
 
 
@@ -63,14 +63,14 @@ def test_parse_block_assignments():
 
 def test_call_openai_model(monkeypatch):
     """CR 509.1a: The defending player chooses how creatures block."""
-    monkeypatch.setattr("openai.AsyncClient", lambda: DummyClient())
+    monkeypatch.setattr("openai.AsyncOpenAI", lambda: DummyClient())
     res = asyncio.run(call_openai_model(["p1", "p2"]))
     assert res == "response to p1\n\nresponse to p2"
 
 
 def test_llm_cache_hit(monkeypatch):
     """CR 509.1a: The defending player chooses how creatures block."""
-    monkeypatch.setattr("openai.AsyncClient", lambda: DummyClient())
+    monkeypatch.setattr("openai.AsyncOpenAI", lambda: DummyClient())
     cache = MockLLMCache()
     res1 = asyncio.run(
         call_openai_model(["p1"], model="m", temperature=0.3, seed=1, cache=cache)
@@ -86,7 +86,7 @@ def test_llm_cache_hit(monkeypatch):
 
 def test_llm_cache_miss(monkeypatch):
     """CR 509.1a: The defending player chooses how creatures block."""
-    monkeypatch.setattr("openai.AsyncClient", lambda: DummyClient())
+    monkeypatch.setattr("openai.AsyncOpenAI", lambda: DummyClient())
     cache = MockLLMCache()
     res1 = asyncio.run(
         call_openai_model(["p1"], model="m", temperature=0.3, seed=1, cache=cache)


### PR DESCRIPTION
## Summary
- update the OpenAI async client usage
- adjust tests for new `openai.AsyncOpenAI` interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859cf2c9404832ab8f90a840ec7ec3f