### PR TITLE
Fix provoke menace interaction

### DIFF
--- a/magic_combat/simulator.py
+++ b/magic_combat/simulator.py
@@ -246,7 +246,17 @@ class CombatSimulator:
                 raise IllegalBlockError("Provoke attacker not in combat")
             if target not in self.defenders:
                 raise IllegalBlockError("Provoke target not defending creature")
-            if can_block(attacker, target) and target.blocking is not attacker:
+            if not can_block(attacker, target) or target.tapped:
+                continue
+            if attacker.menace:
+                eligible = [
+                    b
+                    for b in self.defenders
+                    if b is not target and not b.tapped and can_block(attacker, b)
+                ]
+                if not eligible:
+                    continue
+            if target.blocking is not attacker:
                 raise IllegalBlockError("Provoke target failed to block")
 
     def _check_tapped_blockers(self) -> None:

--- a/tests/abilities/test_interactions.py
+++ b/tests/abilities/test_interactions.py
@@ -1046,13 +1046,14 @@ def test_skulk_flanking_bushido_precombat_death():
 
 
 def test_provoke_and_menace_insufficient_blockers():
-    """CR 702.40a & 702.110b: Provoke requires the targeted creature to block, but menace demands two blockers."""
+    """CR 702.40a & 702.110b: Provoke is ignored when menace can't be satisfied."""
     attacker = CombatCreature("Taunting Brute", 2, 2, "A", menace=True)
     blocker = CombatCreature("Goblin", 2, 2, "B")
-    link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker], provoke_map={attacker: blocker})
-    with pytest.raises(ValueError):
-        sim.validate_blocking()
+    sim.validate_blocking()
+    result = sim.simulate()
+    assert result.damage_to_players["B"] == 2
+    assert blocker not in result.creatures_destroyed
 
 
 def test_undying_and_persist_prefers_undying():

--- a/tests/combat/test_block_ai.py
+++ b/tests/combat/test_block_ai.py
@@ -206,6 +206,20 @@ def test_ai_blocks_menace_with_two_blockers():
     assert b1.blocking is atk and b2.blocking is atk
 
 
+def test_optimal_ai_ignores_provoke_with_single_blocker():
+    """CR 702.40a & 702.110b: Provoke doesn't force a block if menace can't be satisfied."""
+    atk = CombatCreature("Tunnel Rogue", 2, 2, "A", menace=True, provoke=True)
+    blk = CombatCreature("Goblin", 2, 2, "B")
+    state = GameState(
+        players={
+            "A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]),
+            "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[blk]),
+        }
+    )
+    decide_optimal_blocks([atk], [blk], game_state=state, provoke_map={atk: blk})
+    assert blk.blocking is None
+
+
 def test_ai_blocks_fear_with_correct_color():
     """CR 702.36a: Fear restricts blocking to black or artifact creatures."""
     atk = CombatCreature("Shade", 2, 2, "A", fear=True)

--- a/tests/combat/test_simple_block_ai.py
+++ b/tests/combat/test_simple_block_ai.py
@@ -293,6 +293,20 @@ def test_simple_ai_blocks_provoke_target_favorably():
     assert blk2.blocking is atk2
 
 
+def test_simple_ai_ignores_provoke_with_single_blocker():
+    """CR 702.40a & 702.110b: Provoke is ignored when menace can't be satisfied."""
+    atk = CombatCreature("Tunnel Rogue", 2, 2, "A", provoke=True, menace=True)
+    blk = CombatCreature("Goblin", 2, 2, "B")
+    state = GameState(
+        players={
+            "A": PlayerState(life=20, creatures=[atk]),
+            "B": PlayerState(life=20, creatures=[blk]),
+        }
+    )
+    decide_simple_blocks([atk], [blk], game_state=state, provoke_map={atk: blk})
+    assert blk.blocking is None
+
+
 def test_simple_ai_reacher_blocks_flyer_only():
     """CR 702.9b: Reach allows blocking a creature with flying."""
     flyer = CombatCreature("Angel", 3, 3, "A", flying=True)


### PR DESCRIPTION
## Summary
- handle menace/provoke overlap in simulator
- skip provoke requirement if menace can't be met in block AIs
- test menace/provoke interaction and AI behaviour

## Testing
- `isort --profile black . && black .`
- `autoflake --in-place --remove-unused-variables --remove-all-unused-imports -r .`
- `flake8`
- `pycodestyle .` *(fails: E501 line too long)*
- `pylint magic_combat tests` *(no output)*
- `mypy .`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860dcf564d4832abfa5dc2a36b6fd04