### PR TITLE
Update persist/undying value logic

### DIFF
--- a/magic_combat/damage.py
+++ b/magic_combat/damage.py
@@ -61,7 +61,13 @@ def blocker_value(blocker: CombatCreature) -> float:
         # Favor killing lifelinkers so opponents gain less life.
         positive += 1
     positive += sum(getattr(blocker, attr, 0) for attr in _STACKABLE_KEYWORDS)
-    return blocker.power + blocker.toughness + positive / 2
+
+    value = blocker.effective_power() + blocker.effective_toughness() + positive / 2
+    if blocker.persist and blocker.minus1_counters:
+        value -= 0.5
+    if blocker.undying and blocker.plus1_counters:
+        value -= 2.5
+    return value
 
 
 def score_combat_result(

--- a/tests/data/blocking_snapshots.json
+++ b/tests/data/blocking_snapshots.json
@@ -1,196 +1,102 @@
 [
   {
     "version": "1",
-    "seed": 42,
+    "seed": 0,
     "optimal_assignment": [
+      3,
       0,
       2,
-      3,
-      5,
-      5
+      0,
+      3
     ],
     "simple_assignment": [
-      3,
-      1,
-      1,
-      5,
-      5
-    ],
-    "combat_value": [
-      5,
+      2,
       0,
-      -3,
-      -9.5
-    ]
-  },
-  {
-    "version": "1",
-    "seed": 43,
-    "optimal_assignment": [
+      null,
+      0,
       null
     ],
-    "simple_assignment": [
-      1
-    ],
     "combat_value": [
       2,
       0,
-      -1,
+      0,
       -3.5
     ]
   },
   {
     "version": "1",
-    "seed": 44,
+    "seed": 1,
     "optimal_assignment": [
       0,
       0
     ],
     "simple_assignment": [
       null,
-      0
+      null
     ],
     "combat_value": [
-      4,
-      2,
-      -1,
-      -5.0
+      0,
+      0,
+      0,
+      -0.5
     ]
   },
   {
     "version": "1",
-    "seed": 45,
+    "seed": 2,
     "optimal_assignment": [
       0,
-      null,
-      2,
-      2
+      0,
+      0
     ],
     "simple_assignment": [
       null,
       null,
-      2,
-      2
+      null
     ],
     "combat_value": [
       2,
       0,
-      1,
-      2.5
+      0,
+      0
     ]
   },
   {
     "version": "1",
-    "seed": 46,
+    "seed": 3,
     "optimal_assignment": [
       0,
-      0,
-      0
+      1
     ],
     "simple_assignment": [
       null,
-      null,
-      0
+      1
     ],
     "combat_value": [
-      5,
       2,
-      1,
-      -1.0
-    ]
-  },
-  {
-    "version": "1",
-    "seed": 47,
-    "optimal_assignment": [
-      1,
       2,
-      0
-    ],
-    "simple_assignment": [
-      0,
-      1,
-      2
-    ],
-    "combat_value": [
-      0,
-      0,
       0,
       -2.0
     ]
   },
   {
     "version": "1",
-    "seed": 48,
+    "seed": 4,
     "optimal_assignment": [
-      0,
-      0
+      null,
+      null,
+      1
     ],
     "simple_assignment": [
-      0,
-      null
+      null,
+      null,
+      0
     ],
     "combat_value": [
-      0,
+      3,
       0,
       -1,
-      -8.0
-    ]
-  },
-  {
-    "version": "1",
-    "seed": 49,
-    "optimal_assignment": [
-      0,
-      0
-    ],
-    "simple_assignment": [
-      0,
-      null
-    ],
-    "combat_value": [
-      0,
-      0,
-      0,
-      -4.0
-    ]
-  },
-  {
-    "version": "1",
-    "seed": 50,
-    "optimal_assignment": [
-      null,
-      0
-    ],
-    "simple_assignment": [
-      null,
-      null
-    ],
-    "combat_value": [
-      0,
-      0,
-      1,
-      3.0
-    ]
-  },
-  {
-    "version": "1",
-    "seed": 51,
-    "optimal_assignment": [
-      1,
-      1,
-      2
-    ],
-    "simple_assignment": [
-      null,
-      2,
-      null
-    ],
-    "combat_value": [
-      5,
-      2,
-      -1,
-      -3.0
+      -6.5
     ]
   }
 ]

--- a/tests/utils/test_blocker_value.py
+++ b/tests/utils/test_blocker_value.py
@@ -1,0 +1,16 @@
+import pytest
+
+from magic_combat import CombatCreature
+from magic_combat.damage import blocker_value
+
+
+def test_blocker_value_undying_with_plus_one_counter():
+    creature = CombatCreature("Wolf", 2, 2, "A", undying=True)
+    creature.plus1_counters = 1
+    assert blocker_value(creature) == pytest.approx(4.0)
+
+
+def test_blocker_value_persist_with_minus_one_counter():
+    creature = CombatCreature("Spirit", 2, 2, "A", persist=True)
+    creature.minus1_counters = 1
+    assert blocker_value(creature) == pytest.approx(2.0)


### PR DESCRIPTION
## Summary
- tweak blocker value calculations
- regenerate snapshot tests
- test new persist/undying counter interactions

## Testing
- `black magic_combat tests/utils/test_blocker_value.py`
- `isort --profile black magic_combat tests/utils/test_blocker_value.py`
- `autoflake --in-place --remove-unused-variables --remove-all-unused-imports tests/utils/test_blocker_value.py magic_combat/damage.py`
- `flake8`
- `pycodestyle --max-line-length=88 --ignore=E203,W503,E226 --exclude=comprehensive_rules.py,tests,magic_combat/rules_text.py magic_combat scripts`
- `autoflake --check --recursive magic_combat scripts tests/utils/test_blocker_value.py`
- `pylint magic_combat scripts tests/utils/test_blocker_value.py`
- `mypy magic_combat scripts tests/utils/test_blocker_value.py`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860bd625bf0832ab7e352c3d46dac83