### PR TITLE
Fix lint and type errors

### DIFF
--- a/magic_combat/__init__.py
+++ b/magic_combat/__init__.py
@@ -1,45 +1,45 @@
 """Core package for the Magic Combat simulator."""
 
-from .creature import CombatCreature, Color
+from .creature import Color, CombatCreature
 
 # Default life total used when initializing ``PlayerState`` instances
 DEFAULT_STARTING_LIFE = 20
 # Poison counter threshold at which a player loses the game
 POISON_LOSS_THRESHOLD = 10
 
-from .simulator import CombatResult, CombatSimulator
-from .damage import DamageAssignmentStrategy, OptimalDamageStrategy
 from .blocking_ai import decide_optimal_blocks, decide_simple_blocks
-from .utils import (
-    calculate_mana_value,
-    apply_attacker_blocking_bonuses,
-    apply_blocker_bushido,
-)
 from .combat_utils import damage_creature, damage_player
+from .create_llm_prompt import create_llm_prompt, parse_block_assignments
+from .damage import DamageAssignmentStrategy, OptimalDamageStrategy
 from .gamestate import GameState, PlayerState, has_player_lost
+from .llm_cache import LLMCache, MockLLMCache
+from .random_creature import (
+    assign_random_counters,
+    assign_random_tapped,
+    compute_card_statistics,
+    generate_random_creature,
+)
+from .random_scenario import (
+    build_value_map,
+    ensure_cards,
+    generate_balanced_creatures,
+    generate_random_scenario,
+    sample_balanced,
+)
+from .rules_text import RULES_TEXT, get_relevant_rules_text
 from .scryfall_loader import (
+    card_to_creature,
+    cards_to_creatures,
     fetch_french_vanilla_cards,
     load_cards,
     save_cards,
-    card_to_creature,
-    cards_to_creatures,
 )
