### PR TITLE
Expose combat value evaluation and print in LLM eval

### DIFF
--- a/magic_combat/__init__.py
+++ b/magic_combat/__init__.py
@@ -22,6 +22,7 @@ from .random_creature import (
 from .random_scenario import (
     build_value_map,
     ensure_cards,
+    evaluate_combat_value,
     generate_balanced_creatures,
     generate_random_scenario,
     sample_balanced,
@@ -70,6 +71,7 @@ __all__ = [
     "sample_balanced",
     "generate_balanced_creatures",
     "generate_random_scenario",
+    "evaluate_combat_value",
     "damage_creature",
     "damage_player",
     "apply_attacker_blocking_bonuses",

--- a/magic_combat/damage.py
+++ b/magic_combat/damage.py
@@ -1,6 +1,9 @@
 """Damage assignment ordering strategies."""
 
-from typing import List, Tuple
+from typing import TYPE_CHECKING, List, Tuple
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .simulator import CombatResult
 
 from .creature import CombatCreature
 from .limits import IterationCounter

--- a/scripts/random_combat.py
+++ b/scripts/random_combat.py
@@ -119,6 +119,7 @@ def main() -> None:
             blockers,
             provoke_map,
             mentor_map,
+            *_,
         ) = generate_random_scenario(
             cards,
             values,

--- a/tests/random/test_random_scenario_seed.py
+++ b/tests/random/test_random_scenario_seed.py
@@ -1,4 +1,3 @@
-import random
 from pathlib import Path
 
 from magic_combat import load_cards


### PR DESCRIPTION
## Summary
- add `evaluate_combat_value` helper
- extend `generate_random_scenario` to return optimal and heuristic block maps and combat value
- print combat value comparison in `evaluate_random_combat_scenarios`
- expose `evaluate_combat_value` from package
- update sample script and test for new return signature
- fix mypy typing in damage module

## Testing
- `flake8 magic_combat/random_scenario.py scripts/evaluate_random_combat_scenarios.py scripts/random_combat.py magic_combat/__init__.py magic_combat/damage.py tests/random/test_random_scenario_seed.py`
- `pylint magic_combat/random_scenario.py scripts/evaluate_random_combat_scenarios.py scripts/random_combat.py magic_combat/__init__.py magic_combat/damage.py tests/random/test_random_scenario_seed.py`
- `mypy magic_combat/random_scenario.py scripts/evaluate_random_combat_scenarios.py scripts/random_combat.py magic_combat/__init__.py tests/random/test_random_scenario_seed.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f928995b4832a8be0ca36117f668a