### PR TITLE
Add custom exceptions and use them

### DIFF
--- a/magic_combat/__init__.py
+++ b/magic_combat/__init__.py
@@ -10,6 +10,9 @@ from .creature import Color
 from .creature import CombatCreature
 from .damage import DamageAssignmentStrategy
 from .damage import OptimalDamageStrategy
+from .exceptions import IllegalBlockError
+from .exceptions import InvalidBlockScenarioError
+from .exceptions import UnparsableLLMOutputError
 from .gamestate import GameState
 from .gamestate import PlayerState
 from .gamestate import has_player_lost
@@ -74,6 +77,9 @@ __all__ = [
     "damage_player",
     "apply_attacker_blocking_bonuses",
     "apply_blocker_bushido",
+    "IllegalBlockError",
+    "InvalidBlockScenarioError",
+    "UnparsableLLMOutputError",
     "parse_block_assignments",
     "create_llm_prompt",
     "LLMCache",

--- a/magic_combat/block_utils.py
+++ b/magic_combat/block_utils.py
@@ -9,6 +9,7 @@ from typing import Tuple
 from .creature import CombatCreature
 from .damage import OptimalDamageStrategy
 from .damage import score_combat_result
+from .exceptions import IllegalBlockError
 from .gamestate import GameState
 from .limits import IterationCounter
 from .simulator import CombatSimulator
@@ -50,7 +51,7 @@ def evaluate_block_assignment(
     try:
         counter.increment()
         result = sim.simulate()
-    except ValueError:
+    except IllegalBlockError:
         ass_key = tuple(
             len(attackers) if choice is None else choice for choice in assignment
         )

--- a/magic_combat/blocking_ai.py
+++ b/magic_combat/blocking_ai.py
@@ -12,6 +12,7 @@ from .block_utils import evaluate_block_assignment
 from .creature import CombatCreature
 from .damage import blocker_value
 from .damage import score_combat_result
+from .exceptions import IllegalBlockError
 from .gamestate import GameState
 from .limits import IterationCounter
 from .simulator import CombatResult
@@ -90,7 +91,7 @@ def _best_value_trade_assignment(
                 provoke_map,
                 counter,
             )
-        except ValueError:
+        except IllegalBlockError:
             continue
 
         # Reject any blocks that fail to at least trade.
@@ -190,7 +191,7 @@ def _best_survival_assignment(
                 provoke_map,
                 counter,
             )
-        except ValueError:
+        except IllegalBlockError:
             continue
 
         if score[0] != 0:

--- a/magic_combat/create_llm_prompt.py
+++ b/magic_combat/create_llm_prompt.py
@@ -138,5 +138,7 @@ def parse_block_assignments(
         else:
             invalid = True
     if not seen_assignment:
-        raise ValueError("No block assignments found")
+        from .exceptions import UnparsableLLMOutputError
+
+        raise UnparsableLLMOutputError("No block assignments found")
     return pairs, invalid

--- a/magic_combat/exceptions.py
+++ b/magic_combat/exceptions.py
@@ -1,0 +1,17 @@
+"""Custom exception types for the Magic Combat package."""
+
+
+class MagicCombatError(Exception):
+    """Base class for custom exceptions in this package."""
+
+
+class UnparsableLLMOutputError(MagicCombatError):
+    """Raised when language model output cannot be parsed."""
+
+
+class IllegalBlockError(MagicCombatError, ValueError):
+    """Raised when combat contains illegal blocking assignments."""
+
+
+class InvalidBlockScenarioError(MagicCombatError):
+    """Raised when generated block assignments are invalid or trivial."""

--- a/magic_combat/random_scenario.py
+++ b/magic_combat/random_scenario.py
@@ -19,6 +19,8 @@ from .blocking_ai import decide_simple_blocks
 from .creature import CombatCreature
 from .damage import blocker_value
 from .damage import score_combat_result
+from .exceptions import IllegalBlockError
+from .exceptions import InvalidBlockScenarioError
 from .gamestate import GameState
 from .gamestate import PlayerState
 from .random_creature import assign_random_counters
@@ -245,7 +247,7 @@ def _determine_block_assignments(
         sim_check.validate_blocking()
         atk_map = {id(a): i for i, a in enumerate(simple_atk)}
         simple_assignment = tuple(atk_map.get(id(b.blocking), None) for b in simple_blk)
-    except ValueError:
+    except IllegalBlockError:
         simple_assignment = None
 
     _, opt_count = decide_optimal_blocks(
@@ -256,13 +258,13 @@ def _determine_block_assignments(
         max_iterations=max_iterations,
     )
     if unique_optimal and opt_count != 1:
-        raise RuntimeError("non unique optimal blocks")
+        raise InvalidBlockScenarioError("non unique optimal blocks")
 
     opt_map = {id(a): i for i, a in enumerate(attackers)}
     optimal_assignment = tuple(opt_map.get(id(b.blocking), None) for b in blockers)
 
     if simple_assignment is not None and simple_assignment == optimal_assignment:
-        raise RuntimeError("simple blocks equal optimal")
+        raise InvalidBlockScenarioError("simple blocks equal optimal")
 
     return simple_assignment, optimal_assignment
 
@@ -419,7 +421,7 @@ def generate_random_scenario(
                 max_iterations=max_iterations,
                 unique_optimal=unique_optimal,
             )
-        except (ValueError, RuntimeError):
+        except (IllegalBlockError, InvalidBlockScenarioError):
             continue
 
         start_state = copy.deepcopy(state)

--- a/scripts/evaluate_random_combat_scenarios.py
+++ b/scripts/evaluate_random_combat_scenarios.py
@@ -16,6 +16,7 @@ from magic_combat.create_llm_prompt import create_llm_prompt
 from magic_combat.create_llm_prompt import parse_block_assignments
 from magic_combat.creature import CombatCreature
 from magic_combat.damage import score_combat_result
+from magic_combat.exceptions import UnparsableLLMOutputError
 from magic_combat.gamestate import GameState
 from magic_combat.llm_cache import LLMCache
 
@@ -169,7 +170,7 @@ async def _evaluate_single_scenario(
             continue
         try:
             parsed, invalid = parse_block_assignments(llm_response, blockers, attackers)
-        except ValueError:
+        except UnparsableLLMOutputError:
             attempts += 1
             if attempts > max_attempts:
                 print("Unparseable response; giving up")


### PR DESCRIPTION
## Summary
- define new MagicCombat exception module with custom error types
- expose custom errors in package exports
- use UnparsableLLMOutputError in LLM parsing helper and script
- use IllegalBlockError throughout simulator and catching code
- raise InvalidBlockScenarioError for duplicate/simple block scenarios

## Testing
- `isort --profile black .`
- `black .`
- `autoflake --in-place --remove-unused-variables --remove-all-unused-imports -r .`
- `flake8`
- `pycodestyle . > /tmp/pycodestyle.log`
- `pylint magic_combat > /tmp/pylint.log`
- `mypy -p magic_combat > /tmp/mypy.log`
- `pyright > /tmp/pyright.log`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860a0c43188832a8e2768e423c4897a