### PR TITLE
Introduce CardDataError and update handlers

### DIFF
--- a/magic_combat/__init__.py
+++ b/magic_combat/__init__.py
@@ -13,6 +13,7 @@ from .creature import Color
 from .creature import CombatCreature
 from .damage import DamageAssignmentStrategy
 from .damage import OptimalDamageStrategy
+from .exceptions import CardDataError
 from .exceptions import IllegalBlockError
 from .exceptions import InvalidBlockScenarioError
 from .exceptions import UnparsableLLMOutputError
@@ -76,6 +77,7 @@ __all__ = [
     "apply_blocker_bushido",
     "IllegalBlockError",
     "InvalidBlockScenarioError",
+    "CardDataError",
     "UnparsableLLMOutputError",
     "parse_block_assignments",
     "create_llm_prompt",

--- a/magic_combat/exceptions.py
+++ b/magic_combat/exceptions.py
@@ -15,3 +15,7 @@ class IllegalBlockError(MagicCombatError, ValueError):
 
 class InvalidBlockScenarioError(MagicCombatError):
     """Raised when generated block assignments are invalid or trivial."""
+
+
+class CardDataError(MagicCombatError, ValueError):
+    """Raised when card data is missing or unusable."""

--- a/magic_combat/random_scenario.py
+++ b/magic_combat/random_scenario.py
@@ -19,6 +19,7 @@ from .blocking_ai import decide_simple_blocks
 from .creature import CombatCreature
 from .damage import blocker_value
 from .damage import score_combat_result
+from .exceptions import CardDataError
 from .exceptions import IllegalBlockError
 from .exceptions import InvalidBlockScenarioError
 from .exceptions import MagicCombatError
@@ -49,7 +50,7 @@ def ensure_cards(path: str) -> list[dict[str, Any]]:
         try:
             cards = fetch_french_vanilla_cards()
         except Exception as exc:  # pragma: no cover - network failure
-            raise SystemExit(f"Failed to download card data: {exc}")
+            raise CardDataError(f"Failed to download card data: {exc}") from exc
         os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
         save_cards(cards, path)
     return load_cards(path)
@@ -65,7 +66,7 @@ def build_value_map(cards: Iterable[dict[str, Any]]) -> Dict[int, float]:
             continue
         values[idx] = blocker_value(creature)
     if not values:
-        raise ValueError("No usable creatures found in card data")
+        raise CardDataError("No usable creatures found in card data")
     return values
 
 
@@ -81,7 +82,7 @@ def sample_balanced(
     rng = rng if rng is not None else random.Random()
     idxs = list(values.keys())
     if n_att + n_blk > len(idxs):
-        raise ValueError("Not enough cards to sample from")
+        raise CardDataError("Not enough cards to sample from")
 
     best: Tuple[List[int], List[int]] | None = None
     best_diff = float("inf")

--- a/scripts/random_combat.py
+++ b/scripts/random_combat.py
@@ -18,6 +18,7 @@ from magic_combat.abilities import BOOL_NAMES as _BOOL_ABILITIES
 from magic_combat.abilities import INT_NAMES as _INT_ABILITIES
 from magic_combat.creature import CombatCreature
 from magic_combat.damage import blocker_value
+from magic_combat.exceptions import CardDataError
 
 # Ability name mappings for pretty printing come from ``magic_combat.abilities``
 
@@ -109,7 +110,10 @@ def main() -> None:
     random.seed(args.seed)
     np.random.seed(args.seed)
 
-    cards = ensure_cards(args.cards)
+    try:
+        cards = ensure_cards(args.cards)
+    except CardDataError as exc:
+        raise SystemExit(str(exc)) from exc
     values = build_value_map(cards)
     stats = compute_card_statistics(cards) if args.generated_cards else None
 

--- a/tests/random/test_card_data_error.py
+++ b/tests/random/test_card_data_error.py
@@ -1,0 +1,29 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring
+import pytest
+
+from magic_combat.exceptions import CardDataError
+from magic_combat.random_scenario import build_value_map
+from magic_combat.random_scenario import ensure_cards
+from magic_combat.random_scenario import sample_balanced
+
+
+def test_ensure_cards_download_failure(monkeypatch, tmp_path):
+    def fail_fetch():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(
+        "magic_combat.random_scenario.fetch_french_vanilla_cards", fail_fetch
+    )
+    path = tmp_path / "cards.json"
+    with pytest.raises(CardDataError):
+        ensure_cards(str(path))
+
+
+def test_build_value_map_no_creatures():
+    with pytest.raises(CardDataError):
+        build_value_map([])
+
+
+def test_sample_balanced_not_enough_cards():
+    with pytest.raises(CardDataError):
+        sample_balanced([], {}, 1, 1)


### PR DESCRIPTION
## Summary
- add `CardDataError` exception type
- switch various value errors to use `CardDataError`
- make `ensure_cards` raise `CardDataError` on download failure
- update CLI script for the new exception
- export `CardDataError` in `__init__`
- test the new behaviour

## Testing
- `black magic_combat scripts tests --check`
- `isort --profile black magic_combat scripts tests --check-only`
- `flake8 magic_combat scripts tests`
- `pycodestyle --max-line-length=88 --ignore=E203,W503,E226 --exclude=comprehensive_rules.py,tests,magic_combat/rules_text.py magic_combat scripts`
- `autoflake --check --recursive magic_combat scripts tests`
- `pylint magic_combat scripts tests`
- `mypy magic_combat scripts tests`
- `pyright magic_combat scripts tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6860aba1ba64832a9ca4c4c9e7625e94