### PR TITLE
Move creature_value to CombatCreature

### DIFF
--- a/magic_combat/blocking_ai.py
+++ b/magic_combat/blocking_ai.py
@@ -10,7 +10,6 @@ from typing import Tuple
 
 from .block_utils import evaluate_block_assignment
 from .creature import CombatCreature
-from .creature import creature_value
 from .exceptions import IllegalBlockError
 from .gamestate import GameState
 from .limits import IterationCounter
@@ -41,7 +40,7 @@ def _should_force_provoke(
 
 def _creature_value(creature: CombatCreature) -> float:
     """Return a heuristic value for the creature."""
-    return creature_value(creature)
+    return creature.creature_value()
 
 
 def _reset_block_assignments(
@@ -226,7 +225,7 @@ def _best_survival_assignment(
 
         defender = blockers[0].controller if blockers else "B"
         def_val = sum(
-            creature_value(c)
+            c.creature_value()
             for c in result.creatures_destroyed
             if c.controller == defender
         )

--- a/magic_combat/creature.py
+++ b/magic_combat/creature.py
@@ -229,19 +229,18 @@ class CombatCreature:
         self.temp_power = 0
         self.temp_toughness = 0
 
+    def creature_value(self) -> float:
+        """Heuristic combat value for tie-breaking."""
 
-def creature_value(creature: CombatCreature) -> float:
-    """Heuristic combat value for tie-breaking."""
+        positive = sum(1 for attr in _POSITIVE_KEYWORDS if getattr(self, attr, False))
+        if self.double_strike:
+            # Count double strike twice so it contributes 1 point instead of 0.5.
+            positive += 1
+        positive += sum(getattr(self, attr, 0) for attr in _STACKABLE_KEYWORDS)
 
-    positive = sum(1 for attr in _POSITIVE_KEYWORDS if getattr(creature, attr, False))
-    if creature.double_strike:
-        # Count double strike twice so it contributes 1 point instead of 0.5.
-        positive += 1
-    positive += sum(getattr(creature, attr, 0) for attr in _STACKABLE_KEYWORDS)
-
-    value = creature.effective_power() + creature.effective_toughness() + positive / 2
-    if creature.persist and creature.minus1_counters:
-        value -= 0.5
-    if creature.undying and creature.plus1_counters:
-        value -= 2.5
-    return value
+        value = self.effective_power() + self.effective_toughness() + positive / 2
+        if self.persist and self.minus1_counters:
+            value -= 0.5
+        if self.undying and self.plus1_counters:
+            value -= 2.5
+        return value

--- a/magic_combat/random_scenario.py
+++ b/magic_combat/random_scenario.py
@@ -17,7 +17,6 @@ import numpy as np
 from .blocking_ai import decide_optimal_blocks
 from .blocking_ai import decide_simple_blocks
 from .creature import CombatCreature
-from .creature import creature_value
 from .exceptions import CardDataError
 from .exceptions import IllegalBlockError
 from .exceptions import InvalidBlockScenarioError
@@ -65,7 +64,7 @@ def build_value_map(cards: Iterable[dict[str, Any]]) -> Dict[int, float]:
             creature = card_to_creature(card, "A")
         except ValueError:
             continue
-        values[idx] = creature_value(creature)
+        values[idx] = creature.creature_value()
     if not values:
         raise CardDataError("No usable creatures found in card data")
     return values
@@ -125,8 +124,8 @@ def generate_balanced_creatures(
             generate_random_creature(stats, controller="B") for _ in range(n_blk)
         ]
 
-        att_val = sum(creature_value(c) for c in attackers)
-        blk_val = sum(creature_value(c) for c in blockers)
+        att_val = sum(c.creature_value() for c in attackers)
+        blk_val = sum(c.creature_value() for c in blockers)
         avg = (att_val + blk_val) / 2 or 1
         diff = abs(att_val - blk_val) / avg
 

--- a/magic_combat/simulator.py
+++ b/magic_combat/simulator.py
@@ -9,7 +9,6 @@ from typing import Optional
 from .combat_utils import damage_creature
 from .combat_utils import damage_player
 from .creature import CombatCreature
-from .creature import creature_value
 from .damage import DamageAssignmentStrategy
 from .damage import OptimalDamageStrategy
 from .exceptions import IllegalBlockError
@@ -92,12 +91,12 @@ class CombatResult:
             lost = 0
 
         att_val = sum(
-            creature_value(c)
+            c.creature_value()
             for c in self.creatures_destroyed
             if c.controller == attacker_player
         )
         def_val = sum(
-            creature_value(c)
+            c.creature_value()
             for c in self.creatures_destroyed
             if c.controller == defender
         )

--- a/scripts/random_combat.py
+++ b/scripts/random_combat.py
@@ -17,7 +17,6 @@ from magic_combat import generate_random_scenario
 from magic_combat.abilities import BOOL_NAMES as _BOOL_ABILITIES
 from magic_combat.abilities import INT_NAMES as _INT_ABILITIES
 from magic_combat.creature import CombatCreature
-from magic_combat.creature import creature_value
 from magic_combat.exceptions import CardDataError
 from magic_combat.text_utils import summarize_creature
 
@@ -145,11 +144,11 @@ def main() -> None:
         print("Attackers:")
         for atk in start_state.players["A"].creatures:
             summary = summarize_creature(atk, include_colors=include_colors)
-            print(f"  {summary}, {creature_value(atk)}")
+            print(f"  {summary}, {atk.creature_value()}")
         print("Blockers:")
         for blk in start_state.players["B"].creatures:
             summary = summarize_creature(blk, include_colors=include_colors)
-            print(f"  {summary}, {creature_value(blk)}")
+            print(f"  {summary}, {blk.creature_value()}")
 
         prov_map_display = (
             {a.name: b.name for a, b in provoke_map.items()} if provoke_map else None

--- a/tests/utils/test_blocker_value.py
+++ b/tests/utils/test_blocker_value.py
@@ -1,16 +1,15 @@
 import pytest
 
 from magic_combat import CombatCreature
-from magic_combat.creature import creature_value
 
 
 def test_blocker_value_undying_with_plus_one_counter():
     creature = CombatCreature("Wolf", 2, 2, "A", undying=True)
     creature.plus1_counters = 1
-    assert creature_value(creature) == pytest.approx(4.0)
+    assert creature.creature_value() == pytest.approx(4.0)
 
 
 def test_blocker_value_persist_with_minus_one_counter():
     creature = CombatCreature("Spirit", 2, 2, "A", persist=True)
     creature.minus1_counters = 1
-    assert creature_value(creature) == pytest.approx(2.0)
+    assert creature.creature_value() == pytest.approx(2.0)


### PR DESCRIPTION
## Summary
- convert `creature_value` helper into an instance method of `CombatCreature`
- update internal logic and callers
- adjust tests and script usage

## Testing
- `isort --profile black magic_combat scripts tests`
- `black magic_combat scripts tests`
- `autoflake --check --recursive magic_combat scripts tests`
- `flake8 magic_combat scripts tests`
- `pycodestyle --max-line-length=88 --ignore=E203,W503,E226 --exclude=comprehensive_rules.py,tests,magic_combat/rules_text.py magic_combat scripts`
- `pylint magic_combat scripts tests`
- `mypy magic_combat scripts tests`
- `pyright magic_combat scripts tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686169a8b15c832a8232640e9cd91ca2