### PR TITLE
Add seed option for deterministic scenario evaluation

### DIFF
--- a/scripts/evaluate_random_combat_scenarios.py
+++ b/scripts/evaluate_random_combat_scenarios.py
@@ -1,5 +1,8 @@
 import asyncio
+import random
 from typing import List, Optional
+
+import numpy as np
 
 import openai
 from magic_combat import (
@@ -77,7 +80,15 @@ async def call_openai_model(
         await client.close()
 
 
-async def evaluate_random_scenarios(n: int, cards_path: str) -> None:
+async def evaluate_random_scenarios(
+    n: int,
+    cards_path: str,
+    *,
+    seed: int = 0,
+) -> None:
+
+    random.seed(seed)
+    np.random.seed(seed)
 
     cards = load_cards(cards_path)
     stats = compute_card_statistics(cards)
@@ -95,6 +106,7 @@ async def evaluate_random_scenarios(n: int, cards_path: str) -> None:
             values,
             stats,
             generated_cards=False,
+            seed=seed + idx,
         )
 
         # Determine optimal blocks for comparison
@@ -112,7 +124,7 @@ async def evaluate_random_scenarios(n: int, cards_path: str) -> None:
         print(prompt)
 
         try:
-            llm_response = await call_openai_model([prompt])
+            llm_response = await call_openai_model([prompt], seed=seed + idx)
         except Exception as exc:  # pragma: no cover - network failure
             print(f"Failed to query model: {exc}")
             continue
@@ -131,9 +143,12 @@ def main() -> None:
     parser.add_argument(
         "--cards", default="tests/example_test_cards.json", help="Card data JSON"
     )
+    parser.add_argument(
+        "--seed", type=int, default=0, help="Random seed controlling sampling"
+    )
     args = parser.parse_args()
 
-    asyncio.run(evaluate_random_scenarios(args.n, args.cards))
+    asyncio.run(evaluate_random_scenarios(args.n, args.cards, seed=args.seed))
 
 
 if __name__ == "__main__":

--- a/tests/test_random_scenario_seed.py
+++ b/tests/test_random_scenario_seed.py
@@ -1,0 +1,23 @@
+import random
+from magic_combat import load_cards
+from magic_combat.random_scenario import build_value_map, generate_random_scenario
+
+DATA_PATH = "tests/example_test_cards.json"
+
+
+def test_generate_random_scenario_seed():
+    """CR 509.1a: The defending player chooses how creatures block."""
+    cards = load_cards(DATA_PATH)
+    values = build_value_map(cards)
+    res1 = generate_random_scenario(cards, values, seed=123)
+    res2 = generate_random_scenario(cards, values, seed=123)
+
+    atk1 = [c.name for c in res1[1]]
+    atk2 = [c.name for c in res2[1]]
+    blk1 = [c.name for c in res1[2]]
+    blk2 = [c.name for c in res2[2]]
+
+    assert atk1 == atk2
+    assert blk1 == blk2
+    assert res1[0].players["A"].life == res2[0].players["A"].life
+    assert res1[0].players["B"].life == res2[0].players["B"].life


### PR DESCRIPTION
## Summary
- support passing a seed to `generate_random_scenario`
- pass deterministic seed through `evaluate_random_scenarios`
- expose a command-line seed flag for evaluation script
- ensure randomness uses the provided seed
- test that random scenarios repeat with the same seed

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859dc7e1364832abffcb99fc03bb27d