### PR TITLE
Introduce IterationLimitError for iteration counter

### DIFF
--- a/magic_combat/__init__.py
+++ b/magic_combat/__init__.py
@@ -15,6 +15,7 @@ from .damage import DamageAssignmentStrategy
 from .damage import OptimalDamageStrategy
 from .exceptions import IllegalBlockError
 from .exceptions import InvalidBlockScenarioError
+from .exceptions import IterationLimitError
 from .exceptions import UnparsableLLMOutputError
 from .gamestate import GameState
 from .gamestate import PlayerState
@@ -76,6 +77,7 @@ __all__ = [
     "apply_blocker_bushido",
     "IllegalBlockError",
     "InvalidBlockScenarioError",
+    "IterationLimitError",
     "UnparsableLLMOutputError",
     "parse_block_assignments",
     "create_llm_prompt",

--- a/magic_combat/exceptions.py
+++ b/magic_combat/exceptions.py
@@ -15,3 +15,7 @@ class IllegalBlockError(MagicCombatError, ValueError):
 
 class InvalidBlockScenarioError(MagicCombatError):
     """Raised when generated block assignments are invalid or trivial."""
+
+
+class IterationLimitError(MagicCombatError, RuntimeError):
+    """Raised when a search exceeds the configured iteration limit."""

--- a/magic_combat/limits.py
+++ b/magic_combat/limits.py
@@ -6,7 +6,9 @@ class IterationCounter:
         self.count = 0
 
     def increment(self) -> None:
-        """Increment the counter and raise ``RuntimeError`` if the limit is exceeded."""
+        """Increment the counter and raise ``IterationLimitError`` if exceeded."""
         self.count += 1
         if self.count > self.max_iterations:
-            raise RuntimeError("Maximum combat simulation iterations exceeded")
+            from .exceptions import IterationLimitError
+
+            raise IterationLimitError("Maximum combat simulation iterations exceeded")

--- a/tests/combat/test_block_ai.py
+++ b/tests/combat/test_block_ai.py
@@ -369,7 +369,9 @@ def test_iteration_limit_triggers():
             "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[b1, b2]),
         }
     )
-    with pytest.raises(RuntimeError):
+    from magic_combat import IterationLimitError
+
+    with pytest.raises(IterationLimitError):
         decide_optimal_blocks([atk], [b1, b2], game_state=state, max_iterations=1)
 
 

--- a/tests/combat/test_simple_block_ai.py
+++ b/tests/combat/test_simple_block_ai.py
@@ -302,7 +302,9 @@ def test_simple_ai_iteration_limit_triggers():
             "B": PlayerState(life=20, creatures=[b1, b2]),
         }
     )
-    with pytest.raises(RuntimeError):
+    from magic_combat import IterationLimitError
+
+    with pytest.raises(IterationLimitError):
         decide_simple_blocks([atk], [b1, b2], game_state=state, max_iterations=1)
 
 


### PR DESCRIPTION
## Summary
- add `IterationLimitError` exception
- raise `IterationLimitError` in `IterationCounter.increment`
- export the new exception in `magic_combat.__all__`
- update combat AI tests to expect the new exception

## Testing
- `black magic_combat tests scripts -q`
- `isort --profile black magic_combat tests scripts`
- `autoflake --check --recursive magic_combat scripts tests`
- `flake8 magic_combat scripts tests`
- `pycodestyle --max-line-length=88 --ignore=E203,W503,E226 --exclude=comprehensive_rules.py,tests,magic_combat/rules_text.py magic_combat scripts`
- `pylint magic_combat scripts tests`
- `mypy magic_combat tests scripts`
- `pyright magic_combat tests scripts`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860ab9de6a0832a84d4cedfa09794e6