### PR TITLE
Reduce pyright warnings

### DIFF
--- a/magic_combat/blocking_ai.py
+++ b/magic_combat/blocking_ai.py
@@ -181,8 +181,10 @@ def decide_optimal_blocks(
             options.append(list(range(len(attackers))) + [None])
 
     best: Optional[Tuple[Optional[int], ...]] = None
-    best_score: Optional[tuple] = None
-    best_score_numeric: Optional[tuple] = None
+    best_score: Optional[
+        Tuple[int, float, int, int, int, int, Tuple[Optional[int], ...]]
+    ] = None
+    best_score_numeric: Optional[Tuple[int, float, int, int, int, int]] = None
     optimal_count = 0
 
     for assignment in product(*options):

--- a/magic_combat/creature.py
+++ b/magic_combat/creature.py
@@ -29,7 +29,7 @@ class CombatCreature:
     controller: str
     mana_cost: str = ""
     oracle_text: str = ""
-    colors: set[Color] = field(default_factory=set)
+    colors: set[Color] = field(default_factory=set[Color])
     artifact: bool = False
 
     # --- Combat Keywords ---
@@ -75,13 +75,13 @@ class CombatCreature:
     provoke: bool = False
 
     # --- Special Protections ---
-    protection_colors: set[Color] = field(default_factory=set)
+    protection_colors: set[Color] = field(default_factory=set[Color])
 
     # --- State ---
     tapped: bool = False
     attacking: bool = False
     blocking: Optional["CombatCreature"] = None
-    blocked_by: list["CombatCreature"] = field(default_factory=list)
+    blocked_by: list["CombatCreature"] = field(default_factory=list["CombatCreature"])
     damage_marked: int = 0
 
     # --- Counters ---

--- a/magic_combat/damage.py
+++ b/magic_combat/damage.py
@@ -64,33 +64,6 @@ def blocker_value(blocker: CombatCreature) -> float:
     return blocker.power + blocker.toughness + positive / 2
 
 
-def _select_kill_indices(
-    power: int, costs: List[float], values: List[float]
-) -> List[int]:
-    """Return indices of blockers that should be destroyed first."""
-
-    dp: List[Tuple[int, float, List[int]]] = [(0, 0.0, []) for _ in range(power + 1)]
-    for i, cost in enumerate(costs):
-        if cost == float("inf") or cost > power:
-            continue
-        int_cost = int(cost)
-        for w in range(power, int_cost - 1, -1):
-            prev_cnt, prev_val, prev_set = dp[w - int_cost]
-            cand_cnt = prev_cnt + 1
-            cand_val = prev_val + values[i]
-            curr_cnt, curr_val, _ = dp[w]
-            if cand_cnt > curr_cnt or (cand_cnt == curr_cnt and cand_val > curr_val):
-                dp[w] = (cand_cnt, cand_val, prev_set + [i])
-
-    best = dp[0]
-    for w in range(1, power + 1):
-        cnt, val, _ = dp[w]
-        if cnt > best[0] or (cnt == best[0] and val > best[1]):
-            best = dp[w]
-
-    return best[2]
-
-
 def score_combat_result(
     result: "CombatResult",
     attacker_player: str,

--- a/magic_combat/gamestate.py
+++ b/magic_combat/gamestate.py
@@ -40,11 +40,11 @@ class PlayerState:
 class GameState:
     """Overall game state tracking both players."""
 
-    players: dict[str, PlayerState] = field(default_factory=dict)
+    players: dict[str, PlayerState] = field(default_factory=dict[str, PlayerState])
 
     def __str__(self) -> str:
         """Return a readable summary of all players."""
-        lines = []
+        lines: list[str] = []
         for label, state in self.players.items():
             lines.append(f"Player {label}:")
             for line in str(state).splitlines():

--- a/magic_combat/random_creature.py
+++ b/magic_combat/random_creature.py
@@ -49,12 +49,12 @@ def compute_card_statistics(cards: Iterable[dict[str, Any]]) -> Dict[str, Any]:
     powers: list[int] = []
     toughnesses: list[int] = []
     ability_counts: Counter[str] = Counter()
-    pair_counts: Dict[str, Counter[str]] = defaultdict(Counter)
+    pair_counts: Dict[str, Counter[str]] = defaultdict(lambda: Counter[str]())
 
     for cr in creatures:
         powers.append(cr.power)
         toughnesses.append(cr.toughness)
-        present = []
+        present: list[str] = []
         for attr in _BOOL_ABILITIES:
             if getattr(cr, attr, False):
                 present.append(attr)
@@ -66,7 +66,7 @@ def compute_card_statistics(cards: Iterable[dict[str, Any]]) -> Dict[str, Any]:
         ability_counts.update(present)
         for i, a in enumerate(present):
             for b in present[i + 1 :]:
-                pair = tuple(sorted((a, b)))
+                pair = cast(Tuple[str, str], tuple(sorted((a, b))))
                 pair_counts[pair[0]][pair[1]] += 1
                 pair_counts[pair[1]][pair[0]] += 1
 

--- a/magic_combat/random_scenario.py
+++ b/magic_combat/random_scenario.py
@@ -109,7 +109,7 @@ def generate_balanced_creatures(
     stats: Dict[str, object], n_att: int, n_blk: int
 ) -> Tuple[list[CombatCreature], list[CombatCreature]]:
     """Generate two sets of creatures with roughly equal value."""
-    best: Tuple[List, List] | None = None
+    best: Tuple[list[CombatCreature], list[CombatCreature]] | None = None
     best_diff = float("inf")
 
     for _ in range(1000):
@@ -196,10 +196,12 @@ def _generate_interactions(
     attackers: list[CombatCreature],
     blockers: list[CombatCreature],
     rng: random.Random,
-) -> Tuple[dict, dict]:
+) -> Tuple[dict[CombatCreature, CombatCreature], dict[CombatCreature, CombatCreature],]:
     """Create provoke and mentor interaction mappings."""
 
-    provoke_map = {atk: rng.choice(blockers) for atk in attackers if atk.provoke}
+    provoke_map: dict[CombatCreature, CombatCreature] = {
+        atk: rng.choice(blockers) for atk in attackers if atk.provoke
+    }
     for blk in provoke_map.values():
         blk.tapped = False
 
@@ -221,7 +223,7 @@ def _determine_block_assignments(
     attackers: list[CombatCreature],
     blockers: list[CombatCreature],
     state: GameState,
-    provoke_map: dict,
+    provoke_map: dict[CombatCreature, CombatCreature],
     *,
     max_iterations: int,
     unique_optimal: bool,
@@ -269,8 +271,8 @@ def _score_optimal_result(
     blockers: list[CombatCreature],
     state: GameState,
     optimal_assignment: Tuple[Optional[int], ...],
-    provoke_map: dict,
-    mentor_map: dict,
+    provoke_map: dict[CombatCreature, CombatCreature],
+    mentor_map: dict[CombatCreature, CombatCreature],
 ) -> Tuple[int, int, int, float]:
     """Simulate combat using ``optimal_assignment`` and return its value."""
 
@@ -315,8 +317,8 @@ def _compute_combat_results(
     attackers: list[CombatCreature],
     blockers: list[CombatCreature],
     state: GameState,
-    provoke_map: dict,
-    mentor_map: dict,
+    provoke_map: dict[CombatCreature, CombatCreature],
+    mentor_map: dict[CombatCreature, CombatCreature],
     *,
     max_iterations: int,
     unique_optimal: bool,

--- a/scripts/generate_blocking_snapshots.py
+++ b/scripts/generate_blocking_snapshots.py
@@ -16,7 +16,7 @@ from magic_combat import load_cards
 from magic_combat.constants import SNAPSHOT_VERSION
 
 
-def _dump_snapshot(data: List[dict], path: Path) -> None:
+def _dump_snapshot(data: List[dict[str, object]], path: Path) -> None:
     """Write snapshot data to ``path`` in JSON format."""
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", encoding="utf-8") as fh:
@@ -47,7 +47,7 @@ def main() -> None:
     cards = load_cards(args.cards)
     values = build_value_map(cards)
 
-    snapshots: List[dict] = []
+    snapshots: List[dict[str, object]] = []
     for i in range(args.num):
         seed = args.seed + i
         res = generate_random_scenario(cards, values, seed=seed)

--- a/scripts/random_combat.py
+++ b/scripts/random_combat.py
@@ -16,12 +16,13 @@ from magic_combat import ensure_cards
 from magic_combat import generate_random_scenario
 from magic_combat.abilities import BOOL_NAMES as _BOOL_ABILITIES
 from magic_combat.abilities import INT_NAMES as _INT_ABILITIES
+from magic_combat.creature import CombatCreature
 from magic_combat.damage import blocker_value
 
 # Ability name mappings for pretty printing come from ``magic_combat.abilities``
 
 
-def describe_abilities(creature) -> str:
+def describe_abilities(creature: CombatCreature) -> str:
     """Return a comma-separated string of the creature's keyword abilities."""
     parts: List[str] = []
     for attr, name in _BOOL_ABILITIES.items():
@@ -39,7 +40,7 @@ def describe_abilities(creature) -> str:
     return ", ".join(parts) if parts else "none"
 
 
-def summarize_creature(creature) -> str:
+def summarize_creature(creature: CombatCreature) -> str:
     """Return a readable one-line summary of ``creature``."""
     extra: List[str] = []
     if creature.plus1_counters:
@@ -54,7 +55,9 @@ def summarize_creature(creature) -> str:
     return f"{creature}{extras} -- {describe_abilities(creature)}"
 
 
-def print_player_state(label: str, ps: PlayerState, destroyed: List) -> None:
+def print_player_state(
+    label: str, ps: PlayerState, destroyed: List[CombatCreature]
+) -> None:
     """Display life total and surviving creatures for a player."""
     print(f"{label}: {ps.life} life, {ps.poison} poison")
     survivors = [c for c in ps.creatures if c not in destroyed]
@@ -135,7 +138,7 @@ def main() -> None:
             mentor_map=mentor_map,
         ).simulate()
 
-        print(f"\n=== Scenario {i+1} ===")
+        print(f"\n=== Scenario {i + 1} ===")
         print("Starting life totals:")
         for p in ["A", "B"]:
             ps = start_state.players[p]


### PR DESCRIPTION
## Summary
- restore strict unknown-type warnings in pyrightconfig
- annotate dataclass defaults for proper typing
- refine types in random scenario helpers
- add parameter annotations in scripts
- fix pycodestyle whitespace

## Testing
- `isort --profile black .`
- `black .`
- `autoflake --in-place --remove-unused-variables -r magic_combat scripts`
- `pycodestyle --max-line-length=88 --ignore=E501,E203,W503 .`
- `flake8`
- `pylint magic_combat`
- `mypy`
- `npx -y pyright`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68607b143958832a90dac6f4285a2458