### PR TITLE
Refactor combat result scoring

### DIFF
--- a/magic_combat/block_utils.py
+++ b/magic_combat/block_utils.py
@@ -8,7 +8,6 @@ from typing import Tuple
 
 from .creature import CombatCreature
 from .damage import OptimalDamageStrategy
-from .damage import score_combat_result
 from .exceptions import IllegalBlockError
 from .gamestate import GameState
 from .limits import IterationCounter
@@ -70,5 +69,5 @@ def evaluate_block_assignment(
     ass_key = tuple(
         len(attackers) if choice is None else choice for choice in assignment
     )
-    score = score_combat_result(result, attacker_player, defender) + (ass_key,)
+    score = result.score(attacker_player, defender) + (ass_key,)
     return score

--- a/magic_combat/blocking_ai.py
+++ b/magic_combat/blocking_ai.py
@@ -11,7 +11,6 @@ from typing import Tuple
 from .block_utils import evaluate_block_assignment
 from .creature import CombatCreature
 from .damage import blocker_value
-from .damage import score_combat_result
 from .exceptions import IllegalBlockError
 from .gamestate import GameState
 from .limits import IterationCounter
@@ -90,6 +89,8 @@ def _best_value_trade_assignment(
                 game_state,
                 provoke_map,
                 counter,
+                include_life=False,
+                include_poison=False,
             )
         except IllegalBlockError:
             continue
@@ -220,6 +221,13 @@ def _simulate_assignment(
     game_state: Optional[GameState],
     provoke_map: Optional[dict[CombatCreature, CombatCreature]] = None,
     counter: IterationCounter | None = None,
+    *,
+    include_life: bool = True,
+    include_poison: bool = True,
+    include_mana: bool = True,
+    include_value: bool = True,
+    include_count: bool = True,
+    include_loss: bool = True,
 ) -> tuple[CombatResult, set[int], set[int], tuple[int, float, int, int, int, int]]:
     """Return simulation result and sets of dead attacker/blocker indices."""
 
@@ -254,7 +262,16 @@ def _simulate_assignment(
     result = sim.simulate()
     attacker_player = atk_copy[0].controller if atk_copy else "attacker"
     defender = blk_copy[0].controller if blk_copy else "defender"
-    score = score_combat_result(result, attacker_player, defender)
+    score = result.score(
+        attacker_player,
+        defender,
+        include_life=include_life,
+        include_poison=include_poison,
+        include_mana=include_mana,
+        include_value=include_value,
+        include_count=include_count,
+        include_loss=include_loss,
+    )
 
     dead_atk = {atk_map[id(c)] for c in result.creatures_destroyed if id(c) in atk_map}
     dead_blk = {blk_map[id(c)] for c in result.creatures_destroyed if id(c) in blk_map}

--- a/magic_combat/damage.py
+++ b/magic_combat/damage.py
@@ -69,31 +69,9 @@ def score_combat_result(
     attacker_player: str,
     defender: str,
 ) -> Tuple[int, float, int, int, int, int]:
-    """Return a scoring tuple evaluating combat from the defender's perspective."""
+    """Wrapper calling :meth:`CombatResult.score` for backward compatibility."""
 
-    lost = 1 if defender in getattr(result, "players_lost", []) else 0
-
-    att_val = sum(
-        blocker_value(c)
-        for c in result.creatures_destroyed
-        if c.controller == attacker_player
-    )
-    def_val = sum(
-        blocker_value(c) for c in result.creatures_destroyed if c.controller == defender
-    )
-    val_diff = def_val - att_val
-
-    att_cnt = sum(
-        1 for c in result.creatures_destroyed if c.controller == attacker_player
-    )
-    def_cnt = sum(1 for c in result.creatures_destroyed if c.controller == defender)
-    cnt_diff = def_cnt - att_cnt
-
-    mana_total = sum(c.mana_value for c in result.creatures_destroyed)
-    life_lost = result.damage_to_players.get(defender, 0)
-    poison = result.poison_counters.get(defender, 0)
-
-    return (lost, val_diff, cnt_diff, -mana_total, life_lost, poison)
+    return result.score(attacker_player, defender)
 
 
 class DamageAssignmentStrategy:
@@ -153,7 +131,7 @@ class OptimalDamageStrategy(DamageAssignmentStrategy):
             attacker_player = attacker.controller
             defender = blockers[0].controller
             key = tuple(index_map[id(b)] for b in perm)
-            score = score_combat_result(result, attacker_player, defender) + (key,)
+            score = result.score(attacker_player, defender) + (key,)
             if best_score is None or score > best_score:
                 best_score = score
                 best_order = list(perm)

--- a/magic_combat/random_scenario.py
+++ b/magic_combat/random_scenario.py
@@ -160,7 +160,10 @@ def _sample_creatures(
             raise ValueError("stats must be provided when generated_cards is True")
         return generate_balanced_creatures(stats, n_atk, n_blk)
 
-    atk_idx, blk_idx_list = sample_balanced(cards, values, n_atk, n_blk, rng=rng)
+    try:
+        atk_idx, blk_idx_list = sample_balanced(cards, values, n_atk, n_blk, rng=rng)
+    except ValueError as exc:  # pragma: no cover - rare
+        raise InvalidBlockScenarioError(str(exc)) from exc
     attackers = cards_to_creatures((cards[j] for j in atk_idx), "A")
     blockers = cards_to_creatures((cards[j] for j in blk_idx_list), "B")
     return attackers, blockers

--- a/tests/core/test_combat_result_score.py
+++ b/tests/core/test_combat_result_score.py
@@ -1,0 +1,18 @@
+from magic_combat import CombatCreature
+from magic_combat import CombatResult
+
+
+def test_score_optional_components():
+    atk = CombatCreature("Goblin", 2, 2, "A")
+    res = CombatResult(
+        damage_to_players={"B": 2},
+        creatures_destroyed=[atk],
+        lifegain={},
+        poison_counters={"B": 1},
+    )
+    full = res.score("A", "B")
+    partial = res.score("A", "B", include_life=False, include_poison=False)
+    assert full[4] == 2
+    assert full[5] == 1
+    assert partial[4] == 0
+    assert partial[5] == 0


### PR DESCRIPTION
## Summary
- move `score_combat_result` logic into `CombatResult.score`
- update consumers to use new method
- add formatting helper for scenario evaluation script
- handle failed creature sampling gracefully
- test optional score components

## Testing
- `isort --profile black magic_combat scripts tests`
- `black .`
- `autoflake --in-place --remove-unused-variables --remove-all-unused-imports -r magic_combat scripts tests`
- `pycodestyle --max-line-length=88 --ignore=E203,W503,E226 --exclude=comprehensive_rules.py,tests,magic_combat/rules_text.py magic_combat scripts`
- `python -m pylint magic_combat scripts` *(no output)*
- `mypy magic_combat`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860a621c40c832aabf647735b75d05b