### PR TITLE
Fix iteration limit handling in simple AI

### DIFF
--- a/scripts/generate_blocking_snapshots.py
+++ b/scripts/generate_blocking_snapshots.py
@@ -54,13 +54,13 @@ def main() -> None:
         optimal_assignment: List[Optional[int]] = list(res[5])
         simple_assignment = list(res[6]) if res[6] is not None else None
         combat_value = list(res[7])
-        snapshot = {
-                "version": SNAPSHOT_VERSION,
-                "seed": seed,
-                "optimal_assignment": optimal_assignment,
-                "simple_assignment": simple_assignment,
-                "combat_value": combat_value,
-            }
+        snapshot: dict[str, object] = {
+            "version": SNAPSHOT_VERSION,
+            "seed": seed,
+            "optimal_assignment": optimal_assignment,
+            "simple_assignment": simple_assignment,
+            "combat_value": combat_value,
+        }
         snapshots.append(snapshot)
         print(snapshot)
 


### PR DESCRIPTION
## Summary
- track iterations during simple AI search
- propagate iteration counter through helper functions
- fix snapshot script typing
- test that simple AI enforces max_iterations

## Testing
- `flake8 magic_combat scripts tests`
- `pycodestyle --max-line-length=2000 --ignore=E203,W503,E226 --exclude=comprehensive_rules.py magic_combat scripts tests`
- `pylint magic_combat scripts tests`
- `mypy magic_combat scripts tests`
- `pyright magic_combat scripts tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686094ecc1c8832a99e1d596e2c5d29b