### PR TITLE
Clarify custom error guideline

### DIFF
--- a/style_guide.md
+++ b/style_guide.md
@@ -57,4 +57,8 @@ requirements to ensure consistency across the code base.
 - Avoid relative imports that escape the package.
 - Limit parameter lists to keep APIs simple.
 - Document non-obvious behavior with comments and docstrings.
+- Domain-specific errors should be implemented as custom exception classes
+  derived from ``MagicCombatError`` (and from relevant built-in exceptions
+  when compatibility is needed). Examples include ``IterationLimitError``,
+  ``CardDataError``, ``ScenarioGenerationError`` and ``MissingStatisticsError``.
 


### PR DESCRIPTION
## Summary
- document our approach for domain-specific errors
- reference new custom error classes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860aba8c614832aba64da875d7dee48