### PR TITLE
Fix default card path

### DIFF
--- a/scripts/evaluate_random_combat_scenarios.py
+++ b/scripts/evaluate_random_combat_scenarios.py
@@ -160,7 +160,9 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Evaluate LLM blocking advice")
     parser.add_argument("-n", type=int, default=1, help="Number of scenarios")
     parser.add_argument(
-        "--cards", default="tests/example_test_cards.json", help="Card data JSON"
+        "--cards",
+        default="tests/data/example_test_cards.json",
+        help="Card data JSON",
     )
     parser.add_argument(
         "--seed", type=int, default=0, help="Random seed controlling sampling"


### PR DESCRIPTION
## Summary
- point evaluate_random_combat_scenarios.py to example card data in `tests/data`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f85cdc1fc832a89b3db32629cf213