### PR TITLE
Add scenario generation exceptions

### DIFF
--- a/magic_combat/__init__.py
+++ b/magic_combat/__init__.py
@@ -17,6 +17,8 @@ from .exceptions import CardDataError
 from .exceptions import IllegalBlockError
 from .exceptions import InvalidBlockScenarioError
 from .exceptions import IterationLimitError
+from .exceptions import MissingStatisticsError
+from .exceptions import ScenarioGenerationError
 from .exceptions import UnparsableLLMOutputError
 from .gamestate import GameState
 from .gamestate import PlayerState
@@ -80,6 +82,8 @@ __all__ = [
     "InvalidBlockScenarioError",
     "IterationLimitError",
     "CardDataError",
+    "ScenarioGenerationError",
+    "MissingStatisticsError",
     "UnparsableLLMOutputError",
     "parse_block_assignments",
     "create_llm_prompt",

--- a/magic_combat/exceptions.py
+++ b/magic_combat/exceptions.py
@@ -23,3 +23,11 @@ class IterationLimitError(MagicCombatError, RuntimeError):
 
 class CardDataError(MagicCombatError, ValueError):
     """Raised when card data is missing or unusable."""
+
+
+class ScenarioGenerationError(MagicCombatError, RuntimeError):
+    """Raised when a random scenario cannot be generated."""
+
+
+class MissingStatisticsError(MagicCombatError, ValueError):
+    """Raised when required statistics are not provided."""

--- a/magic_combat/random_scenario.py
+++ b/magic_combat/random_scenario.py
@@ -23,6 +23,8 @@ from .exceptions import CardDataError
 from .exceptions import IllegalBlockError
 from .exceptions import InvalidBlockScenarioError
 from .exceptions import MagicCombatError
+from .exceptions import MissingStatisticsError
+from .exceptions import ScenarioGenerationError
 from .gamestate import GameState
 from .gamestate import PlayerState
 from .random_creature import assign_random_counters
@@ -105,8 +107,8 @@ def sample_balanced(
             return att_idx, blk_idx
 
     if best is None:
-        raise MagicCombatError("Failed to sample creatures")
-    raise MagicCombatError("Unable to generate balanced creature sets")
+        raise ScenarioGenerationError("Failed to sample creatures")
+    raise ScenarioGenerationError("Unable to generate balanced creature sets")
 
 
 def generate_balanced_creatures(
@@ -137,8 +139,8 @@ def generate_balanced_creatures(
             return attackers, blockers
 
     if best is None:
-        raise ValueError("Failed to generate creatures")
-    raise ValueError("Unable to generate balanced creature sets")
+        raise ScenarioGenerationError("Failed to generate creatures")
+    raise ScenarioGenerationError("Unable to generate balanced creature sets")
 
 
 def _sample_creatures(
@@ -159,7 +161,9 @@ def _sample_creatures(
 
     if generated_cards:
         if stats is None:
-            raise ValueError("stats must be provided when generated_cards is True")
+            raise MissingStatisticsError(
+                "stats must be provided when generated_cards is True"
+            )
         return generate_balanced_creatures(stats, n_atk, n_blk)
 
     try:
@@ -461,7 +465,7 @@ def generate_random_scenario(
     while True:
         attempts += 1
         if attempts > 100:
-            raise RuntimeError("Unable to generate valid scenario")
+            raise ScenarioGenerationError("Unable to generate valid scenario")
         try:
             return _attempt_random_scenario(
                 cards,
@@ -473,5 +477,7 @@ def generate_random_scenario(
                 max_iterations,
                 unique_optimal,
             )
+        except MissingStatisticsError:
+            raise
         except (MagicCombatError, IllegalBlockError, InvalidBlockScenarioError):
             continue

--- a/style_guide.md
+++ b/style_guide.md
@@ -59,6 +59,8 @@ requirements to ensure consistency across the code base.
 - Document non-obvious behavior with comments and docstrings.
 - Domain-specific errors should be implemented as custom exception classes
   derived from ``MagicCombatError`` (and from relevant built-in exceptions
-  when compatibility is needed). Examples include ``IterationLimitError``,
+  when compatibility is needed). The package defines the following custom
+  exceptions: ``MagicCombatError`` (base class), ``UnparsableLLMOutputError``,
+  ``IllegalBlockError``, ``InvalidBlockScenarioError``, ``IterationLimitError``,
   ``CardDataError``, ``ScenarioGenerationError`` and ``MissingStatisticsError``.
 

--- a/tests/random/test_scenario_exceptions.py
+++ b/tests/random/test_scenario_exceptions.py
@@ -1,0 +1,24 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring
+from pathlib import Path
+
+import pytest
+
+from magic_combat import MissingStatisticsError
+from magic_combat import ScenarioGenerationError
+from magic_combat import build_value_map
+from magic_combat import generate_random_scenario
+from magic_combat import load_cards
+
+DATA_PATH = Path(__file__).resolve().parents[1] / "data" / "example_test_cards.json"
+
+
+def test_missing_statistics_error():
+    cards = load_cards(str(DATA_PATH))
+    values = build_value_map(cards)
+    with pytest.raises(MissingStatisticsError):
+        generate_random_scenario(cards, values, generated_cards=True)
+
+
+def test_scenario_generation_error():
+    with pytest.raises(ScenarioGenerationError):
+        generate_random_scenario([], {})


### PR DESCRIPTION
## Summary
- implement `ScenarioGenerationError` and `MissingStatisticsError`
- use the new exceptions in `random_scenario`
- export them from the package
- document the available custom exceptions in the style guide
- test the new errors

## Testing
- `isort --profile black magic_combat tests`
- `black magic_combat tests`
- `autoflake --check --recursive magic_combat tests`
- `flake8 magic_combat tests`
- `pycodestyle --max-line-length=88 --ignore=E203,W503,E226 --exclude=comprehensive_rules.py,tests,magic_combat/rules_text.py magic_combat scripts`
- `pylint magic_combat scripts tests`
- `mypy magic_combat tests`
- `pyright magic_combat tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860b2f4a444832aa0def73f6f9effbb