### PR TITLE
Adjust defender valuation

### DIFF
--- a/magic_combat/create_llm_prompt.py
+++ b/magic_combat/create_llm_prompt.py
@@ -60,8 +60,8 @@ The criteria for the best blocking strategy are as follows:
 2. Maximize the difference in total creature value destroyed (attacker minus defender).
 Value is defined as the sum of the power and toughness of the creatures
 plus 0.5 times the number of abilities they have.
-Skip defender in this calculation (it's worth 0), and count double
-strike twice (it's worth 1 instead of 0.5).
+A creature with defender incurs a -0.5 penalty in this calculation, and
+double strike is counted twice (it's worth 1 instead of 0.5).
 3. Maximize the difference in number of creatures destroyed.
 4. Maximize the total mana value of creatures lost.
 5. Minimize life lost.

--- a/magic_combat/creature.py
+++ b/magic_combat/creature.py
@@ -231,7 +231,14 @@ class CombatCreature:
 
 
 def creature_value(creature: CombatCreature) -> float:
-    """Heuristic combat value for tie-breaking."""
+    """Heuristic combat value for tie-breaking.
+
+    The value is computed as the sum of the creature's effective power and
+    toughness plus half the number of keyword abilities it has. Double strike is
+    counted twice. Creatures with the ``defender`` ability incur a ``-0.5``
+    penalty. If a creature with persist has a -1/-1 counter it loses ``0.5`` and
+    a creature with undying that has a +1/+1 counter loses ``2.5``.
+    """
 
     positive = sum(1 for attr in _POSITIVE_KEYWORDS if getattr(creature, attr, False))
     if creature.double_strike:
@@ -244,4 +251,6 @@ def creature_value(creature: CombatCreature) -> float:
         value -= 0.5
     if creature.undying and creature.plus1_counters:
         value -= 2.5
+    if creature.defender:
+        value -= 0.5
     return value

--- a/tests/utils/test_blocker_value.py
+++ b/tests/utils/test_blocker_value.py
@@ -14,3 +14,8 @@ def test_blocker_value_persist_with_minus_one_counter():
     creature = CombatCreature("Spirit", 2, 2, "A", persist=True)
     creature.minus1_counters = 1
     assert creature_value(creature) == pytest.approx(2.0)
+
+
+def test_blocker_value_defender_penalty():
+    creature = CombatCreature("Wall", 0, 4, "A", defender=True)
+    assert creature_value(creature) == pytest.approx(3.5)


### PR DESCRIPTION
## Summary
- subtract 0.5 from creature value if the creature has defender
- document defender penalty in `creature_value` docstring
- update LLM prompt description of creature value
- test the new defender penalty

## Testing
- `black .`
- `isort --profile black .`
- `autoflake --remove-all-unused-imports --remove-unused-variables -r -i .`
- `flake8 magic_combat scripts tests`
- `pycodestyle --max-line-length=88 --ignore=E203,W503,E226 --exclude=comprehensive_rules.py,tests,magic_combat/rules_text.py magic_combat scripts`
- `autoflake --check --recursive magic_combat scripts tests`
- `pylint magic_combat scripts tests`
- `mypy magic_combat scripts tests`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68616a188410832a9b2ebe03a36c421e