### PR TITLE
Add snapshot versioning

### DIFF
--- a/magic_combat/__init__.py
+++ b/magic_combat/__init__.py
@@ -7,6 +7,9 @@ DEFAULT_STARTING_LIFE = 20
 # Poison counter threshold at which a player loses the game
 POISON_LOSS_THRESHOLD = 10
 
+# Version string used to tag snapshot data for tests
+SNAPSHOT_VERSION = "1"
+
 from .blocking_ai import decide_optimal_blocks, decide_simple_blocks
 from .combat_utils import damage_creature, damage_player
 from .create_llm_prompt import create_llm_prompt, parse_block_assignments
@@ -56,6 +59,7 @@ __all__ = [
     "calculate_mana_value",
     "DEFAULT_STARTING_LIFE",
     "POISON_LOSS_THRESHOLD",
+    "SNAPSHOT_VERSION",
     "fetch_french_vanilla_cards",
     "load_cards",
     "save_cards",

--- a/scripts/generate_blocking_snapshots.py
+++ b/scripts/generate_blocking_snapshots.py
@@ -9,7 +9,12 @@ from typing import List, Optional
 
 import numpy as np
 
-from magic_combat import build_value_map, generate_random_scenario, load_cards
+from magic_combat import (
+    SNAPSHOT_VERSION,
+    build_value_map,
+    generate_random_scenario,
+    load_cards,
+)
 
 
 def _dump_snapshot(data: List[dict], path: Path) -> None:
@@ -52,6 +57,7 @@ def main() -> None:
         combat_value = list(res[7])
         snapshots.append(
             {
+                "version": SNAPSHOT_VERSION,
                 "seed": seed,
                 "optimal_assignment": optimal_assignment,
                 "simple_assignment": simple_assignment,

--- a/tests/combat/test_snapshot_blocks.py
+++ b/tests/combat/test_snapshot_blocks.py
@@ -2,7 +2,12 @@ import json
 from pathlib import Path
 from typing import List, Optional
 
-from magic_combat import build_value_map, generate_random_scenario, load_cards
+from magic_combat import (
+    SNAPSHOT_VERSION,
+    build_value_map,
+    generate_random_scenario,
+    load_cards,
+)
 from magic_combat.blocking_ai import decide_optimal_blocks
 from magic_combat.random_scenario import _score_optimal_result
 
@@ -22,6 +27,14 @@ def test_optimal_blocks_snapshots() -> None:
     values = build_value_map(cards)
     snapshots = _load_snapshots()
     for snap in snapshots:
+        if snap.get("version") != SNAPSHOT_VERSION:
+            print(
+                "Warning: snapshot version",
+                snap.get("version"),
+                "!=",
+                SNAPSHOT_VERSION,
+            )
+            continue
         seed = snap["seed"]
         (
             state,

--- a/tests/data/blocking_snapshots.json
+++ b/tests/data/blocking_snapshots.json
@@ -1,5 +1,6 @@
 [
   {
+    "version": "1",
     "seed": 0,
     "optimal_assignment": [
       1
@@ -13,6 +14,7 @@
     ]
   },
   {
+    "version": "1",
     "seed": 1,
     "optimal_assignment": [
       0,
@@ -27,6 +29,7 @@
     ]
   },
   {
+    "version": "1",
     "seed": 2,
     "optimal_assignment": [
       null
@@ -40,6 +43,7 @@
     ]
   },
   {
+    "version": "1",
     "seed": 3,
     "optimal_assignment": [
       0,
@@ -57,6 +61,7 @@
     ]
   },
   {
+    "version": "1",
     "seed": 4,
     "optimal_assignment": [
       1,


### PR DESCRIPTION
## Summary
- introduce `SNAPSHOT_VERSION` constant
- embed snapshot version in snapshot generation script
- update combat snapshot tests to check version and warn if mismatched
- include version data in stored snapshots

## Testing
- `isort --profile black .`
- `black . --quiet`
- `flake8 .`
- `pylint magic_combat tests scripts | tail -n 20`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68604746c6f0832aba92b03307599188