### PR TITLE
Clean up unused imports in tests

### DIFF
--- a/comprehensive_rules.py
+++ b/comprehensive_rules.py
@@ -4,7 +4,6 @@ Downloaded from: https://media.wizards.com/2025/downloads/MagicCompRules%2020250
 See also: https://magic.wizards.com/en/rules
 """
 
-
 COMPREHENSIVE_RULES = """
 Magic: The Gathering Comprehensive Rules
 

--- a/tests/abilities/test_battalion.py
+++ b/tests/abilities/test_battalion.py
@@ -1,6 +1,4 @@
-import pytest
-
-from magic_combat import CombatCreature, CombatSimulator, GameState, PlayerState
+from magic_combat import CombatCreature, CombatSimulator
 from tests.conftest import link_block
 
 

--- a/tests/abilities/test_battle_cry.py
+++ b/tests/abilities/test_battle_cry.py
@@ -1,5 +1,3 @@
-import pytest
-
 from magic_combat import CombatCreature, CombatSimulator
 from tests.conftest import link_block
 

--- a/tests/abilities/test_deathtouch.py
+++ b/tests/abilities/test_deathtouch.py
@@ -1,5 +1,3 @@
-import pytest
-
 from magic_combat import (
     DEFAULT_STARTING_LIFE,
     CombatCreature,

--- a/tests/abilities/test_dethrone.py
+++ b/tests/abilities/test_dethrone.py
@@ -1,5 +1,3 @@
-import pytest
-
 from magic_combat import CombatCreature, CombatSimulator, GameState, PlayerState
 from tests.conftest import link_block
 

--- a/tests/abilities/test_exalted.py
+++ b/tests/abilities/test_exalted.py
@@ -1,5 +1,3 @@
-import pytest
-
 from magic_combat import CombatCreature, CombatSimulator, GameState, PlayerState
 from tests.conftest import link_block
 

--- a/tests/abilities/test_frenzy.py
+++ b/tests/abilities/test_frenzy.py
@@ -1,5 +1,3 @@
-import pytest
-
 from magic_combat import CombatCreature, CombatSimulator
 from tests.conftest import link_block
 

--- a/tests/abilities/test_lifelink.py
+++ b/tests/abilities/test_lifelink.py
@@ -1,6 +1,4 @@
-import pytest
-
-from magic_combat import CombatCreature, CombatSimulator, GameState, PlayerState
+from magic_combat import CombatCreature, CombatSimulator
 from tests.conftest import link_block
 
 

--- a/tests/abilities/test_poison.py
+++ b/tests/abilities/test_poison.py
@@ -1,5 +1,3 @@
-import pytest
-
 from magic_combat import (
     DEFAULT_STARTING_LIFE,
     POISON_LOSS_THRESHOLD,

--- a/tests/abilities/test_shadow.py
+++ b/tests/abilities/test_shadow.py
@@ -1,6 +1,6 @@
 import pytest
 
-from magic_combat import Color, CombatCreature, CombatSimulator
+from magic_combat import CombatCreature, CombatSimulator
 from tests.conftest import link_block
 
 

--- a/tests/abilities/test_skulk.py
+++ b/tests/abilities/test_skulk.py
@@ -1,6 +1,6 @@
 import pytest
 
-from magic_combat import Color, CombatCreature, CombatSimulator
+from magic_combat import CombatCreature, CombatSimulator
 from tests.conftest import link_block
 
 

--- a/tests/abilities/test_training.py
+++ b/tests/abilities/test_training.py
@@ -1,7 +1,6 @@
 import pytest
 
 from magic_combat import CombatCreature, CombatSimulator
-from tests.conftest import link_block
 
 
 def test_training_adds_counter():

--- a/tests/abilities/test_vigilance.py
+++ b/tests/abilities/test_vigilance.py
@@ -1,7 +1,6 @@
 import pytest
 
 from magic_combat import CombatCreature, CombatSimulator
-from tests.conftest import link_block
 
 
 def test_vigilance_attacker_stays_untapped():

--- a/tests/combat/test_basic_combat.py
+++ b/tests/combat/test_basic_combat.py
@@ -1,5 +1,3 @@
-import pytest
-
 from magic_combat import CombatCreature, CombatSimulator
 from tests.conftest import link_block
 

--- a/tests/combat/test_combat_buffs.py
+++ b/tests/combat/test_combat_buffs.py
@@ -1,12 +1,4 @@
-import pytest
-
-from magic_combat import (
-    DEFAULT_STARTING_LIFE,
-    CombatCreature,
-    CombatSimulator,
-    GameState,
-    PlayerState,
-)
+from magic_combat import CombatCreature, CombatSimulator
 from tests.conftest import link_block
 
 # Rampage tests

--- a/tests/combat/test_game_loss_scenarios.py
+++ b/tests/combat/test_game_loss_scenarios.py
@@ -1,5 +1,3 @@
-import pytest
-
 from magic_combat import (
     DEFAULT_STARTING_LIFE,
     POISON_LOSS_THRESHOLD,

--- a/tests/combat/test_gamestate.py
+++ b/tests/combat/test_gamestate.py
@@ -1,5 +1,3 @@
-import pytest
-
 from magic_combat import (
     DEFAULT_STARTING_LIFE,
     POISON_LOSS_THRESHOLD,

--- a/tests/combat/test_life_poison.py
+++ b/tests/combat/test_life_poison.py
@@ -1,5 +1,3 @@
-import pytest
-
 from magic_combat import (
     DEFAULT_STARTING_LIFE,
     POISON_LOSS_THRESHOLD,

--- a/tests/combat/test_lifelink_assignment.py
+++ b/tests/combat/test_lifelink_assignment.py
@@ -1,5 +1,3 @@
-import pytest
-
 from magic_combat import CombatCreature, CombatSimulator
 from tests.conftest import link_block
 

--- a/tests/combat/test_logged_scenarios.py
+++ b/tests/combat/test_logged_scenarios.py
@@ -1,5 +1,3 @@
-import pytest
-
 from magic_combat import (
     CombatCreature,
     CombatSimulator,
@@ -7,7 +5,6 @@ from magic_combat import (
     PlayerState,
     decide_optimal_blocks,
 )
-from magic_combat.creature import Color
 
 
 def test_logged_scenario_17():

--- a/tests/combat/test_simple_vs_optimal_difference.py
+++ b/tests/combat/test_simple_vs_optimal_difference.py
@@ -1,7 +1,4 @@
-import pytest
-
 from magic_combat import (
-    Color,
     CombatCreature,
     GameState,
     PlayerState,

--- a/tests/llm/test_llm_prompt.py
+++ b/tests/llm/test_llm_prompt.py
@@ -1,7 +1,5 @@
 import asyncio
 
-import pytest
-
 from magic_combat import CombatCreature, GameState, PlayerState
 from magic_combat.create_llm_prompt import create_llm_prompt, parse_block_assignments
 from magic_combat.llm_cache import MockLLMCache

--- a/tests/random/test_random_scenario_seed.py
+++ b/tests/random/test_random_scenario_seed.py
@@ -1,4 +1,3 @@
-import random
 from pathlib import Path
 
 from magic_combat import load_cards

--- a/tests/utils/test_counters.py
+++ b/tests/utils/test_counters.py
@@ -1,5 +1,3 @@
-import pytest
-
 from magic_combat import (
     DEFAULT_STARTING_LIFE,
     CombatCreature,


### PR DESCRIPTION
## Summary
- remove unused imports across tests
- sort imports with isort and reformat comprehensive rules with black

## Testing
- `flake8`
- `isort . --profile black --check`
- `black --check .`
- `mypy magic_combat`
- `pylint magic_combat`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685fa605d494832a884c4845ea60f87f