### PR TITLE
Fix lint errors in blocking_ai

### DIFF
--- a/magic_combat/blocking_ai.py
+++ b/magic_combat/blocking_ai.py
@@ -14,6 +14,7 @@ from .damage import blocker_value
 from .damage import score_combat_result
 from .gamestate import GameState
 from .limits import IterationCounter
+from .simulator import CombatResult
 from .simulator import CombatSimulator
 from .utils import can_block
 
@@ -80,7 +81,7 @@ def _best_value_trade_assignment(
             continue
 
         try:
-            result, dead_atk, dead_blk, score = _simulate_assignment(
+            _, dead_atk, dead_blk, score = _simulate_assignment(
                 attackers,
                 blockers,
                 assignment,
@@ -178,7 +179,7 @@ def _best_survival_assignment(
             continue
 
         try:
-            result, dead_atk, dead_blk, score = _simulate_assignment(
+            result, _dead_atk, _dead_blk, score = _simulate_assignment(
                 attackers,
                 blockers,
                 ass,
@@ -213,7 +214,7 @@ def _simulate_assignment(
     assignment: Sequence[Optional[int]],
     game_state: Optional[GameState],
     provoke_map: Optional[dict[CombatCreature, CombatCreature]] = None,
-) -> tuple["CombatResult", set[int], set[int], tuple[int, float, int, int, int, int],]:
+) -> tuple[CombatResult, set[int], set[int], tuple[int, float, int, int, int, int]]:
     """Return simulation result and sets of dead attacker/blocker indices."""
 
     from copy import deepcopy
@@ -365,9 +366,7 @@ def decide_simple_blocks(
         attackers, blockers, game_state, provoke_map
     )
 
-    result, *_ = _simulate_assignment(
-        attackers, blockers, best_ass, game_state, provoke_map
-    )
+    _, *_ = _simulate_assignment(attackers, blockers, best_ass, game_state, provoke_map)
 
     if best_score[0] != 0:
         second_ass, _ = _best_survival_assignment(


### PR DESCRIPTION
## Summary
- import `CombatResult` for type checking
- ignore unused variables returned by `_simulate_assignment`
- format with black and isort

## Testing
- `pytest -q`
- `pytest tests/test_style.py::test_flake8 -q`
- `pytest tests/test_style.py::test_mypy -q`
- `pytest tests/test_style.py::test_pyright -q`


------
https://chatgpt.com/codex/tasks/task_e_68608e754350832ab77cf268912dec2a