### PR TITLE
Move block_utils docstring before imports

### DIFF
--- a/magic_combat/block_utils.py
+++ b/magic_combat/block_utils.py
@@ -1,3 +1,5 @@
+"""Utility helpers for evaluating blocking assignments."""
+
 from __future__ import annotations
 
 from copy import deepcopy
@@ -12,8 +14,6 @@ from .exceptions import IllegalBlockError
 from .gamestate import GameState
 from .limits import IterationCounter
 from .simulator import CombatSimulator
-
-"""Utility helpers for evaluating blocking assignments."""
 
 
 def evaluate_block_assignment(


### PR DESCRIPTION
## Summary
- move docstring in `block_utils.py` to the start of the module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860b53cb1c4832a8413d3a3052ca6da