### PR TITLE
Expose combat scenario values

### DIFF
--- a/magic_combat/damage.py
+++ b/magic_combat/damage.py
@@ -1,9 +1,12 @@
 """Damage assignment ordering strategies."""
 
-from typing import List, Tuple
+from typing import TYPE_CHECKING, List, Tuple
 
 from .creature import CombatCreature
 from .limits import IterationCounter
+
+if TYPE_CHECKING:  # pragma: no cover - used for type checking only
+    from .simulator import CombatResult
 
 # Keyword sets used for estimating combat value of a creature
 _POSITIVE_KEYWORDS = [

--- a/scripts/evaluate_random_combat_scenarios.py
+++ b/scripts/evaluate_random_combat_scenarios.py
@@ -1,22 +1,48 @@
 import asyncio
+import copy
 import random
 from typing import List, Optional
 
 import numpy as np
-
 import openai
+
 from magic_combat import (
-    load_cards,
-    compute_card_statistics,
-    decide_optimal_blocks,
-    generate_random_scenario,
+    CombatSimulator,
     build_value_map,
+    compute_card_statistics,
+    generate_random_scenario,
+    load_cards,
 )
-from magic_combat.create_llm_prompt import (
-    create_llm_prompt,
-    parse_block_assignments,
-)
+from magic_combat.create_llm_prompt import create_llm_prompt, parse_block_assignments
+from magic_combat.damage import score_combat_result
 from magic_combat.llm_cache import LLMCache
+
+
+def _value_for_assignment(
+    attackers: List,
+    blockers: List,
+    assignment: List[Optional[int]],
+    state,
+    provoke_map: dict,
+    mentor_map: dict,
+) -> tuple[int, int, int, float]:
+    atk = copy.deepcopy(attackers)
+    blk = copy.deepcopy(blockers)
+    state_copy = copy.deepcopy(state)
+    for idx, choice in enumerate(assignment):
+        if choice is not None:
+            blk[idx].blocking = atk[choice]
+            atk[choice].blocked_by.append(blk[idx])
+    sim = CombatSimulator(
+        atk,
+        blk,
+        game_state=state_copy,
+        provoke_map=provoke_map,
+        mentor_map=mentor_map,
+    )
+    result = sim.simulate()
+    score = score_combat_result(result, "A", "B")
+    return (score[4], score[5], score[2], score[1])
 
 
 async def call_openai_model_single_prompt(
@@ -50,7 +76,8 @@ async def call_openai_model_single_prompt(
         max_tokens=1500,
         temperature=temperature,
     )
-    text = response.choices[0].message.content.strip()
+    raw = response.choices[0].message.content or ""
+    text = raw.strip()
     if cache is not None:
         cache.add(prompt, model, seed, temperature, text)
     return text
@@ -102,8 +129,11 @@ async def evaluate_random_scenarios(
             state,
             attackers,
             blockers,
-            _,
-            _,
+            provoke_map,
+            mentor_map,
+            opt_map,
+            simple_map,
+            opt_value,
         ) = generate_random_scenario(
             cards,
             values,
@@ -112,9 +142,14 @@ async def evaluate_random_scenarios(
             seed=seed + idx,
         )
 
-        # Determine optimal blocks for comparison
-        decide_optimal_blocks(attackers, blockers, game_state=state)
-        optimal = {b.name: b.blocking.name if b.blocking else None for b in blockers}
+        optimal = {
+            blk.name: (attackers[choice].name if choice is not None else None)
+            for blk, choice in zip(blockers, opt_map)
+        }
+        simple = {
+            blk.name: (attackers[choice].name if choice is not None else None)
+            for blk, choice in zip(blockers, simple_map or [])
+        }
 
         # Clear assignments for the LLM prompt
         for atk in attackers:
@@ -150,7 +185,46 @@ async def evaluate_random_scenarios(
             if invalid:
                 print("Response contained illegal block assignments")
             correct = sum(1 for b, a in parsed.items() if optimal.get(b) == a)
+            llm_map = []
+            for blk in blockers:
+                target = parsed.get(blk.name)
+                idx_choice = None
+                if target is not None:
+                    for i, atk in enumerate(attackers):
+                        if atk.name == target:
+                            idx_choice = i
+                            break
+                llm_map.append(idx_choice)
+            llm_value = _value_for_assignment(
+                attackers,
+                blockers,
+                llm_map,
+                state,
+                provoke_map,
+                mentor_map,
+            )
+            simple_value = (
+                _value_for_assignment(
+                    attackers,
+                    blockers,
+                    list(simple_map),
+                    state,
+                    provoke_map,
+                    mentor_map,
+                )
+                if simple_map is not None
+                else None
+            )
+            diff = tuple(l - o for l, o in zip(llm_value, opt_value))
             print(f"Correct assignments: {correct}/{len(blockers)}")
+            print("Simple blocks:", simple)
+            print("Optimal blocks:", optimal)
+            print("LLM blocks:", {b: parsed.get(b) for b in optimal})
+            if simple_value is not None:
+                print("Simple value:", simple_value)
+            print("Optimal value:", opt_value)
+            print("LLM value:", llm_value)
+            print("Difference:", diff)
             break
 
 

--- a/scripts/random_combat.py
+++ b/scripts/random_combat.py
@@ -119,6 +119,7 @@ def main() -> None:
             blockers,
             provoke_map,
             mentor_map,
+            *_,
         ) = generate_random_scenario(
             cards,
             values,

--- a/tests/random/test_random_scenario_seed.py
+++ b/tests/random/test_random_scenario_seed.py
@@ -23,3 +23,5 @@ def test_generate_random_scenario_seed():
     assert blk1 == blk2
     assert res1[0].players["A"].life == res2[0].players["A"].life
     assert res1[0].players["B"].life == res2[0].players["B"].life
+    assert res1[5] == res2[5]
+    assert res1[7] == res2[7]


### PR DESCRIPTION
## Summary
- extend `generate_random_scenario` to return optimal and simple block maps along with a combat value tuple
- compute combat value using copied combatants and adjusted provoke/mentor maps
- score LLM responses in `evaluate_random_combat_scenarios` and print optimal, simple and LLM blocks and scores
- update CLI scripts and tests for new return values
- fix mypy issues in `damage` module

## Testing
- `flake8 magic_combat/damage.py magic_combat/random_scenario.py scripts/evaluate_random_combat_scenarios.py scripts/random_combat.py tests/random/test_random_scenario_seed.py`
- `pylint magic_combat/damage.py magic_combat/random_scenario.py scripts/evaluate_random_combat_scenarios.py scripts/random_combat.py tests/random/test_random_scenario_seed.py`
- `mypy magic_combat/damage.py magic_combat/random_scenario.py scripts/evaluate_random_combat_scenarios.py scripts/random_combat.py tests/random/test_random_scenario_seed.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f928995b4832a8be0ca36117f668a