### PR TITLE
Add argument type hints

### DIFF
--- a/magic_combat/damage.py
+++ b/magic_combat/damage.py
@@ -1,11 +1,12 @@
 """Damage assignment ordering strategies."""
 
-from typing import List, Tuple
-
-from .limits import IterationCounter
+from typing import TYPE_CHECKING, List, Tuple
 
 from .creature import CombatCreature
+from .limits import IterationCounter
 
+if TYPE_CHECKING:
+    from .simulator import CombatResult
 
 # Keyword sets used for estimating combat value of a creature
 _POSITIVE_KEYWORDS = [
@@ -61,7 +62,9 @@ def _blocker_value(blocker: CombatCreature) -> float:
     return blocker.power + blocker.toughness + positive / 2
 
 
-def _select_kill_indices(power: int, costs: List[float], values: List[float]) -> List[int]:
+def _select_kill_indices(
+    power: int, costs: List[float], values: List[float]
+) -> List[int]:
     """Return indices of blockers that should be destroyed first."""
 
     dp: List[Tuple[int, float, List[int]]] = [(0, 0.0, []) for _ in range(power + 1)]
@@ -87,7 +90,7 @@ def _select_kill_indices(power: int, costs: List[float], values: List[float]) ->
 
 
 def score_combat_result(
-    result,
+    result: "CombatResult",
     attacker_player: str,
     defender: str,
 ) -> Tuple[int, float, int, int, int, int]:
@@ -96,14 +99,20 @@ def score_combat_result(
     lost = 1 if defender in getattr(result, "players_lost", []) else 0
 
     att_val = sum(
-        _blocker_value(c) for c in result.creatures_destroyed if c.controller == attacker_player
+        _blocker_value(c)
+        for c in result.creatures_destroyed
+        if c.controller == attacker_player
     )
     def_val = sum(
-        _blocker_value(c) for c in result.creatures_destroyed if c.controller == defender
+        _blocker_value(c)
+        for c in result.creatures_destroyed
+        if c.controller == defender
     )
     val_diff = def_val - att_val
 
-    att_cnt = sum(1 for c in result.creatures_destroyed if c.controller == attacker_player)
+    att_cnt = sum(
+        1 for c in result.creatures_destroyed if c.controller == attacker_player
+    )
     def_cnt = sum(1 for c in result.creatures_destroyed if c.controller == defender)
     cnt_diff = def_cnt - att_cnt
 
@@ -124,7 +133,6 @@ class DamageAssignmentStrategy:
         return list(blockers)
 
 
-
 class OptimalDamageStrategy(DamageAssignmentStrategy):
     """Order blockers to maximize value destroyed similarly to optimal blocks."""
 
@@ -137,8 +145,9 @@ class OptimalDamageStrategy(DamageAssignmentStrategy):
         if len(blockers) <= 1:
             return list(blockers)
 
-        from itertools import permutations
         from copy import deepcopy
+        from itertools import permutations
+
         from .simulator import CombatSimulator
 
         index_map = {id(b): i for i, b in enumerate(blockers)}
@@ -154,10 +163,14 @@ class OptimalDamageStrategy(DamageAssignmentStrategy):
                 clone_map[id(b)].blocking = atk
 
             class _Fixed(DamageAssignmentStrategy):
-                def __init__(self, order):
+                def __init__(self, order: List[CombatCreature]) -> None:
                     self._order = order
-                def order_blockers(self, a, bs):
+
+                def order_blockers(
+                    self, a: CombatCreature, bs: List[CombatCreature]
+                ) -> List[CombatCreature]:
                     return self._order
+
             strat = _Fixed([clone_map[id(b)] for b in perm])
             sim = CombatSimulator([atk], blks, strategy=strat)
             if self.counter is not None:
@@ -173,4 +186,3 @@ class OptimalDamageStrategy(DamageAssignmentStrategy):
                 best_order = list(perm)
 
         return best_order
-

--- a/magic_combat/utils.py
+++ b/magic_combat/utils.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .creature import CombatCreature
+    from .gamestate import GameState, PlayerState
 
 
 def check_non_negative(value: int, name: str) -> None:
@@ -34,7 +35,7 @@ def check_positive(value: int, name: str) -> None:
         raise ValueError(f"{name} must be positive")
 
 
-def ensure_player_state(state, player: str):
+def ensure_player_state(state: "GameState", player: str) -> "PlayerState":
     """Return existing :class:`PlayerState` for ``player`` or create one."""
     if state is None:
         raise ValueError("state cannot be None")


### PR DESCRIPTION
## Summary
- type `state` parameter in `ensure_player_state`
- add `CombatResult` annotation to `score_combat_result`
- annotate internal `_Fixed` class in `damage`

## Testing
- `isort magic_combat/utils.py magic_combat/damage.py`
- `black magic_combat/utils.py magic_combat/damage.py`
- `flake8 magic_combat/utils.py magic_combat/damage.py`
- `pylint magic_combat/utils.py magic_combat/damage.py`
- `mypy --ignore-missing-imports magic_combat/utils.py magic_combat/damage.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f8ab203a8832a90a230e70d09074a