### PR TITLE
Align Python versions across configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ The ``magic_combat`` package now includes fully implemented modules such as
 ``CombatCreature`` and ``CombatSimulator`` which handle blocking validation,
 damage assignment, keyword abilities and more.
 
+This project requires **Python 3.12**.
+
 ## Repository layout
 
 ```

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,6 @@
 [mypy]
 files = magic_combat
-python_version = 3.10
+python_version = 3.12
 ignore_missing_imports = False
 strict_optional = True
 check_untyped_defs = True

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -32,3 +32,4 @@
   "reportUnusedExpression": "warning",
   "reportUnusedFunction": "warning"
 }
+


### PR DESCRIPTION
## Summary
- document supported Python 3.12 in README
- update `mypy.ini` to use Python 3.12
- add trailing newline to `pyrightconfig.json` so all configs reference Python 3.12

## Testing
- `black --check magic_combat scripts tests`
- `isort --profile black --check-only magic_combat scripts tests`
- `flake8 magic_combat scripts tests`
- `pycodestyle --max-line-length=2000 --ignore=E203,W503,E226 --exclude=comprehensive_rules.py magic_combat scripts tests`
- `autoflake --check --recursive magic_combat scripts tests`
- `pylint magic_combat scripts tests`
- `mypy magic_combat scripts tests`
- `pyright magic_combat scripts tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860a0078bec832aa6b3bd417128fb41