### PR TITLE
Fix LLMCache encoding

### DIFF
--- a/magic_combat/llm_cache.py
+++ b/magic_combat/llm_cache.py
@@ -11,7 +11,7 @@ class LLMCache:
         self.path = Path(path)
         self.entries: list[dict[str, object]] = []
         if self.path.exists():
-            with self.path.open() as f:
+            with self.path.open(encoding="utf8") as f:
                 for line in f:
                     line = line.strip()
                     if line:
@@ -46,7 +46,7 @@ class LLMCache:
             "response": response,
         }
         self.entries.append(entry)
-        with self.path.open("a") as f:
+        with self.path.open("a", encoding="utf8") as f:
             f.write(json.dumps(entry) + "\n")
 
 


### PR DESCRIPTION
## Summary
- ensure LLMCache reads and writes using UTF-8

## Testing
- `black --check magic_combat scripts tests`
- `isort --profile black --check-only magic_combat scripts tests`
- `flake8 magic_combat scripts tests`
- `pycodestyle --max-line-length=2000 --ignore=E203,W503,E226 --exclude=comprehensive_rules.py magic_combat scripts tests`
- `autoflake --check --recursive magic_combat scripts tests`
- `pylint magic_combat scripts tests`
- `mypy magic_combat scripts tests`
- `pyright magic_combat scripts tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68609ff3b994832a97c52fcc5a921fc2