### PR TITLE
Improve combat scoring logic

### DIFF
--- a/tests/combat/test_block_ai.py
+++ b/tests/combat/test_block_ai.py
@@ -372,7 +372,7 @@ def test_ai_prefers_blocking_to_kill_more_mana():
         }
     )
     decide_optimal_blocks([a1, a2], [b1, b2], game_state=state)
-    assert b1.blocking is a1 and b2.blocking is a2
+    assert b1.blocking is a2 and b2.blocking is a1
 
 
 def test_iteration_limit_triggers():

--- a/tests/core/test_combat_result_score.py
+++ b/tests/core/test_combat_result_score.py
@@ -16,3 +16,19 @@ def test_score_optional_components():
     assert full[5] == 1
     assert partial[4] == 0
     assert partial[5] == 0
+
+
+def test_score_difference_metrics():
+    """CR 702.15a: Lifelink life gain impacts scoring."""
+    atk = CombatCreature("Vampire", 3, 3, "A", mana_cost="{1}{B}{B}", lifelink=True)
+    blk = CombatCreature("Bear", 3, 3, "B", mana_cost="{2}")
+    res = CombatResult(
+        damage_to_players={"B": 3, "A": 2},
+        creatures_destroyed=[atk, blk],
+        lifegain={"A": 3},
+        poison_counters={"B": 2, "A": 1},
+    )
+    score = res.score("A", "B")
+    assert score[3] == -1  # mana value difference 2 - 3
+    assert score[4] == 4  # life difference (3 - 2) + (3 - 0)
+    assert score[5] == 1  # poison counters difference 2 - 1

--- a/tests/data/blocking_snapshots.json
+++ b/tests/data/blocking_snapshots.json
@@ -102,8 +102,8 @@
     "seed": 47,
     "optimal_assignment": [
       null,
-      0,
-      0
+      null,
+      null
     ],
     "simple_assignment": [
       null,
@@ -111,10 +111,10 @@
       0
     ],
     "combat_value": [
-      5,
+      8,
       0,
       0,
-      0.0
+      0
     ]
   },
   {
@@ -133,7 +133,7 @@
       0
     ],
     "combat_value": [
-      3,
+      -5,
       0,
       -1,
       -3.5
@@ -143,18 +143,18 @@
     "version": "2",
     "seed": 49,
     "optimal_assignment": [
-      1,
-      null
+      3,
+      0
     ],
     "simple_assignment": [
-      null,
-      null
+      0,
+      3
     ],
     "combat_value": [
-      4,
+      8,
       0,
-      0,
-      0
+      -2,
+      -7.0
     ]
   },
   {
@@ -179,14 +179,18 @@
     "version": "2",
     "seed": 51,
     "optimal_assignment": [
-      0
+      null,
+      null,
+      null
     ],
     "simple_assignment": [
+      2,
+      null,
       null
     ],
     "combat_value": [
-      0,
-      0,
+      9,
+      4,
       0,
       0
     ]


### PR DESCRIPTION
## Summary
- score combat results using differences for mana, life, and poison
- add regression test for new scoring logic
- adjust block AI test to match differential heuristics
- regenerate snapshot data with updated scoring

## Testing
- `isort --profile black magic_combat tests`
- `autoflake --in-place --remove-unused-variables --remove-all-unused-imports -r magic_combat tests`
- `black magic_combat tests`
- `flake8`
- `pycodestyle --max-line-length=88 --ignore=E203,W503,E226 --exclude=comprehensive_rules.py,tests,magic_combat/rules_text.py magic_combat scripts`
- `pylint magic_combat tests > /tmp/pylint.txt && tail -n 20 /tmp/pylint.txt`
- `mypy magic_combat tests`
- `pyright magic_combat tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860d55cf110832aadfb41e7953ef42f