### PR TITLE
Improve LLM prompt and parsing

### DIFF
--- a/scripts/evaluate_random_combat_scenarios.py
+++ b/scripts/evaluate_random_combat_scenarios.py
@@ -9,7 +9,10 @@ from magic_combat import (
     generate_random_scenario,
     build_value_map,
 )
-from magic_combat.create_llm_prompt import create_llm_prompt, parse_block_assignments
+from magic_combat.create_llm_prompt import (
+    create_llm_prompt,
+    parse_block_assignments,
+)
 from magic_combat.llm_cache import LLMCache
 
 
@@ -111,16 +114,32 @@ async def evaluate_random_scenarios(n: int, cards_path: str) -> None:
         print(f"\n=== Scenario {idx+1} ===")
         print(prompt)
 
-        try:
-            llm_response = await call_openai_model([prompt])
-        except Exception as exc:  # pragma: no cover - network failure
-            print(f"Failed to query model: {exc}")
-            continue
+        attempts = 0
+        max_attempts = 3
+        while True:
+            try:
+                llm_response = await call_openai_model([prompt])
+            except Exception as exc:  # pragma: no cover - network failure
+                print(f"Failed to query model: {exc}")
+                break
+            try:
+                parsed, invalid = parse_block_assignments(
+                    llm_response, blockers, attackers
+                )
+            except ValueError:
+                attempts += 1
+                if attempts > max_attempts:
+                    print("Unparseable response; giving up")
+                    break
+                print("Unparseable response; retrying...")
+                continue
 
-        print("\nModel response:\n", llm_response)
-        parsed = parse_block_assignments(llm_response, blockers, attackers)
-        correct = sum(1 for b, a in parsed.items() if optimal.get(b) == a)
-        print(f"Correct assignments: {correct}/{len(blockers)}")
+            print("\nModel response:\n", llm_response)
+            if invalid:
+                print("Response contained illegal block assignments")
+            correct = sum(1 for b, a in parsed.items() if optimal.get(b) == a)
+            print(f"Correct assignments: {correct}/{len(blockers)}")
+            break
 
 
 def main() -> None:

--- a/tests/test_llm_prompt.py
+++ b/tests/test_llm_prompt.py
@@ -57,8 +57,25 @@ def test_create_prompt_contents():
 def test_parse_block_assignments():
     """CR 509.1a: The defending player chooses how creatures block."""
     text = "- Guard -> Goblin\n- Life total: 20"
-    result = parse_block_assignments(text, ["Guard"], ["Goblin"])
+    result, invalid = parse_block_assignments(text, ["Guard"], ["Goblin"])
+    assert not invalid
     assert result == {"Guard": "Goblin"}
+
+
+def test_parse_block_assignments_none():
+    """CR 509.1a: The defending player chooses how creatures block."""
+    text = "None"
+    result, invalid = parse_block_assignments(text, ["Guard"], ["Goblin"])
+    assert result == {}
+    assert not invalid
+
+
+def test_parse_block_assignments_invalid_name():
+    """CR 509.1a: The defending player chooses how creatures block."""
+    text = "- Foo -> Goblin"
+    result, invalid = parse_block_assignments(text, ["Guard"], ["Goblin"])
+    assert invalid
+    assert result == {}
 
 
 def test_call_openai_model(monkeypatch):


### PR DESCRIPTION
## Summary
- make the prompt clearer and specify a `None` marker for no blocks
- detect invalid block assignments and treat "None" as a valid empty list
- retry LLM calls when the output cannot be parsed
- expand tests for the new parser behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859dc3d6290832aadc55fce2af3f495