-from .random_creature import (
-    compute_card_statistics,
-    generate_random_creature,
-    assign_random_counters,
-    assign_random_tapped,
+from .simulator import CombatResult, CombatSimulator
+from .utils import (
+    apply_attacker_blocking_bonuses,
+    apply_blocker_bushido,
+    calculate_mana_value,
 )
-from .random_scenario import (
-    ensure_cards,
-    build_value_map,
-    sample_balanced,
-    generate_balanced_creatures,
-    generate_random_scenario,
-)
-from .create_llm_prompt import create_llm_prompt, parse_block_assignments
-from .llm_cache import LLMCache, MockLLMCache
-from .rules_text import RULES_TEXT, get_relevant_rules_text
 
 __all__ = [
     "CombatCreature",

--- a/magic_combat/block_utils.py
+++ b/magic_combat/block_utils.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 """Utility helpers for evaluating blocking assignments."""
 
 from copy import deepcopy
-from typing import Sequence, Optional, Tuple, Dict
+from typing import Dict, Optional, Sequence, Tuple
 
 from .creature import CombatCreature
+from .damage import OptimalDamageStrategy, score_combat_result
 from .gamestate import GameState
 from .limits import IterationCounter
-from .damage import OptimalDamageStrategy, score_combat_result
 from .simulator import CombatSimulator
 
 
@@ -19,7 +19,7 @@ def evaluate_block_assignment(
     state: Optional[GameState],
     counter: IterationCounter,
     provoke_map: Optional[Dict[CombatCreature, CombatCreature]] = None,
-) -> Tuple[int, float, int, int, int, Tuple[Optional[int], ...]]:
+) -> Tuple[int, float, int, int, int, int, Tuple[Optional[int], ...]]:
     """Simulate combat for ``assignment`` and return a scoring tuple."""
     atks = deepcopy(list(attackers))
     blks = deepcopy(list(blockers))
@@ -47,19 +47,23 @@ def evaluate_block_assignment(
         counter.increment()
         result = sim.simulate()
     except ValueError:
-        ass_key = tuple(len(attackers) if choice is None else choice for choice in assignment)
+        ass_key = tuple(
+            len(attackers) if choice is None else choice for choice in assignment
+        )
         return (
             1,
             float("inf"),
             -len(atks) - len(blks),
-            -float("inf"),
-            float("inf"),
-            float("inf"),
+            -(10**9),
+            10**9,
+            10**9,
             ass_key,
         )
 
     defender = blks[0].controller if blks else "defender"
     attacker_player = atks[0].controller if atks else "attacker"
-    ass_key = tuple(len(attackers) if choice is None else choice for choice in assignment)
+    ass_key = tuple(
+        len(attackers) if choice is None else choice for choice in assignment
+    )
     score = score_combat_result(result, attacker_player, defender) + (ass_key,)
     return score

--- a/magic_combat/create_llm_prompt.py
+++ b/magic_combat/create_llm_prompt.py
@@ -2,8 +2,26 @@
 
 from typing import Iterable
 
-from magic_combat import GameState, CombatCreature
-from scripts.random_combat import summarize_creature
+from .creature import CombatCreature
+from .gamestate import GameState
+from .rules_text import _describe_abilities
+
+
+def summarize_creature(creature: CombatCreature) -> str:
+    """Return a readable one-line summary of ``creature``."""
+
+    extra = []
+    if creature.plus1_counters:
+        extra.append(f"+1/+1 x{creature.plus1_counters}")
+    if creature.minus1_counters:
+        extra.append(f"-1/-1 x{creature.minus1_counters}")
+    if creature.damage_marked:
+        extra.append(f"{creature.damage_marked} dmg")
+    if creature.tapped:
+        extra.append("tapped")
+    extras = f" [{' ,'.join(extra)}]" if extra else ""
+    return f"{creature}{extras} -- {_describe_abilities(creature)}"
+
 
 def create_llm_prompt(
     game_state: GameState,
@@ -20,8 +38,8 @@ def create_llm_prompt(
     Returns:
         A formatted prompt for the model.
     """
-    attacker_string = '\n'.join(summarize_creature(attacker) for attacker in attackers)
-    blocker_string = '\n'.join(summarize_creature(blocker) for blocker in blockers)
+    attacker_string = "\n".join(summarize_creature(attacker) for attacker in attackers)
+    blocker_string = "\n".join(summarize_creature(blocker) for blocker in blockers)
 
     prompt = f"""You are a component of a Magic: The Gathering playing AI.
 Your task is to decide the best blocks for the defending player given a set of attackers, a set of candidate blockers, and the current game state.

--- a/magic_combat/scryfall_loader.py
+++ b/magic_combat/scryfall_loader.py
@@ -1,15 +1,12 @@
 import json
-from typing import List, Dict, Any, Iterable
-
-from .creature import CombatCreature
-from .parsing import (
-    parse_colors as _parse_colors,
-    apply_keyword_attributes,
-)
-from .keywords import ALLOWED_KEYWORDS
-
+from typing import Any, Dict, Iterable, List
 
 import requests
+
+from .creature import CombatCreature
+from .keywords import ALLOWED_KEYWORDS
+from .parsing import apply_keyword_attributes
+from .parsing import parse_colors as _parse_colors
 
 SCRYFALL_API = "https://api.scryfall.com/cards/search"
 QUERY = "is:frenchvanilla t:creature"
@@ -31,7 +28,7 @@ def fetch_french_vanilla_cards(timeout: float = 10.0) -> List[Dict[str, Any]]:
         of 10 seconds should be suitable for most use cases.
     """
     url = SCRYFALL_API
-    params = {"q": QUERY}
+    params: Dict[str, str] | None = {"q": QUERY}
     cards: List[Dict[str, Any]] = []
     with requests.Session() as session:
         while url:
@@ -71,8 +68,6 @@ def load_cards(path: str) -> List[Dict[str, Any]]:
         return json.load(fh)
 
 
-
-
 def card_to_creature(card: Dict[str, Any], controller: str) -> CombatCreature:
     """Convert a single card dictionary into a :class:`CombatCreature`."""
 
@@ -104,7 +99,9 @@ def card_to_creature(card: Dict[str, Any], controller: str) -> CombatCreature:
     return CombatCreature(**kwargs)
 
 
-def cards_to_creatures(cards: Iterable[Dict[str, Any]], controller: str) -> List[CombatCreature]:
+def cards_to_creatures(
+    cards: Iterable[Dict[str, Any]], controller: str
+) -> List[CombatCreature]:
     """Convert an iterable of card dicts into :class:`CombatCreature` objects."""
 
     return [card_to_creature(c, controller) for c in cards]

--- a/magic_combat/utils.py
+++ b/magic_combat/utils.py
@@ -3,6 +3,11 @@
 from __future__ import annotations
 
 import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .creature import CombatCreature
+
 
 def check_non_negative(value: int, name: str) -> None:
     """Validate that ``value`` is not negative.


### PR DESCRIPTION
## Summary
- fix circular imports in create_llm_prompt and random_scenario
- tighten types for random creature generation and scenario helpers
- annotate CombatSimulator attributes and tweak block utils return

## Testing
- `flake8`
- `pylint magic_combat`
- `mypy magic_combat`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f868f1674832aa99e71ac0829e2c6