### PR TITLE
Fix extra info join

### DIFF
--- a/magic_combat/create_llm_prompt.py
+++ b/magic_combat/create_llm_prompt.py
@@ -20,7 +20,7 @@ def summarize_creature(creature: CombatCreature) -> str:
         extra.append(f"{creature.damage_marked} dmg")
     if creature.tapped:
         extra.append("tapped")
-    extras = f" [{' ,'.join(extra)}]" if extra else ""
+    extras = f" [{', '.join(extra)}]" if extra else ""
     return f"{creature}{extras} -- {describe_abilities(creature)}"
 
 

--- a/scripts/random_combat.py
+++ b/scripts/random_combat.py
@@ -51,7 +51,7 @@ def summarize_creature(creature: CombatCreature) -> str:
         extra.append(f"{creature.damage_marked} dmg")
     if creature.tapped:
         extra.append("tapped")
-    extras = f" [{' ,'.join(extra)}]" if extra else ""
+    extras = f" [{', '.join(extra)}]" if extra else ""
     return f"{creature}{extras} -- {describe_abilities(creature)}"
 
 


### PR DESCRIPTION
## Summary
- fix comma spacing in summarize_creature for CLI and LLM prompts

## Testing
- `flake8`
- `pycodestyle magic_combat/create_llm_prompt.py scripts/random_combat.py` *(fails: E501 line too long)*
- `pylint --exit-zero magic_combat/create_llm_prompt.py scripts/random_combat.py`
- `mypy magic_combat/create_llm_prompt.py scripts/random_combat.py`
- `pyright magic_combat/create_llm_prompt.py scripts/random_combat.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860a030aaf0832a906191bf58d08215