### PR TITLE
Add snapshot version checks

### DIFF
--- a/magic_combat/__init__.py
+++ b/magic_combat/__init__.py
@@ -6,6 +6,8 @@ from .creature import Color, CombatCreature
 DEFAULT_STARTING_LIFE = 20
 # Poison counter threshold at which a player loses the game
 POISON_LOSS_THRESHOLD = 10
+# Version tag used in snapshot test files
+SNAPSHOT_VERSION = "1"
 
 from .blocking_ai import decide_optimal_blocks, decide_simple_blocks
 from .combat_utils import damage_creature, damage_player
@@ -56,6 +58,7 @@ __all__ = [
     "calculate_mana_value",
     "DEFAULT_STARTING_LIFE",
     "POISON_LOSS_THRESHOLD",
+    "SNAPSHOT_VERSION",
     "fetch_french_vanilla_cards",
     "load_cards",
     "save_cards",

--- a/tests/combat/test_snapshot_blocks.py
+++ b/tests/combat/test_snapshot_blocks.py
@@ -1,8 +1,14 @@
 import json
+import warnings
 from pathlib import Path
 from typing import List, Optional
 
-from magic_combat import build_value_map, generate_random_scenario, load_cards
+from magic_combat import (
+    SNAPSHOT_VERSION,
+    build_value_map,
+    generate_random_scenario,
+    load_cards,
+)
 from magic_combat.blocking_ai import decide_optimal_blocks
 from magic_combat.random_scenario import _score_optimal_result
 
@@ -41,6 +47,12 @@ def test_optimal_blocks_snapshots() -> None:
             attackers.index(b.blocking) if b.blocking is not None else None
             for b in blockers
         ]
+        if snap.get("snapshot_version") != SNAPSHOT_VERSION:
+            warnings.warn(
+                "Outdated snapshot for seed %s (have %s, expected %s)"
+                % (seed, snap.get("snapshot_version"), SNAPSHOT_VERSION)
+            )
+            continue
         assert chosen == snap["optimal_assignment"]
         value = list(
             _score_optimal_result(

--- a/tests/data/blocking_snapshots.json
+++ b/tests/data/blocking_snapshots.json
@@ -10,7 +10,8 @@
       2,
       -1,
       -2.5
-    ]
+    ],
+    "snapshot_version": "1"
   },
   {
     "seed": 1,
@@ -24,7 +25,8 @@
       0,
       -2,
       -6.5
-    ]
+    ],
+    "snapshot_version": "1"
   },
   {
     "seed": 2,
@@ -37,7 +39,8 @@
       0,
       0,
       0
-    ]
+    ],
+    "snapshot_version": "1"
   },
   {
     "seed": 3,
@@ -54,7 +57,8 @@
       2,
       0,
       2.0
-    ]
+    ],
+    "snapshot_version": "1"
   },
   {
     "seed": 4,
@@ -70,6 +74,7 @@
       0,
       -1,
       -7.0
-    ]
+    ],
+    "snapshot_version": "1"
   }
 ]


### PR DESCRIPTION
## Summary
- add `SNAPSHOT_VERSION` constant
- embed version in blocking snapshot data
- only fail snapshot tests when snapshot version matches

## Testing
- `black --check .`
- `flake8`
- `isort --profile black --check .`
- `pylint $(git ls-files '*.py')`
- `mypy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68604746c6f0832aba92b03307599188