### PR TITLE
Return combat state from block evaluation

### DIFF
--- a/magic_combat/blocking_ai.py
+++ b/magic_combat/blocking_ai.py
@@ -339,7 +339,7 @@ def _minimax_blocks(
         order_iter = product(*order_options) if order_options else [tuple()]
         for orders in order_iter:
             damage_order = {atk_keys[i]: orders[i] for i in range(len(orders))}
-            score = evaluate_block_assignment(
+            score, _ = evaluate_block_assignment(
                 attackers,
                 blockers,
                 assignment,

--- a/scripts/experiment_with_simple_ai.py
+++ b/scripts/experiment_with_simple_ai.py
@@ -40,7 +40,7 @@ def main():
     )
     assignment = [attackers.index(b.blocking) if b.blocking else None for b in blockers]
     iteration_counter = IterationCounter(max_iterations=1000)
-    score = evaluate_block_assignment(
+    score, _ = evaluate_block_assignment(
         attackers=attackers,
         blockers=blockers,
         assignment=assignment,

--- a/tests/combat/test_block_damage_extra.py
+++ b/tests/combat/test_block_damage_extra.py
@@ -58,7 +58,7 @@ def _compute_best_assignment(atk, blk, state):
     best = None
     best_score = None
     for ass in product(*options):
-        score = evaluate_block_assignment(atk, blk, ass, state, counter)
+        score, _ = evaluate_block_assignment(atk, blk, ass, state, counter)
         if best_score is None or score < best_score:
             best_score = score
             best = ass

--- a/tests/combat/test_random_card_blocks.py
+++ b/tests/combat/test_random_card_blocks.py
@@ -26,7 +26,7 @@ def _compute_best_assignment(atk, blk, state):
     best = None
     best_score = None
     for ass in product(*options):
-        score = evaluate_block_assignment(atk, blk, ass, state, counter)
+        score, _ = evaluate_block_assignment(atk, blk, ass, state, counter)
         if best_score is None or score < best_score:
             best_score = score
             best = ass

--- a/tests/combat/test_result_state_diff.py
+++ b/tests/combat/test_result_state_diff.py
@@ -1,0 +1,98 @@
+import copy
+
+from magic_combat import CombatCreature
+from magic_combat import CombatSimulator
+from magic_combat import GameState
+from magic_combat import PlayerState
+from magic_combat.block_utils import evaluate_block_assignment
+from magic_combat.gamestate import has_player_lost
+from magic_combat.limits import IterationCounter
+from tests.conftest import link_block
+
+
+def _score_from_states(
+    start: GameState, end: GameState | None, attacker: str, defender: str
+) -> tuple[int, float, int, int, int, int]:
+    assert end is not None
+    lost = 1 if has_player_lost(end, defender) else 0
+    start_att = start.players[attacker].creatures
+    start_def = start.players[defender].creatures
+    end_att_names = {c.name for c in end.players[attacker].creatures}
+    end_def_names = {c.name for c in end.players[defender].creatures}
+    att_lost = [c for c in start_att if c.name not in end_att_names]
+    def_lost = [c for c in start_def if c.name not in end_def_names]
+    val_diff = sum(c.value() for c in def_lost) - sum(c.value() for c in att_lost)
+    cnt_diff = len(def_lost) - len(att_lost)
+    mana_diff = sum(c.mana_value for c in def_lost) - sum(
+        c.mana_value for c in att_lost
+    )
+    life_diff = (start.players[defender].life - end.players[defender].life) - (
+        start.players[attacker].life - end.players[attacker].life
+    )
+    poison_diff = (end.players[defender].poison - start.players[defender].poison) - (
+        end.players[attacker].poison - start.players[attacker].poison
+    )
+    return lost, val_diff, cnt_diff, mana_diff, life_diff, poison_diff
+
+
+def test_persist_undying_state_value():
+    """CR 702.77a & 702.92a: Persist and undying return creatures that died without counters."""
+    atk = CombatCreature("Phoenix", 2, 2, "A", undying=True, mana_cost="{2}{R}")
+    blk = CombatCreature("Spirit", 2, 2, "B", persist=True, mana_cost="{2}{W}")
+    link_block(atk, blk)
+    start = GameState(
+        players={
+            "A": PlayerState(life=20, creatures=[atk]),
+            "B": PlayerState(life=20, creatures=[blk]),
+        }
+    )
+    state_for_sim = copy.deepcopy(start)
+    sim = CombatSimulator(
+        [state_for_sim.players["A"].creatures[0]],
+        [state_for_sim.players["B"].creatures[0]],
+        game_state=state_for_sim,
+    )
+    result = sim.simulate()
+    expected = _score_from_states(start, state_for_sim, "A", "B")
+    assert result.score("A", "B") == expected
+    # Reset blocking on the original objects before evaluation
+    atk.blocked_by.clear()
+    blk.blocking = None
+    score, end_state = evaluate_block_assignment(
+        [atk], [blk], [0], start, IterationCounter(10)
+    )
+    assert _score_from_states(start, end_state, "A", "B") == expected
+    assert score == expected + ((0,),)
+    assert end_state is not None
+    p_creature = end_state.players["A"].creatures[0]
+    s_creature = end_state.players["B"].creatures[0]
+    assert p_creature.name == "Phoenix"
+    assert p_creature.plus1_counters == 1
+    assert s_creature.name == "Spirit"
+    assert s_creature.minus1_counters == 1
+
+
+def test_lifelink_infect_state_changes():
+    """CR 702.90b & 702.15a: Infect deals poison counters and lifelink gains that much life."""
+    atk = CombatCreature("Infecter", 2, 2, "A", infect=True, lifelink=True)
+    defender = CombatCreature("Dummy", 0, 1, "B")
+    start = GameState(
+        players={
+            "A": PlayerState(life=10, creatures=[atk]),
+            "B": PlayerState(life=10, creatures=[defender], poison=8),
+        }
+    )
+    state_for_sim = copy.deepcopy(start)
+    sim = CombatSimulator(
+        [state_for_sim.players["A"].creatures[0]],
+        [state_for_sim.players["B"].creatures[0]],
+        game_state=state_for_sim,
+    )
+    result = sim.simulate()
+    expected = _score_from_states(start, state_for_sim, "A", "B")
+    assert result.score("A", "B") == expected
+    score, end_state = evaluate_block_assignment(
+        [atk], [defender], [None], start, IterationCounter(10)
+    )
+    assert _score_from_states(start, end_state, "A", "B") == expected
+    assert score == expected + ((1,),)

--- a/tests/core/test_block_utils.py
+++ b/tests/core/test_block_utils.py
@@ -14,5 +14,8 @@ def test_evaluate_block_assignment_simple():
             "B": PlayerState(life=20, creatures=[blk]),
         }
     )
-    score = evaluate_block_assignment([atk], [blk], [0], state, IterationCounter(10))
+    score, new_state = evaluate_block_assignment(
+        [atk], [blk], [0], state, IterationCounter(10)
+    )
     assert score == (0, 0.0, 0, 0, 0, 0, (0,))
+    assert new_state is not None


### PR DESCRIPTION
## Summary
- return final `GameState` from `evaluate_block_assignment`
- adapt AI utilities and tests to new return type
- add regression tests checking that combat result metrics equal the difference between initial and final states
- assert revived creatures have appropriate counters in persist/undying scenario

## Testing
- `isort . --profile black`
- `black .`
- `autoflake -i -r .`
- `pycodestyle --max-line-length=88 --ignore=E203,W503,E226 --exclude=comprehensive_rules.py,tests,magic_combat/rules_text.py magic_combat scripts`
- `flake8 magic_combat scripts`
- `pylint magic_combat`
- `mypy --install-types --non-interactive .`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686216105214832a9e18be8c93d95b24