### PR TITLE
Add snapshot tests for optimal blocking

### DIFF
--- a/scripts/generate_blocking_snapshots.py
+++ b/scripts/generate_blocking_snapshots.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+"""Generate snapshot data for optimal blocking scenarios."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from magic_combat import build_value_map, generate_random_scenario, load_cards
+
+DEFAULT_CARDS = Path("tests/data/example_test_cards.json")
+DEFAULT_OUTPUT = Path("tests/data/blocking_snapshots.json")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Create snapshot data for optimal blocking tests"
+    )
+    parser.add_argument(
+        "--cards", type=Path, default=DEFAULT_CARDS, help="Path to card data JSON"
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help="Where to write snapshot JSON",
+    )
+    parser.add_argument(
+        "-n", "--count", type=int, default=5, help="Number of scenarios to generate"
+    )
+    parser.add_argument(
+        "--seed", type=int, default=0, help="Base random seed controlling sampling"
+    )
+    args = parser.parse_args()
+
+    cards = load_cards(str(args.cards))
+    values = build_value_map(cards)
+
+    data = []
+    for i in range(args.count):
+        seed = args.seed + i
+        (
+            _state,
+            _attackers,
+            _blockers,
+            _prov_map,
+            _mentor_map,
+            opt_map,
+            simple_map,
+            combat_value,
+        ) = generate_random_scenario(cards, values, seed=seed)
+        data.append(
+            {
+                "seed": seed,
+                "optimal_assignment": list(opt_map),
+                "simple_assignment": (
+                    list(simple_map) if simple_map is not None else None
+                ),
+                "combat_value": list(combat_value),
+            }
+        )
+
+    args.output.write_text(json.dumps(data, indent=2))
+
+
+if __name__ == "__main__":  # pragma: no cover - manual tool
+    main()

--- a/tests/data/blocking_snapshots.json
+++ b/tests/data/blocking_snapshots.json
@@ -1,0 +1,50 @@
+[
+  {
+    "seed": 100,
+    "optimal_assignment": [
+      0,
+      1
+    ],
+    "simple_assignment": null,
+    "combat_value": [
+      3,
+      0,
+      -1,
+      -0.5
+    ]
+  },
+  {
+    "seed": 101,
+    "optimal_assignment": [
+      2,
+      3
+    ],
+    "simple_assignment": [
+      1,
+      0
+    ],
+    "combat_value": [
+      3,
+      2,
+      -1,
+      -4.5
+    ]
+  },
+  {
+    "seed": 102,
+    "optimal_assignment": [
+      0,
+      0
+    ],
+    "simple_assignment": [
+      null,
+      0
+    ],
+    "combat_value": [
+      0,
+      0,
+      1,
+      1.5
+    ]
+  }
+]

--- a/tests/random/test_blocking_snapshots.py
+++ b/tests/random/test_blocking_snapshots.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from magic_combat import build_value_map, generate_random_scenario, load_cards
+
+DATA_PATH = Path(__file__).resolve().parents[1] / "data"
+CARD_FILE = DATA_PATH / "example_test_cards.json"
+SNAPSHOT_FILE = DATA_PATH / "blocking_snapshots.json"
+
+
+def test_blocking_snapshots() -> None:
+    """Ensure optimal blocks remain stable for known random seeds."""
+    snapshots = json.loads(SNAPSHOT_FILE.read_text())
+    cards = load_cards(str(CARD_FILE))
+    values = build_value_map(cards)
+
+    for snap in snapshots:
+        seed = snap["seed"]
+        (
+            _state,
+            _attackers,
+            _blockers,
+            _prov,
+            _mentor,
+            opt_map,
+            simple_map,
+            combat_value,
+        ) = generate_random_scenario(cards, values, seed=seed)
+        assert list(opt_map) == snap["optimal_assignment"]
+        expected_simple = snap["simple_assignment"]
+        assert (list(simple_map) if simple_map is not None else None) == expected_simple
+        assert list(combat_value) == snap["combat_value"]


### PR DESCRIPTION
## Summary
- add a script to generate snapshot data for optimal block outcomes
- store a few generated scenarios in `blocking_snapshots.json`
- add tests verifying the snapshots

## Testing
- `black .`
- `isort --profile black .`
- `flake8 .`
- `pylint magic_combat scripts tests`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68601db41b24832a98e00023c0e38f29