### PR TITLE
Add mana cost to creature summaries and prompts

### DIFF
--- a/magic_combat/text_utils.py
+++ b/magic_combat/text_utils.py
@@ -28,4 +28,10 @@ def summarize_creature(
         color_info = f" [{joined}]"
     elif include_colors:
         color_info = " [Colorless]"
-    return f"{creature}{color_info}{extras} -- {describe_abilities(creature)}"
+
+    stats = f"{creature.name}"
+    if creature.mana_cost:
+        stats += f" {creature.mana_cost}"
+    stats += f" ({creature.power}/{creature.toughness})"
+
+    return f"{stats}{color_info}{extras} -- {describe_abilities(creature)}"

--- a/tests/core/test_summarize_creature.py
+++ b/tests/core/test_summarize_creature.py
@@ -1,0 +1,8 @@
+from magic_combat.creature import CombatCreature
+from magic_combat.text_utils import summarize_creature
+
+
+def test_summarize_creature_includes_mana_cost():
+    creature = CombatCreature("Wizard", 2, 3, "A", mana_cost="{1}{U}")
+    summary = summarize_creature(creature)
+    assert "{1}{U}" in summary

--- a/tests/llm/test_llm_prompt.py
+++ b/tests/llm/test_llm_prompt.py
@@ -65,6 +65,20 @@ def test_create_prompt_contents():
     assert "Guard" in prompt
 
 
+def test_prompt_includes_mana_cost():
+    atk = CombatCreature("Zombie", 3, 3, "A", mana_cost="{2}{B}")
+    blk = CombatCreature("Cleric", 1, 4, "B", mana_cost="{1}{W}")
+    state = GameState(
+        players={
+            "A": PlayerState(life=20, creatures=[atk]),
+            "B": PlayerState(life=20, creatures=[blk]),
+        }
+    )
+    prompt = create_llm_prompt(state, [atk], [blk])
+    assert "{2}{B}" in prompt
+    assert "{1}{W}" in prompt
+
+
 def test_prompt_includes_colors_when_relevant():
     """CR 702.13b: Intimidate checks color of potential blockers."""
     atk = CombatCreature("Rogue", 2, 2, "A", intimidate=True, colors={Color.GREEN})


### PR DESCRIPTION
## Summary
- show mana cost when summarizing creatures
- test summarization of mana cost
- ensure LLM prompts include mana costs

## Testing
- `isort --profile black magic_combat tests scripts`
- `black magic_combat tests scripts`
- `autoflake --check --recursive magic_combat tests scripts`
- `flake8 magic_combat tests scripts`
- `pycodestyle --max-line-length=88 --ignore=E203,W503,E226 --exclude=comprehensive_rules.py,tests,magic_combat/rules_text.py magic_combat scripts`
- `pylint magic_combat tests`
- `mypy magic_combat tests`
- `pyright magic_combat tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686164513f40832a8b6d3dc46f18c2e0