### PR TITLE
Add snapshot tests for optimal blocking

### DIFF
--- a/tests/combat/test_snapshot_blocks.py
+++ b/tests/combat/test_snapshot_blocks.py
@@ -1,0 +1,55 @@
+import json
+from pathlib import Path
+from typing import List, Optional
+
+from magic_combat import build_value_map, generate_random_scenario, load_cards
+from magic_combat.blocking_ai import decide_optimal_blocks
+from magic_combat.random_scenario import _score_optimal_result
+
+DATA_PATH = Path(__file__).resolve().parents[1] / "data"
+CARDS_PATH = DATA_PATH / "example_test_cards.json"
+SNAP_PATH = DATA_PATH / "blocking_snapshots.json"
+
+
+def _load_snapshots() -> List[dict]:
+    with SNAP_PATH.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def test_optimal_blocks_snapshots() -> None:
+    """CR 509.1a: The defending player chooses how creatures block."""
+    cards = load_cards(str(CARDS_PATH))
+    values = build_value_map(cards)
+    snapshots = _load_snapshots()
+    for snap in snapshots:
+        seed = snap["seed"]
+        (
+            state,
+            attackers,
+            blockers,
+            provoke_map,
+            mentor_map,
+            *_,
+        ) = generate_random_scenario(cards, values, seed=seed)
+        decide_optimal_blocks(
+            attackers,
+            blockers,
+            game_state=state,
+            provoke_map=provoke_map,
+        )
+        chosen: List[Optional[int]] = [
+            attackers.index(b.blocking) if b.blocking is not None else None
+            for b in blockers
+        ]
+        assert chosen == snap["optimal_assignment"]
+        value = list(
+            _score_optimal_result(
+                attackers,
+                blockers,
+                state,
+                tuple(chosen),
+                provoke_map,
+                mentor_map,
+            )
+        )
+        assert value == snap["combat_value"]

--- a/tests/data/blocking_snapshots.json
+++ b/tests/data/blocking_snapshots.json
@@ -1,0 +1,75 @@
+[
+  {
+    "seed": 0,
+    "optimal_assignment": [
+      1
+    ],
+    "simple_assignment": null,
+    "combat_value": [
+      2,
+      2,
+      -1,
+      -2.5
+    ]
+  },
+  {
+    "seed": 1,
+    "optimal_assignment": [
+      0,
+      1
+    ],
+    "simple_assignment": null,
+    "combat_value": [
+      4,
+      0,
+      -2,
+      -6.5
+    ]
+  },
+  {
+    "seed": 2,
+    "optimal_assignment": [
+      null
+    ],
+    "simple_assignment": null,
+    "combat_value": [
+      2,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "seed": 3,
+    "optimal_assignment": [
+      0,
+      1
+    ],
+    "simple_assignment": [
+      null,
+      1
+    ],
+    "combat_value": [
+      2,
+      2,
+      0,
+      2.0
+    ]
+  },
+  {
+    "seed": 4,
+    "optimal_assignment": [
+      1,
+      null,
+      1,
+      null
+    ],
+    "simple_assignment": null,
+    "combat_value": [
+      2,
+      0,
+      -1,
+      -7.0
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- add script to generate optimal blocking snapshots
- store generated scenarios as JSON
- test optimal block calculations against snapshots

## Testing
- `isort --profile black .`
- `black .`
- `flake8 .`
- `pylint magic_combat scripts tests/combat/test_snapshot_blocks.py`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68601db41b24832a98e00023c0e38f29