### PR TITLE
Refactor creature summary helper

### DIFF
--- a/magic_combat/create_llm_prompt.py
+++ b/magic_combat/create_llm_prompt.py
@@ -4,34 +4,8 @@ from typing import Iterable
 
 from .creature import CombatCreature
 from .gamestate import GameState
-from .rules_text import describe_abilities
 from .rules_text import get_relevant_rules_text
-
-
-def summarize_creature(
-    creature: CombatCreature, *, include_colors: bool = False
-) -> str:
-    """Return a readable one-line summary of ``creature``."""
-
-    extra: list[str] = []
-    if creature.plus1_counters:
-        extra.append(f"+1/+1 x{creature.plus1_counters}")
-    if creature.minus1_counters:
-        extra.append(f"-1/-1 x{creature.minus1_counters}")
-    if creature.damage_marked:
-        extra.append(f"{creature.damage_marked} dmg")
-    if creature.tapped:
-        extra.append("tapped")
-    extras = f" [{', '.join(extra)}]" if extra else ""
-    color_info = ""
-    if include_colors and creature.colors:
-        joined = "/".join(
-            c.name.capitalize() for c in sorted(creature.colors, key=lambda x: x.name)
-        )
-        color_info = f" [{joined}]"
-    elif include_colors:
-        color_info = " [Colorless]"
-    return f"{creature}{color_info}{extras} -- {describe_abilities(creature)}"
+from .text_utils import summarize_creature
 
 
 def create_llm_prompt(

--- a/magic_combat/gamestate.py
+++ b/magic_combat/gamestate.py
@@ -8,7 +8,7 @@ from dataclasses import field
 from magic_combat.constants import POISON_LOSS_THRESHOLD
 
 from .creature import CombatCreature
-from .rules_text import describe_abilities
+from .text_utils import summarize_creature
 from .utils import check_non_negative
 
 
@@ -30,7 +30,7 @@ class PlayerState:
         if self.creatures:
             lines.append("Creatures:")
             for creature in self.creatures:
-                lines.append(f"  - {creature} -- {describe_abilities(creature)}")
+                lines.append(f"  - {summarize_creature(creature)}")
         else:
             lines.append("Creatures: None")
         return "\n".join(lines)

--- a/magic_combat/text_utils.py
+++ b/magic_combat/text_utils.py
@@ -1,0 +1,31 @@
+"""Utility helpers for generating descriptive text."""
+
+from typing import List
+
+from .creature import CombatCreature
+from .rules_text import describe_abilities
+
+
+def summarize_creature(
+    creature: CombatCreature, *, include_colors: bool = False
+) -> str:
+    """Return a readable one-line summary of ``creature``."""
+    extra: List[str] = []
+    if creature.plus1_counters:
+        extra.append(f"+1/+1 x{creature.plus1_counters}")
+    if creature.minus1_counters:
+        extra.append(f"-1/-1 x{creature.minus1_counters}")
+    if creature.damage_marked:
+        extra.append(f"{creature.damage_marked} dmg")
+    if creature.tapped:
+        extra.append("tapped")
+    extras = f" [{', '.join(extra)}]" if extra else ""
+    color_info = ""
+    if include_colors and creature.colors:
+        joined = "/".join(
+            c.name.capitalize() for c in sorted(creature.colors, key=lambda x: x.name)
+        )
+        color_info = f" [{joined}]"
+    elif include_colors:
+        color_info = " [Colorless]"
+    return f"{creature}{color_info}{extras} -- {describe_abilities(creature)}"

--- a/scripts/evaluate_random_combat_scenarios.py
+++ b/scripts/evaluate_random_combat_scenarios.py
@@ -15,12 +15,12 @@ from magic_combat import generate_random_scenario
 from magic_combat import load_cards
 from magic_combat.create_llm_prompt import create_llm_prompt
 from magic_combat.create_llm_prompt import parse_block_assignments
-from magic_combat.create_llm_prompt import summarize_creature
 from magic_combat.creature import CombatCreature
 from magic_combat.exceptions import UnparsableLLMOutputError
 from magic_combat.gamestate import GameState
 from magic_combat.gamestate import PlayerState
 from magic_combat.llm_cache import LLMCache
+from magic_combat.text_utils import summarize_creature
 
 
 def _simulate_assignment(

--- a/scripts/random_combat.py
+++ b/scripts/random_combat.py
@@ -19,6 +19,7 @@ from magic_combat.abilities import INT_NAMES as _INT_ABILITIES
 from magic_combat.creature import CombatCreature
 from magic_combat.damage import blocker_value
 from magic_combat.exceptions import CardDataError
+from magic_combat.text_utils import summarize_creature
 
 # Ability name mappings for pretty printing come from ``magic_combat.abilities``
 
@@ -39,31 +40,6 @@ def describe_abilities(creature: CombatCreature) -> str:
     if creature.artifact:
         parts.append("Artifact")
     return ", ".join(parts) if parts else "none"
-
-
-def summarize_creature(
-    creature: CombatCreature, *, include_colors: bool = False
-) -> str:
-    """Return a readable one-line summary of ``creature``."""
-    extra: List[str] = []
-    if creature.plus1_counters:
-        extra.append(f"+1/+1 x{creature.plus1_counters}")
-    if creature.minus1_counters:
-        extra.append(f"-1/-1 x{creature.minus1_counters}")
-    if creature.damage_marked:
-        extra.append(f"{creature.damage_marked} dmg")
-    if creature.tapped:
-        extra.append("tapped")
-    extras = f" [{', '.join(extra)}]" if extra else ""
-    color_info = ""
-    if include_colors and creature.colors:
-        joined = "/".join(
-            c.name.capitalize() for c in sorted(creature.colors, key=lambda x: x.name)
-        )
-        color_info = f" [{joined}]"
-    elif include_colors:
-        color_info = " [Colorless]"
-    return f"{creature}{color_info}{extras} -- {describe_abilities(creature)}"
 
 
 def print_player_state(

--- a/tests/core/test_playerstate_str.py
+++ b/tests/core/test_playerstate_str.py
@@ -1,0 +1,29 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring
+from magic_combat import GameState
+from magic_combat import PlayerState
+from magic_combat.creature import CombatCreature
+
+
+def test_playerstate_str_summarizes_creatures():
+    creature = CombatCreature("Bear", 2, 2, "A")
+    creature.plus1_counters = 2
+    creature.minus1_counters = 1
+    creature.damage_marked = 3
+    creature.tapped = True
+    ps = PlayerState(life=20, creatures=[creature])
+    expected = (
+        "Life: 20\n"
+        "Poison: 0\n"
+        "Creatures:\n"
+        "  - Bear (2/2) [+1/+1 x2, -1/-1 x1, 3 dmg, tapped] -- none"
+    )
+    assert str(ps) == expected
+
+
+def test_gamestate_str_uses_playerstate():
+    creature = CombatCreature("Elf", 1, 1, "A", vigilance=True)
+    ps = PlayerState(life=10, creatures=[creature])
+    gs = GameState(players={"A": ps})
+    text = str(gs)
+    assert "Player A:" in text
+    assert "- Elf (1/1) -- Vigilance" in text


### PR DESCRIPTION
## Summary
- extract `summarize_creature` into new `text_utils` module
- import shared helper in prompt builder and scripts
- show detailed creature info when printing `PlayerState`/`GameState`
- add tests for the new string output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860ba766e98832a973d35b8c104a9f7