### PR TITLE
Return final state from block evaluation

### DIFF
--- a/magic_combat/block_utils.py
+++ b/magic_combat/block_utils.py
@@ -23,8 +23,17 @@ def evaluate_block_assignment(
     state: Optional[GameState],
     counter: IterationCounter,
     provoke_map: Optional[Dict[CombatCreature, CombatCreature]] = None,
-) -> Tuple[int, float, int, int, int, int, Tuple[Optional[int], ...]]:
-    """Simulate combat for ``assignment`` and return a scoring tuple."""
+) -> Tuple[
+    int,
+    float,
+    int,
+    int,
+    int,
+    int,
+    Tuple[Optional[int], ...],
+    Optional[GameState],
+]:
+    """Simulate combat for ``assignment`` and return a scoring tuple and state."""
     atks = deepcopy(list(attackers))
     blks = deepcopy(list(blockers))
     for idx, choice in enumerate(assignment):
@@ -62,6 +71,7 @@ def evaluate_block_assignment(
             10**9,
             10**9,
             ass_key,
+            sim.game_state,
         )
 
     defender = blks[0].controller if blks else "defender"
@@ -69,5 +79,6 @@ def evaluate_block_assignment(
     ass_key = tuple(
         len(attackers) if choice is None else choice for choice in assignment
     )
-    score = result.score(attacker_player, defender) + (ass_key,)
+    new_state = sim.game_state
+    score = result.score(attacker_player, defender) + (ass_key, new_state)
     return score

--- a/magic_combat/blocking_ai.py
+++ b/magic_combat/blocking_ai.py
@@ -351,7 +351,16 @@ def decide_optimal_blocks(
 
     best: Optional[Tuple[Optional[int], ...]] = None
     best_score: Optional[
-        Tuple[int, float, int, int, int, int, Tuple[Optional[int], ...]]
+        Tuple[
+            int,
+            float,
+            int,
+            int,
+            int,
+            int,
+            Tuple[Optional[int], ...],
+            GameState | None,
+        ]
     ] = None
     best_score_numeric: Optional[Tuple[int, float, int, int, int, int]] = None
     optimal_count = 0
@@ -365,8 +374,9 @@ def decide_optimal_blocks(
             counter,
             provoke_map,
         )
-        numeric = score[:-1]
-        if best_score is None or score < best_score:
+        compare_score = score[:-1]
+        numeric = compare_score[:-1]
+        if best_score is None or compare_score < best_score[:-1]:
             # Update the chosen assignment whenever we find a strictly better
             # score. Only reset ``optimal_count`` if the numeric portion of the
             # score actually improved; otherwise we simply update the stored

--- a/tests/combat/test_block_damage_extra.py
+++ b/tests/combat/test_block_damage_extra.py
@@ -59,8 +59,9 @@ def _compute_best_assignment(atk, blk, state):
     best_score = None
     for ass in product(*options):
         score = evaluate_block_assignment(atk, blk, ass, state, counter)
-        if best_score is None or score < best_score:
-            best_score = score
+        comp = score[:-1]
+        if best_score is None or comp < best_score:
+            best_score = comp
             best = ass
     return best
 

--- a/tests/combat/test_random_card_blocks.py
+++ b/tests/combat/test_random_card_blocks.py
@@ -27,8 +27,9 @@ def _compute_best_assignment(atk, blk, state):
     best_score = None
     for ass in product(*options):
         score = evaluate_block_assignment(atk, blk, ass, state, counter)
-        if best_score is None or score < best_score:
-            best_score = score
+        comp = score[:-1]
+        if best_score is None or comp < best_score:
+            best_score = comp
             best = ass
     return best
 

--- a/tests/combat/test_result_state.py
+++ b/tests/combat/test_result_state.py
@@ -1,0 +1,64 @@
+from copy import deepcopy
+
+from magic_combat import CombatCreature
+from magic_combat import CombatSimulator
+from magic_combat import GameState
+from magic_combat import PlayerState
+from tests.conftest import link_block
+
+
+def test_combat_result_matches_state_difference() -> None:
+    """CR 120.3f: Damage dealt by a source with lifelink causes life gain."""
+
+    atk1 = CombatCreature("Lifelink", 2, 2, "A", lifelink=True, mana_cost="{2}")
+    atk2 = CombatCreature("Infector", 1, 1, "A", infect=True, mana_cost="{G}")
+    blk = CombatCreature("Blocker", 2, 2, "B", mana_cost="{2}")
+    link_block(atk1, blk)
+
+    start = GameState(
+        players={
+            "A": PlayerState(life=10, creatures=[atk1, atk2]),
+            "B": PlayerState(life=20, creatures=[blk]),
+        }
+    )
+    state = deepcopy(start)
+    sim = CombatSimulator([atk1, atk2], [blk], game_state=state)
+    result = sim.simulate()
+
+    def total_value(creatures):
+        return sum(c.value() for c in creatures)
+
+    def total_mana(creatures):
+        return sum(c.mana_value for c in creatures)
+
+    start_atk = start.players["A"].creatures
+    start_blk = start.players["B"].creatures
+    end_atk = [c for c in start_atk if c not in result.creatures_destroyed]
+    end_blk = [c for c in start_blk if c not in result.creatures_destroyed]
+
+    value_diff = (
+        total_value(start_blk)
+        - total_value(end_blk)
+        - (total_value(start_atk) - total_value(end_atk))
+    )
+    count_diff = len(start_blk) - len(end_blk) - (len(start_atk) - len(end_atk))
+    mana_diff = (
+        total_mana(start_blk)
+        - total_mana(end_blk)
+        - (total_mana(start_atk) - total_mana(end_atk))
+    )
+
+    a_life = state.players["A"].life - start.players["A"].life
+    b_life = state.players["B"].life - start.players["B"].life
+    life_diff = a_life - b_life
+
+    a_poison = state.players["A"].poison - start.players["A"].poison
+    b_poison = state.players["B"].poison - start.players["B"].poison
+    poison_diff = b_poison - a_poison
+
+    score = result.score("A", "B")
+    assert score[1] == value_diff
+    assert score[2] == count_diff
+    assert score[3] == mana_diff
+    assert score[4] == life_diff
+    assert score[5] == poison_diff

--- a/tests/core/test_block_utils.py
+++ b/tests/core/test_block_utils.py
@@ -15,4 +15,8 @@ def test_evaluate_block_assignment_simple():
         }
     )
     score = evaluate_block_assignment([atk], [blk], [0], state, IterationCounter(10))
