### PR TITLE
Improve LLM prompt with rules text and clean game state

### DIFF
--- a/magic_combat/create_llm_prompt.py
+++ b/magic_combat/create_llm_prompt.py
@@ -4,7 +4,7 @@ from typing import Iterable
 
 from .creature import CombatCreature
 from .gamestate import GameState
-from .rules_text import _describe_abilities
+from .rules_text import _describe_abilities, get_relevant_rules_text
 
 
 def summarize_creature(creature: CombatCreature) -> str:
@@ -40,6 +40,7 @@ def create_llm_prompt(
     """
     attacker_string = "\n".join(summarize_creature(attacker) for attacker in attackers)
     blocker_string = "\n".join(summarize_creature(blocker) for blocker in blockers)
+    rules_text = get_relevant_rules_text(list(attackers) + list(blockers))
 
     prompt = f"""You are a component of a Magic: The Gathering playing AI.
 Your task is to decide the best blocks for the defending player given a set of attackers, a set of candidate blockers, and the current game state.
@@ -52,6 +53,8 @@ The attackers are:
 
 The blockers are:
 {blocker_string}
+
+{rules_text}
 
 Please analyze the combat situation and provide a detailed explanation of the best blocking strategy for the defending player.
 The criteria for the best blocking strategy are as follows:

--- a/magic_combat/gamestate.py
+++ b/magic_combat/gamestate.py
@@ -1,14 +1,14 @@
-from __future__ import annotations
-
 """Game state representation for the combat simulator."""
+
+from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Dict, List
 
-from .utils import check_non_negative
-
-from .creature import CombatCreature
 from . import POISON_LOSS_THRESHOLD
+from .creature import CombatCreature
+from .rules_text import _describe_abilities
+from .utils import check_non_negative
 
 
 @dataclass
@@ -23,12 +23,32 @@ class PlayerState:
         check_non_negative(self.life, "life")
         check_non_negative(self.poison, "poison")
 
+    def __str__(self) -> str:
+        """Return a readable summary of the player's state."""
+        lines = [f"Life: {self.life}", f"Poison: {self.poison}"]
+        if self.creatures:
+            lines.append("Creatures:")
+            for creature in self.creatures:
+                lines.append(f"  - {creature} -- {_describe_abilities(creature)}")
+        else:
+            lines.append("Creatures: None")
+        return "\n".join(lines)
+
 
 @dataclass
 class GameState:
     """Overall game state tracking both players."""
 
     players: Dict[str, PlayerState] = field(default_factory=dict)
+
+    def __str__(self) -> str:
+        """Return a readable summary of all players."""
+        lines = []
+        for label, state in self.players.items():
+            lines.append(f"Player {label}:")
+            for line in str(state).splitlines():
+                lines.append(f"  {line}")
+        return "\n".join(lines)
 
 
 def has_player_lost(state: GameState, player: str) -> bool:


### PR DESCRIPTION
## Summary
- improve GameState and PlayerState `__str__` output for better readability
- include rules text snippets in `create_llm_prompt`

## Testing
- `isort magic_combat/create_llm_prompt.py magic_combat/gamestate.py`
- `black magic_combat/create_llm_prompt.py magic_combat/gamestate.py`
- `flake8 magic_combat/create_llm_prompt.py magic_combat/gamestate.py`
- `pylint magic_combat/create_llm_prompt.py magic_combat/gamestate.py`
- `mypy magic_combat/create_llm_prompt.py magic_combat/gamestate.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685f8bd7c0fc832ab77938e6e4b36ccf