### PR TITLE
Return final state from evaluation

### DIFF
--- a/magic_combat/block_utils.py
+++ b/magic_combat/block_utils.py
@@ -6,7 +6,6 @@ from copy import deepcopy
 from typing import Dict
 from typing import Optional
 from typing import Sequence
-from typing import Tuple
 
 from .creature import CombatCreature
 from .damage import OptimalDamageStrategy
@@ -23,8 +22,11 @@ def evaluate_block_assignment(
     state: Optional[GameState],
     counter: IterationCounter,
     provoke_map: Optional[Dict[CombatCreature, CombatCreature]] = None,
-) -> Tuple[int, float, int, int, int, int, Tuple[Optional[int], ...]]:
-    """Simulate combat for ``assignment`` and return a scoring tuple."""
+) -> tuple[
+    tuple[int, float, int, int, int, int, tuple[Optional[int], ...]],
+    Optional[GameState],
+]:
+    """Return score and final state for ``assignment``."""
     atks = deepcopy(list(attackers))
     blks = deepcopy(list(blockers))
     for idx, choice in enumerate(assignment):
@@ -38,12 +40,24 @@ def evaluate_block_assignment(
     if provoke_map:
         for atk, blk in provoke_map.items():
             if atk in attackers and blk in blockers:
-                prov_copies[atks[attackers.index(atk)]] = blks[blockers.index(blk)]
+                atk_copy = atks[attackers.index(atk)]
+                blk_copy = blks[blockers.index(blk)]
+                prov_copies[atk_copy] = blk_copy
 
+    state_copy = deepcopy(state)
+    if state_copy is not None:
+        for orig, copy_creature in zip(attackers, atks):
+            ps = state_copy.players.get(orig.controller)
+            if ps and orig in ps.creatures:
+                ps.creatures[ps.creatures.index(orig)] = copy_creature
+        for orig, copy_creature in zip(blockers, blks):
+            ps = state_copy.players.get(orig.controller)
+            if ps and orig in ps.creatures:
+                ps.creatures[ps.creatures.index(orig)] = copy_creature
     sim = CombatSimulator(
         atks,
         blks,
-        game_state=deepcopy(state),
+        game_state=state_copy,
         strategy=OptimalDamageStrategy(counter),
         provoke_map=prov_copies or None,
     )
@@ -54,7 +68,7 @@ def evaluate_block_assignment(
         ass_key = tuple(
             len(attackers) if choice is None else choice for choice in assignment
         )
-        return (
+        score = (
             1,
             float("inf"),
             -len(atks) - len(blks),
@@ -63,6 +77,13 @@ def evaluate_block_assignment(
             10**9,
             ass_key,
         )
+        return score, state_copy
+
+    if state_copy is not None:
+        for dead in result.creatures_destroyed:
+            ps = state_copy.players.get(dead.controller)
+            if ps and dead in ps.creatures:
+                ps.creatures.remove(dead)
 
     defender = blks[0].controller if blks else "defender"
     attacker_player = atks[0].controller if atks else "attacker"
@@ -70,4 +91,4 @@ def evaluate_block_assignment(
         len(attackers) if choice is None else choice for choice in assignment
     )
     score = result.score(attacker_player, defender) + (ass_key,)
-    return score
+    return score, state_copy

--- a/magic_combat/blocking_ai.py
+++ b/magic_combat/blocking_ai.py
@@ -357,7 +357,7 @@ def decide_optimal_blocks(
     optimal_count = 0
 
     for assignment in product(*options):
-        score = evaluate_block_assignment(
+        score, _ = evaluate_block_assignment(
             attackers,
             blockers,
             assignment,

--- a/tests/combat/test_block_damage_extra.py
+++ b/tests/combat/test_block_damage_extra.py
@@ -58,7 +58,7 @@ def _compute_best_assignment(atk, blk, state):
     best = None
     best_score = None
     for ass in product(*options):
-        score = evaluate_block_assignment(atk, blk, ass, state, counter)
+        score, _ = evaluate_block_assignment(atk, blk, ass, state, counter)
         if best_score is None or score < best_score:
             best_score = score
             best = ass

--- a/tests/combat/test_random_card_blocks.py
+++ b/tests/combat/test_random_card_blocks.py
@@ -26,7 +26,7 @@ def _compute_best_assignment(atk, blk, state):
     best = None
     best_score = None
     for ass in product(*options):
-        score = evaluate_block_assignment(atk, blk, ass, state, counter)
+        score, _ = evaluate_block_assignment(atk, blk, ass, state, counter)
         if best_score is None or score < best_score:
             best_score = score
             best = ass

--- a/tests/combat/test_result_state_sync.py
+++ b/tests/combat/test_result_state_sync.py
@@ -1,0 +1,107 @@
+"""Additional tests for state and result consistency."""
+
+from copy import deepcopy
+
+from magic_combat import CombatCreature
+from magic_combat import CombatSimulator
+from magic_combat import GameState
+from magic_combat import PlayerState
+from magic_combat.block_utils import evaluate_block_assignment
+from magic_combat.gamestate import has_player_lost
+from magic_combat.limits import IterationCounter
+
+
+def _total_value(creatures: list[CombatCreature]) -> float:
+    return sum(c.value() for c in creatures)
+
+
+def _total_mana(creatures: list[CombatCreature]) -> int:
+    return sum(c.mana_value for c in creatures)
+
+
+def test_result_matches_state_diff():
+    """CR 119.3: Life totals adjust when players gain or lose life."""
+
+    atk_lifelink = CombatCreature(
+        "Toxic Cleric",
+        2,
+        2,
+        "A",
+        infect=True,
+        lifelink=True,
+        mana_cost="{2}",
+    )
+    atk_warrior = CombatCreature("Warrior", 3, 3, "A", mana_cost="{3}")
+    blk = CombatCreature("Guard", 2, 2, "B", mana_cost="{2}")
+
+    state = GameState(
+        players={
+            "A": PlayerState(life=20, creatures=[atk_lifelink, atk_warrior]),
+            "B": PlayerState(life=20, creatures=[blk]),
+        }
+    )
+
+    start = deepcopy(state)
+
+    score, new_state = evaluate_block_assignment(
+        [atk_lifelink, atk_warrior], [blk], [1], state, IterationCounter(10)
+    )
+    assert new_state is not None
+
+    atk_c = deepcopy([atk_lifelink, atk_warrior])
+    blk_c = deepcopy([blk])
+    blk_c[0].blocking = atk_c[1]
+    atk_c[1].blocked_by.append(blk_c[0])
+    sim = CombatSimulator(atk_c, blk_c, game_state=deepcopy(state))
+    result = sim.simulate()
+
+    attacker = "A"
+    defender = "B"
+
+    assert score[:-1] == result.score(attacker, defender)
+
+    val_a_start = _total_value(start.players[attacker].creatures)
+    val_b_start = _total_value(start.players[defender].creatures)
+    val_a_end = _total_value(new_state.players[attacker].creatures)
+    val_b_end = _total_value(new_state.players[defender].creatures)
+
+    value_diff = (val_b_start - val_b_end) - (val_a_start - val_a_end)
+
+    cnt_a_start = len(start.players[attacker].creatures)
+    cnt_b_start = len(start.players[defender].creatures)
+    cnt_a_end = len(new_state.players[attacker].creatures)
+    cnt_b_end = len(new_state.players[defender].creatures)
+
+    count_diff = (cnt_b_start - cnt_b_end) - (cnt_a_start - cnt_a_end)
+
+    mana_a_start = _total_mana(start.players[attacker].creatures)
+    mana_b_start = _total_mana(start.players[defender].creatures)
+    mana_a_end = _total_mana(new_state.players[attacker].creatures)
+    mana_b_end = _total_mana(new_state.players[defender].creatures)
+
+    mana_diff = (mana_b_start - mana_b_end) - (mana_a_start - mana_a_end)
+
+    life_a_change = new_state.players[attacker].life - start.players[attacker].life
+    life_b_change = new_state.players[defender].life - start.players[defender].life
+    life_component = -(life_b_change - life_a_change)
+
+    poison_a_change = (
+        new_state.players[attacker].poison - start.players[attacker].poison
+    )
+    poison_b_change = (
+        new_state.players[defender].poison - start.players[defender].poison
+    )
+    poison_diff = poison_b_change - poison_a_change
+
+    expected_numeric = (
+        1 if has_player_lost(new_state, defender) else 0,
+        value_diff,
+        count_diff,
+        mana_diff,
+        life_component,
+        poison_diff,
+    )
+
+    assert score[:-1] == expected_numeric
+    assert result.lifegain.get(attacker, 0) == life_a_change
+    assert result.poison_counters.get(defender, 0) == poison_b_change

--- a/tests/core/test_block_utils.py
+++ b/tests/core/test_block_utils.py
@@ -14,5 +14,8 @@ def test_evaluate_block_assignment_simple():
             "B": PlayerState(life=20, creatures=[blk]),
         }
     )
-    score = evaluate_block_assignment([atk], [blk], [0], state, IterationCounter(10))
+    score, end_state = evaluate_block_assignment(
+        [atk], [blk], [0], state, IterationCounter(10)
+    )
     assert score == (0, 0.0, 0, 0, 0, 0, (0,))
+    assert end_state is not state


### PR DESCRIPTION
## Summary
- return the modified `GameState` from `evaluate_block_assignment`
- adjust call sites for new return value
- add state consistency tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68620fc023f8832a88032297fe36ac12