-    assert score == (0, 0.0, 0, 0, 0, 0, (0,))
+    numeric = score[:-2]
+    new_state = score[-1]
+    assert numeric == (0, 0.0, 0, 0, 0, 0)
+    assert score[-2] == (0,)
+    assert isinstance(new_state, GameState)


### PR DESCRIPTION
## Summary
- return final `GameState` from `evaluate_block_assignment`
- adjust block AI helper to ignore the new state when scoring
- update block utility unit test
- fix helper functions in blocking tests
- add regression test ensuring `CombatResult` matches state differences

## Testing
- `black magic_combat tests/combat/test_result_state.py tests/core/test_block_utils.py tests/combat/test_random_card_blocks.py tests/combat/test_block_damage_extra.py magic_combat/blocking_ai.py magic_combat/block_utils.py`
- `isort --profile black magic_combat tests/combat/test_result_state.py tests/core/test_block_utils.py tests/combat/test_random_card_blocks.py tests/combat/test_block_damage_extra.py`
- `autoflake --check --recursive magic_combat tests/combat/test_result_state.py tests/core/test_block_utils.py tests/combat/test_random_card_blocks.py tests/combat/test_block_damage_extra.py`
- `flake8 magic_combat scripts tests`
- `pycodestyle --max-line-length=88 --ignore=E203,W503,E226 --exclude=comprehensive_rules.py,tests,magic_combat/rules_text.py magic_combat scripts`
- `pylint magic_combat scripts tests`
- `mypy magic_combat scripts tests`
- `pyright magic_combat scripts tests`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68620fc023f8832a88032297fe36ac12