### PR TITLE
Simplify block evaluator

### DIFF
--- a/magic_combat/block_utils.py
+++ b/magic_combat/block_utils.py
@@ -17,10 +17,8 @@ from .simulator import CombatSimulator
 
 
 def evaluate_block_assignment(
-    attackers: Sequence[CombatCreature],
-    blockers: Sequence[CombatCreature],
     assignment: Sequence[Optional[int]],
-    state: Optional[GameState],
+    state: GameState,
     counter: IterationCounter,
     provoke_map: Optional[Dict[CombatCreature, CombatCreature]] = None,
     damage_order: Optional[dict[CombatCreature, tuple[CombatCreature, ...]]] = None,
@@ -29,22 +27,13 @@ def evaluate_block_assignment(
     Optional[GameState],
 ]:
     """Simulate combat for ``assignment`` and return the score and new state."""
-    if state is not None:
-        state_copy = deepcopy(state)
-        orig_to_copy_atk: Dict[CombatCreature, CombatCreature] = {}
-        for atk in attackers:
-            idx = state.players[atk.controller].creatures.index(atk)
-            orig_to_copy_atk[atk] = state_copy.players[atk.controller].creatures[idx]
-        orig_to_copy_blk: Dict[CombatCreature, CombatCreature] = {}
-        for blk in blockers:
-            idx = state.players[blk.controller].creatures.index(blk)
-            orig_to_copy_blk[blk] = state_copy.players[blk.controller].creatures[idx]
-        atks = [orig_to_copy_atk[a] for a in attackers]
-        blks = [orig_to_copy_blk[b] for b in blockers]
-    else:
-        state_copy = None
-        atks = deepcopy(list(attackers))
-        blks = deepcopy(list(blockers))
+    orig_atks = list(state.players["A"].creatures)
+    orig_blks = list(state.players["B"].creatures)
+    state_copy = deepcopy(state)
+    atks = list(state_copy.players["A"].creatures)
+    blks = list(state_copy.players["B"].creatures)
+    atk_map = {orig: copy for orig, copy in zip(orig_atks, atks)}
+    blk_map = {orig: copy for orig, copy in zip(orig_blks, blks)}
     for idx, choice in enumerate(assignment):
         if choice is not None:
             blk = blks[idx]
@@ -55,13 +44,11 @@ def evaluate_block_assignment(
     prov_copies: Dict[CombatCreature, CombatCreature] = {}
     if provoke_map:
         for atk, blk in provoke_map.items():
-            if atk in attackers and blk in blockers:
-                prov_copies[atks[attackers.index(atk)]] = blks[blockers.index(blk)]
+            if atk in atk_map and blk in blk_map:
+                prov_copies[atk_map[atk]] = blk_map[blk]
 
     order_map: dict[CombatCreature, tuple[CombatCreature, ...]] | None = None
     if damage_order:
-        atk_map = {orig: copy for orig, copy in zip(attackers, atks)}
-        blk_map = {orig: copy for orig, copy in zip(blockers, blks)}
         order_map = {
             atk_map[a]: tuple(blk_map[b] for b in seq)
             for a, seq in damage_order.items()
@@ -88,7 +75,7 @@ def evaluate_block_assignment(
         result = sim.simulate()
     except IllegalBlockError:
         ass_key = tuple(
-            len(attackers) if choice is None else choice for choice in assignment
+            len(atks) if choice is None else choice for choice in assignment
         )
         return (
             1,
@@ -100,10 +87,8 @@ def evaluate_block_assignment(
             ass_key,
         ), None
 
-    defender = blks[0].controller if blks else "defender"
-    attacker_player = atks[0].controller if atks else "attacker"
-    ass_key = tuple(
-        len(attackers) if choice is None else choice for choice in assignment
-    )
+    defender = "B"
+    attacker_player = "A"
+    ass_key = tuple(len(atks) if choice is None else choice for choice in assignment)
     score = result.score(attacker_player, defender) + (ass_key,)
     return score, sim.game_state

--- a/magic_combat/create_llm_prompt.py
+++ b/magic_combat/create_llm_prompt.py
@@ -8,22 +8,18 @@ from .rules_text import get_relevant_rules_text
 from .text_utils import summarize_creature
 
 
-def create_llm_prompt(
-    game_state: GameState,
-    attackers: Iterable[CombatCreature],
-    blockers: Iterable[CombatCreature],
-) -> str:
+def create_llm_prompt(game_state: GameState) -> str:
     """Create a prompt instructing a language model to choose blocks.
 
     Args:
-        game_state: The current game state.
-        attackers: Creatures attacking this turn.
-        blockers: Creatures available to block.
+        game_state: The current game state with players ``A`` and ``B``.
 
     Returns:
         A formatted prompt for the model.
     """
-    all_creatures = list(attackers) + list(blockers)
+    attackers = list(game_state.players["A"].creatures)
+    blockers = list(game_state.players["B"].creatures)
+    all_creatures = attackers + blockers
     include_colors = any(
         c.fear or c.intimidate or c.protection_colors for c in all_creatures
     )

--- a/magic_combat/random_scenario.py
+++ b/magic_combat/random_scenario.py
@@ -246,8 +246,6 @@ def _determine_block_assignments(
     simple_state = copy.deepcopy(state)
     try:
         decide_simple_blocks(
-            simple_atk,
-            simple_blk,
             game_state=simple_state,
             provoke_map=provoke_map,
             max_iterations=max_iterations,
@@ -260,8 +258,6 @@ def _determine_block_assignments(
         simple_assignment = None
 
     _, opt_count = decide_optimal_blocks(
-        attackers,
-        blockers,
         game_state=state,
         provoke_map=provoke_map,
         max_iterations=max_iterations,

--- a/scripts/evaluate_random_combat_scenarios.py
+++ b/scripts/evaluate_random_combat_scenarios.py
@@ -206,7 +206,7 @@ async def _evaluate_single_scenario(
     for blk in blockers:
         blk.blocking = None
 
-    prompt = create_llm_prompt(state, attackers, blockers)
+    prompt = create_llm_prompt(state)
 
     attempts = 0
     max_attempts = 3

--- a/scripts/experiment_with_simple_ai.py
+++ b/scripts/experiment_with_simple_ai.py
@@ -13,7 +13,7 @@ def main():
             name="Attacker 1",
             power=2,
             toughness=2,
-            controller="Player A",
+            controller="A",
             persist=True,
         ),
     ]
@@ -22,27 +22,23 @@ def main():
             name="Blocker 1",
             power=2,
             toughness=3,
-            controller="Player B",
+            controller="B",
         ),
     ]
     game_state = GameState(
         players={
-            "Player A": PlayerState(life=20, creatures=attackers, poison=0),
-            "Player B": PlayerState(life=20, creatures=blockers, poison=0),
+            "A": PlayerState(life=20, creatures=attackers, poison=0),
+            "B": PlayerState(life=20, creatures=blockers, poison=0),
         }
     )
     print(game_state)
     decide_optimal_blocks(
-        attackers=attackers,
-        blockers=blockers,
         game_state=game_state,
         provoke_map={},
     )
     assignment = [attackers.index(b.blocking) if b.blocking else None for b in blockers]
     iteration_counter = IterationCounter(max_iterations=1000)
     score, _ = evaluate_block_assignment(
-        attackers=attackers,
-        blockers=blockers,
         assignment=assignment,
         state=game_state,
         counter=iteration_counter,  # No iteration counter needed for this example

--- a/tests/combat/test_block_ai.py
+++ b/tests/combat/test_block_ai.py
@@ -21,7 +21,7 @@ def test_optimal_ai_respects_provoke():
             "B": PlayerState(life=20, creatures=[blk]),
         }
     )
-    decide_optimal_blocks([atk], [blk], game_state=state, provoke_map={atk: blk})
+    decide_optimal_blocks(game_state=state, provoke_map={atk: blk})
     sim = CombatSimulator([atk], [blk], game_state=state, provoke_map={atk: blk})
     sim.validate_blocking()
     assert blk.blocking is atk
@@ -39,7 +39,7 @@ def test_optimal_ai_provoke_untaps_tapped_blocker():
         }
     )
     blk.tapped = False
-    decide_optimal_blocks([atk], [blk], game_state=state, provoke_map={atk: blk})
+    decide_optimal_blocks(game_state=state, provoke_map={atk: blk})
     sim = CombatSimulator([atk], [blk], game_state=state, provoke_map={atk: blk})
     sim.validate_blocking()
     assert blk.blocking is atk
@@ -55,7 +55,7 @@ def test_ai_blocks_to_prevent_lethal():
             "B": PlayerState(life=2, creatures=[blk]),
         }
     )
-    decide_optimal_blocks([atk], [blk], game_state=state)
+    decide_optimal_blocks(game_state=state)
     assert blk.blocking is atk
     assert atk.blocked_by == [blk]
     sim = CombatSimulator([atk], [blk], game_state=state)
@@ -75,7 +75,7 @@ def test_ai_prefers_best_value_trade():
             "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[b1, b2]),
         }
     )
-    decide_optimal_blocks([a1, a2], [b1, b2], game_state=state)
+    decide_optimal_blocks(game_state=state)
     # The heuristic keeps the Soldier back and has Knight trade with Goblin
     assert b2.blocking is None
     assert b1.blocking is a2
@@ -98,7 +98,7 @@ def test_ai_saves_creature_when_blocking_is_bad():
             "B": PlayerState(life=10, creatures=[blk]),
         }
     )
-    decide_optimal_blocks([atk], [blk], game_state=state)
+    decide_optimal_blocks(game_state=state)
     assert blk.blocking is None
 
 
@@ -112,7 +112,7 @@ def test_ai_chump_block_to_prevent_lethal():
             "B": PlayerState(life=5, creatures=[blk]),
         }
     )
-    decide_optimal_blocks([atk], [blk], game_state=state)
+    decide_optimal_blocks(game_state=state)
     assert blk.blocking is atk
 
 
@@ -127,7 +127,7 @@ def test_ai_selects_correct_blocker_with_multiple_attackers():
             "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[blk]),
         }
     )
-    decide_optimal_blocks([a1, a2], [blk], game_state=state)
+    decide_optimal_blocks(game_state=state)
     assert blk.blocking is a2
 
 
@@ -142,7 +142,7 @@ def test_ai_double_blocks_big_attacker_to_kill():
             "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[b1, b2]),
         }
     )
-    decide_optimal_blocks([atk], [b1, b2], game_state=state)
+    decide_optimal_blocks(game_state=state)
     assert b1.blocking is atk and b2.blocking is atk
 
 
@@ -158,7 +158,7 @@ def test_ai_double_blocks_first_striker():
             "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[b1, b2]),
         }
     )
-    decide_optimal_blocks([atk1, atk2], [b1, b2], game_state=state)
+    decide_optimal_blocks(game_state=state)
     assert b1.blocking is atk1 and b2.blocking is atk1
 
 
@@ -172,7 +172,7 @@ def test_ai_blocks_trample_to_prevent_lethal():
             "B": PlayerState(life=4, creatures=[blk]),
         }
     )
-    decide_optimal_blocks([atk], [blk], game_state=state)
+    decide_optimal_blocks(game_state=state)
     assert blk.blocking is atk
 
 
@@ -187,7 +187,7 @@ def test_ai_blocks_trample_with_two_when_needed():
             "B": PlayerState(life=1, creatures=[b1, b2]),
         }
     )
-    decide_optimal_blocks([atk], [b1, b2], game_state=state)
+    decide_optimal_blocks(game_state=state)
     assert b1.blocking is atk and b2.blocking is atk
 
 
@@ -202,7 +202,7 @@ def test_ai_blocks_menace_with_two_blockers():
             "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[b1, b2]),
         }
     )
-    decide_optimal_blocks([atk], [b1, b2], game_state=state)
+    decide_optimal_blocks(game_state=state)
     assert b1.blocking is atk and b2.blocking is atk
 
 
@@ -216,7 +216,7 @@ def test_optimal_ai_ignores_provoke_with_single_blocker():
             "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[blk]),
         }
     )
-    decide_optimal_blocks([atk], [blk], game_state=state, provoke_map={atk: blk})
+    decide_optimal_blocks(game_state=state, provoke_map={atk: blk})
     assert blk.blocking is None
 
 
@@ -231,7 +231,7 @@ def test_ai_blocks_fear_with_correct_color():
             "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[w, blk]),
         }
     )
-    decide_optimal_blocks([atk], [w, blk], game_state=state)
+    decide_optimal_blocks(game_state=state)
     assert w.blocking is None and blk.blocking is atk
 
 
@@ -246,7 +246,7 @@ def test_ai_blocks_infect_when_poison_would_be_lethal():
             "B": PlayerState(life=10, creatures=[blk], poison=9),
         }
     )
-    decide_optimal_blocks([atk, big], [blk], game_state=state)
+    decide_optimal_blocks(game_state=state)
     assert blk.blocking is atk
 
 
@@ -261,7 +261,7 @@ def test_ai_blocks_flying_with_reach_creature():
             "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[reacher]),
         }
     )
-    decide_optimal_blocks([flyer, ground], [reacher], game_state=state)
+    decide_optimal_blocks(game_state=state)
     assert reacher.blocking is flyer
 
 
@@ -278,7 +278,7 @@ def test_ai_spreads_blocks_for_max_value():
             "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[b1, b2, b3]),
         }
     )
-    decide_optimal_blocks([a1, a2], [b1, b2, b3], game_state=state)
+    decide_optimal_blocks(game_state=state)
     assert sum(blk.blocking is not None for blk in (b1, b2, b3)) >= 2
 
 
@@ -295,7 +295,7 @@ def test_ai_blocks_three_attackers_prioritize_biggest():
             "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[b1, b2]),
         }
     )
-    decide_optimal_blocks([a1, a2, a3], [b1, b2], game_state=state)
+    decide_optimal_blocks(game_state=state)
     assert b1.blocking is a2 and b2.blocking is a1
 
 
@@ -310,7 +310,7 @@ def test_ai_blocks_to_minimize_life_loss():
             "B": PlayerState(life=5, creatures=[blk]),
         }
     )
-    decide_optimal_blocks([a1, a2], [blk], game_state=state)
+    decide_optimal_blocks(game_state=state)
     assert blk.blocking is a2
 
 
@@ -324,7 +324,7 @@ def test_ai_no_block_when_survival_and_bad_trade():
             "B": PlayerState(life=10, creatures=[blk]),
         }
     )
-    decide_optimal_blocks([atk], [blk], game_state=state)
+    decide_optimal_blocks(game_state=state)
     assert blk.blocking is None
 
 
@@ -338,7 +338,7 @@ def test_ai_blocks_lifelink_attacker_to_stop_gain():
             "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[blk]),
         }
     )
-    decide_optimal_blocks([atk], [blk], game_state=state)
+    decide_optimal_blocks(game_state=state)
     assert blk.blocking is atk
 
 
@@ -354,7 +354,7 @@ def test_ai_deterministic_tiebreaker():
             "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[b1, b2]),
         }
     )
-    decide_optimal_blocks([a1, a2], [b1, b2], game_state=state)
+    decide_optimal_blocks(game_state=state)
     assert (b1.blocking, b2.blocking) == (a1, a2)
 
 
@@ -369,7 +369,7 @@ def test_ai_blocks_creature_with_first_strike_over_vanilla():
             "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[blk]),
         }
     )
-    decide_optimal_blocks([a1, a2], [blk], game_state=state)
+    decide_optimal_blocks(game_state=state)
     assert blk.blocking is a2
 
 
@@ -385,7 +385,7 @@ def test_ai_prefers_blocking_to_kill_more_mana():
             "B": PlayerState(life=4, creatures=[b1, b2]),
         }
     )
-    decide_optimal_blocks([a1, a2], [b1, b2], game_state=state)
+    decide_optimal_blocks(game_state=state)
     assert b1.blocking is a2 and b2.blocking is a1
 
 
@@ -403,7 +403,7 @@ def test_iteration_limit_triggers():
     from magic_combat import IterationLimitError
 
     with pytest.raises(IterationLimitError):
-        decide_optimal_blocks([atk], [b1, b2], game_state=state, max_iterations=1)
+        decide_optimal_blocks(game_state=state, max_iterations=1)
 
 
 def test_iteration_limit_allows_fast_run():
@@ -420,8 +420,6 @@ def test_iteration_limit_allows_fast_run():
     )
     start = time.perf_counter()
     decide_optimal_blocks(
-        [a1, a2],
-        [b1, b2],
         game_state=state,
         max_iterations=1000,
     )
@@ -441,7 +439,7 @@ def test_ai_optimal_count_ignores_tiebreaker():
             "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[b1, b2]),
         }
     )
-    _, opt = decide_optimal_blocks([a1, a2], [b1, b2], game_state=state)
+    _, opt = decide_optimal_blocks(game_state=state)
     assert opt == 2
 
 
@@ -456,5 +454,5 @@ def test_ai_ignores_tapped_blocker():
             "B": PlayerState(life=1, creatures=[blk]),
         }
     )
-    decide_optimal_blocks([atk], [blk], game_state=state)
+    decide_optimal_blocks(game_state=state)
     assert blk.blocking is None

--- a/tests/combat/test_block_damage_extra.py
+++ b/tests/combat/test_block_damage_extra.py
@@ -40,7 +40,7 @@ def test_ai_uses_deathtouch_on_biggest_attacker():
             "B": PlayerState(life=20, creatures=[snake, knight]),
         }
     )
-    decide_optimal_blocks([giant, goblin], [snake, knight], game_state=state)
+    decide_optimal_blocks(game_state=state)
     assert snake.blocking is giant
     assert knight.blocking is goblin
     sim = CombatSimulator([giant, goblin], [snake, knight], game_state=state)
@@ -58,7 +58,7 @@ def _compute_best_assignment(atk, blk, state):
     best = None
     best_score = None
     for ass in product(*options):
-        score, _ = evaluate_block_assignment(atk, blk, ass, state, counter)
+        score, _ = evaluate_block_assignment(ass, state, counter)
         if best_score is None or score < best_score:
             best_score = score
             best = ass
@@ -84,7 +84,7 @@ def test_fuzz_blocking_optimal(seed):
         }
     )
     expected = _compute_best_assignment(attackers, blockers, state)
-    decide_optimal_blocks(attackers, blockers, game_state=state)
+    decide_optimal_blocks(game_state=state)
     chosen = tuple(
         attackers.index(b.blocking) if b.blocking is not None else None
         for b in blockers

--- a/tests/combat/test_random_card_blocks.py
+++ b/tests/combat/test_random_card_blocks.py
@@ -26,7 +26,7 @@ def _compute_best_assignment(atk, blk, state):
     best = None
     best_score = None
     for ass in product(*options):
-        score, _ = evaluate_block_assignment(atk, blk, ass, state, counter)
+        score, _ = evaluate_block_assignment(ass, state, counter)
         if best_score is None or score < best_score:
             best_score = score
             best = ass
@@ -50,7 +50,7 @@ def test_random_card_blocks_optimal(seed):
         }
     )
     expected = _compute_best_assignment(attackers, blockers, state)
-    decide_optimal_blocks(attackers, blockers, game_state=state)
+    decide_optimal_blocks(game_state=state)
     chosen = tuple(
         attackers.index(b.blocking) if b.blocking is not None else None
         for b in blockers

--- a/tests/combat/test_result_state_diff.py
+++ b/tests/combat/test_result_state_diff.py
@@ -36,7 +36,8 @@ def _score_from_states(
 
 
 def test_persist_undying_state_value():
-    """CR 702.77a & 702.92a: Persist and undying return creatures that died without counters."""
+    """CR 702.77a & 702.92a: Persist and undying return creatures
+    that died without counters."""
     atk = CombatCreature("Phoenix", 2, 2, "A", undying=True, mana_cost="{2}{R}")
     blk = CombatCreature("Spirit", 2, 2, "B", persist=True, mana_cost="{2}{W}")
     link_block(atk, blk)
@@ -58,9 +59,7 @@ def test_persist_undying_state_value():
     # Reset blocking on the original objects before evaluation
     atk.blocked_by.clear()
     blk.blocking = None
-    score, end_state = evaluate_block_assignment(
-        [atk], [blk], [0], start, IterationCounter(10)
-    )
+    score, end_state = evaluate_block_assignment([0], start, IterationCounter(10))
     assert _score_from_states(start, end_state, "A", "B") == expected
     assert score == expected + ((0,),)
     assert end_state is not None
@@ -73,7 +72,8 @@ def test_persist_undying_state_value():
 
 
 def test_lifelink_infect_state_changes():
-    """CR 702.90b & 702.15a: Infect deals poison counters and lifelink gains that much life."""
+    """CR 702.90b & 702.15a: Infect deals poison counters and
+    lifelink gains that much life."""
     atk = CombatCreature("Infecter", 2, 2, "A", infect=True, lifelink=True)
     defender = CombatCreature("Dummy", 0, 1, "B")
     start = GameState(
@@ -91,8 +91,6 @@ def test_lifelink_infect_state_changes():
     result = sim.simulate()
     expected = _score_from_states(start, state_for_sim, "A", "B")
     assert result.score("A", "B") == expected
-    score, end_state = evaluate_block_assignment(
-        [atk], [defender], [None], start, IterationCounter(10)
-    )
+    score, end_state = evaluate_block_assignment([None], start, IterationCounter(10))
     assert _score_from_states(start, end_state, "A", "B") == expected
     assert score == expected + ((1,),)

--- a/tests/combat/test_simple_block_ai.py
+++ b/tests/combat/test_simple_block_ai.py
@@ -19,7 +19,7 @@ def test_simple_ai_respects_provoke():
             "B": PlayerState(life=20, creatures=[blk]),
         }
     )
-    decide_simple_blocks([atk], [blk], game_state=state, provoke_map={atk: blk})
+    decide_simple_blocks(game_state=state, provoke_map={atk: blk})
     sim = CombatSimulator([atk], [blk], game_state=state, provoke_map={atk: blk})
     sim.validate_blocking()
     assert blk.blocking is atk
@@ -37,7 +37,7 @@ def test_simple_ai_provoke_untaps_tapped_blocker():
         }
     )
     blk.tapped = False
-    decide_simple_blocks([atk], [blk], game_state=state, provoke_map={atk: blk})
+    decide_simple_blocks(game_state=state, provoke_map={atk: blk})
     sim = CombatSimulator([atk], [blk], game_state=state, provoke_map={atk: blk})
     sim.validate_blocking()
     assert blk.blocking is atk
@@ -55,7 +55,7 @@ def test_simple_ai_blocks_best_trade():
             "B": PlayerState(life=20, creatures=[b1, b2]),
         }
     )
-    decide_simple_blocks([a1, a2], [b1, b2], game_state=state)
+    decide_simple_blocks(game_state=state)
     assert b1.blocking is a2
     assert b2.blocking is None
 
@@ -71,7 +71,7 @@ def test_simple_ai_uses_deathtouch_block():
             "B": PlayerState(life=20, creatures=[deathtouch_blk, vanilla_blk]),
         }
     )
-    decide_simple_blocks([giant], [deathtouch_blk, vanilla_blk], game_state=state)
+    decide_simple_blocks(game_state=state)
     assert deathtouch_blk.blocking is giant
     assert vanilla_blk.blocking is None
 
@@ -88,7 +88,7 @@ def test_simple_ai_blocks_first_striker_with_first_strike():
             "B": PlayerState(life=20, creatures=[fs_blk, other_blk]),
         }
     )
-    decide_simple_blocks([fs_atk, vanilla_atk], [fs_blk, other_blk], game_state=state)
+    decide_simple_blocks(game_state=state)
     assert fs_blk.blocking is fs_atk
 
 
@@ -103,7 +103,7 @@ def test_simple_ai_blocks_lifelink_attacker():
             "B": PlayerState(life=20, creatures=[blk]),
         }
     )
-    decide_simple_blocks([lifelink_atk, vanilla_atk], [blk], game_state=state)
+    decide_simple_blocks(game_state=state)
     assert blk.blocking is lifelink_atk
 
 
@@ -117,7 +117,7 @@ def test_simple_ai_skips_indestructible_bad_trade():
             "B": PlayerState(life=20, creatures=[blk]),
         }
     )
-    decide_simple_blocks([indestructible_atk], [blk], game_state=state)
+    decide_simple_blocks(game_state=state)
     assert blk.blocking is None
 
 
@@ -133,7 +133,7 @@ def test_simple_ai_blocks_flyer_with_reach():
             "B": PlayerState(life=20, creatures=[reacher, other_blk]),
         }
     )
-    decide_simple_blocks([flyer, ground], [reacher, other_blk], game_state=state)
+    decide_simple_blocks(game_state=state)
     assert reacher.blocking is flyer
 
 
@@ -148,7 +148,7 @@ def test_simple_ai_blocks_double_strike_first():
             "B": PlayerState(life=20, creatures=[blk]),
         }
     )
-    decide_simple_blocks([ds_atk, vanilla_atk], [blk], game_state=state)
+    decide_simple_blocks(game_state=state)
     assert blk.blocking is vanilla_atk
 
 
@@ -164,7 +164,7 @@ def test_simple_ai_trade_instead_of_chump_when_safe():
             "B": PlayerState(life=20, creatures=[big_blk, chump]),
         }
     )
-    decide_simple_blocks([big_atk, small_atk], [big_blk, chump], game_state=state)
+    decide_simple_blocks(game_state=state)
     assert big_blk.blocking is small_atk
     assert chump.blocking is None
 
@@ -181,7 +181,7 @@ def test_simple_ai_chump_to_prevent_lethal():
             "B": PlayerState(life=2, creatures=[big_blk, chump]),
         }
     )
-    decide_simple_blocks([big_atk, small_atk], [big_blk, chump], game_state=state)
+    decide_simple_blocks(game_state=state)
     assert big_blk.blocking is small_atk
     assert chump.blocking is big_atk
 
@@ -198,7 +198,7 @@ def test_simple_ai_lets_infect_kill_when_value_trade():
             "B": PlayerState(life=20, creatures=[b1, b2], poison=9),
         }
     )
-    decide_simple_blocks([infect, big], [b1, b2], game_state=state)
+    decide_simple_blocks(game_state=state)
     sim = CombatSimulator([infect, big], [b1, b2], game_state=state)
     result = sim.simulate()
     assert b1.blocking is infect
@@ -217,7 +217,7 @@ def test_simple_ai_trade_and_die_from_second_attacker():
             "B": PlayerState(life=6, creatures=[blk]),
         }
     )
-    decide_simple_blocks([a1, a2], [blk], game_state=state)
+    decide_simple_blocks(game_state=state)
     sim = CombatSimulator([a1, a2], [blk], game_state=state)
     result = sim.simulate()
     assert blk.blocking in (a1, a2)
@@ -236,7 +236,7 @@ def test_simple_ai_block_lifelink_then_chump_other_attacker():
             "B": PlayerState(life=4, creatures=[big_blk, chump]),
         }
     )
-    decide_simple_blocks([lifelink_atk, other_atk], [big_blk, chump], game_state=state)
+    decide_simple_blocks(game_state=state)
     assert big_blk.blocking is lifelink_atk
     assert chump.blocking is other_atk
 
@@ -253,7 +253,7 @@ def test_simple_ai_chumps_trample_big_attack():
             "B": PlayerState(life=5, creatures=[b1, b2]),
         }
     )
-    decide_simple_blocks([trampler, other_atk], [b1, b2], game_state=state)
+    decide_simple_blocks(game_state=state)
     assert b1.blocking is other_atk
     assert b2.blocking is None
 
@@ -269,7 +269,7 @@ def test_simple_ai_first_strike_blocks_deathtouch():
             "B": PlayerState(life=20, creatures=[fs_blk, vanilla_blk]),
         }
     )
-    decide_simple_blocks([dt_atk], [fs_blk, vanilla_blk], game_state=state)
+    decide_simple_blocks(game_state=state)
     assert fs_blk.blocking is dt_atk
     assert vanilla_blk.blocking is None
 
@@ -286,9 +286,7 @@ def test_simple_ai_blocks_provoke_target_favorably():
             "B": PlayerState(life=20, creatures=[blk1, blk2]),
         }
     )
-    decide_simple_blocks(
-        [atk1, atk2], [blk1, blk2], game_state=state, provoke_map={atk1: blk1}
-    )
+    decide_simple_blocks(game_state=state, provoke_map={atk1: blk1})
     assert blk1.blocking is atk1
     assert blk2.blocking is atk2
 
@@ -303,7 +301,7 @@ def test_simple_ai_ignores_provoke_with_single_blocker():
             "B": PlayerState(life=20, creatures=[blk]),
         }
     )
-    decide_simple_blocks([atk], [blk], game_state=state, provoke_map={atk: blk})
+    decide_simple_blocks(game_state=state, provoke_map={atk: blk})
     assert blk.blocking is None
 
 
@@ -318,7 +316,7 @@ def test_simple_ai_reacher_blocks_flyer_only():
             "B": PlayerState(life=20, creatures=[reacher]),
         }
     )
-    decide_simple_blocks([flyer, ground], [reacher], game_state=state)
+    decide_simple_blocks(game_state=state)
     assert reacher.blocking is ground
 
 
@@ -336,7 +334,7 @@ def test_simple_ai_iteration_limit_triggers():
     from magic_combat import IterationLimitError
 
     with pytest.raises(IterationLimitError):
-        decide_simple_blocks([atk], [b1, b2], game_state=state, max_iterations=1)
+        decide_simple_blocks(game_state=state, max_iterations=1)
 
 
 def test_simple_ai_iteration_limit_allows_fast_run():
@@ -353,8 +351,6 @@ def test_simple_ai_iteration_limit_allows_fast_run():
     )
     start = time.perf_counter()
     decide_simple_blocks(
-        [a1, a2],
-        [b1, b2],
         game_state=state,
         max_iterations=1000,
     )
@@ -373,5 +369,5 @@ def test_simple_ai_ignores_tapped_blocker():
             "B": PlayerState(life=1, creatures=[blk]),
         }
     )
-    decide_simple_blocks([atk], [blk], game_state=state)
+    decide_simple_blocks(game_state=state)
     assert blk.blocking is None

--- a/tests/combat/test_simple_deviations.py
+++ b/tests/combat/test_simple_deviations.py
@@ -17,7 +17,7 @@ def test_simple_ai_skips_nonlethal_double_block():
             "B": PlayerState(life=20, creatures=[b1, b2]),
         }
     )
-    decide_simple_blocks([atk], [b1, b2], game_state=state)
+    decide_simple_blocks(game_state=state)
     assert b1.blocking is None and b2.blocking is None
 
     atk_o = CombatCreature("Giant", 6, 6, "A")
@@ -29,7 +29,7 @@ def test_simple_ai_skips_nonlethal_double_block():
             "B": PlayerState(life=20, creatures=[c1, c2]),
         }
     )
-    decide_optimal_blocks([atk_o], [c1, c2], game_state=state_o)
+    decide_optimal_blocks(game_state=state_o)
     assert c1.blocking is atk_o and c2.blocking is atk_o
 
 
@@ -44,7 +44,7 @@ def test_simple_ai_chumps_instead_of_double_blocking_lethal():
             "B": PlayerState(life=6, creatures=[b1, b2]),
         }
     )
-    decide_simple_blocks([atk], [b1, b2], game_state=state)
+    decide_simple_blocks(game_state=state)
     assert sum(blk.blocking is atk for blk in (b1, b2)) == 1
 
     atk_o = CombatCreature("Giant", 6, 6, "A")
@@ -56,7 +56,7 @@ def test_simple_ai_chumps_instead_of_double_blocking_lethal():
             "B": PlayerState(life=6, creatures=[c1, c2]),
         }
     )
-    decide_optimal_blocks([atk_o], [c1, c2], game_state=state_o)
+    decide_optimal_blocks(game_state=state_o)
     assert c1.blocking is atk_o and c2.blocking is atk_o
 
 
@@ -74,9 +74,7 @@ def test_simple_ai_single_blocks_when_double_block_survives():
             "B": PlayerState(life=5, creatures=[big_blk, small_blk]),
         }
     )
-    decide_simple_blocks(
-        [big_atk, small_atk], [big_blk, small_blk], game_state=state_simple
-    )
+    decide_simple_blocks(game_state=state_simple)
     assert big_blk.blocking is small_atk
     assert small_blk.blocking is big_atk
 
@@ -92,9 +90,7 @@ def test_simple_ai_single_blocks_when_double_block_survives():
             "B": PlayerState(life=5, creatures=[big_blk2, small_blk2]),
         }
     )
-    decide_optimal_blocks(
-        [big_atk2, small_atk2], [big_blk2, small_blk2], game_state=state_opt
-    )
+    decide_optimal_blocks(game_state=state_opt)
     assert big_blk2.blocking is big_atk2 and small_blk2.blocking is big_atk2
 
 
@@ -112,11 +108,7 @@ def test_simple_ai_blocks_lifelink_instead_of_killing_bigger():
             "B": PlayerState(life=10, creatures=[blk1, blk2]),
         }
     )
-    decide_simple_blocks(
-        [lifelink_atk, big_atk],
-        [blk1, blk2],
-        game_state=state_simple,
-    )
+    decide_simple_blocks(game_state=state_simple)
     assert blk1.blocking is lifelink_atk and blk2.blocking is None
 
     lifelink_atk2 = CombatCreature("Priest", 5, 5, "A", lifelink=True)
@@ -131,9 +123,7 @@ def test_simple_ai_blocks_lifelink_instead_of_killing_bigger():
             "B": PlayerState(life=10, creatures=[blk1o, blk2o]),
         }
     )
-    decide_optimal_blocks(
-        [lifelink_atk2, big_atk2], [blk1o, blk2o], game_state=state_opt
-    )
+    decide_optimal_blocks(game_state=state_opt)
     assert blk1o.blocking is big_atk2 and blk2o.blocking is big_atk2
 
 
@@ -149,7 +139,7 @@ def test_simple_vs_optimal_chump_block() -> None:
             "B": PlayerState(life=20, creatures=[g1, g2]),
         }
     )
-    decide_simple_blocks([big, small], [g1, g2], game_state=state)
+    decide_simple_blocks(game_state=state)
     simple = [blk.blocking for blk in (g1, g2)]
 
     atk2 = [CombatCreature("Brute", 5, 5, "A"), CombatCreature("Scout", 2, 2, "A")]
@@ -160,7 +150,7 @@ def test_simple_vs_optimal_chump_block() -> None:
             "B": PlayerState(life=20, creatures=blk2),
         }
     )
-    decide_optimal_blocks(atk2, blk2, game_state=state2)
+    decide_optimal_blocks(game_state=state2)
     optimal = [blk.blocking for blk in blk2]
 
     assert [b.name if b else None for b in simple] == ["Scout", None]
@@ -179,7 +169,7 @@ def test_simple_vs_optimal_poison() -> None:
             "B": PlayerState(life=20, creatures=[b1, b2], poison=8),
         }
     )
-    decide_simple_blocks([infect, big], [b1, b2], game_state=state)
+    decide_simple_blocks(game_state=state)
     simple = [blk.blocking for blk in (b1, b2)]
 
     atk2 = [
@@ -193,7 +183,7 @@ def test_simple_vs_optimal_poison() -> None:
             "B": PlayerState(life=20, creatures=blk2, poison=8),
         }
     )
-    decide_optimal_blocks(atk2, blk2, game_state=state2)
+    decide_optimal_blocks(game_state=state2)
     optimal = [blk.blocking for blk in blk2]
 
     assert [b.name if b else None for b in simple] == ["Carrier", None]
@@ -212,7 +202,7 @@ def test_simple_vs_optimal_indestructible() -> None:
             "B": PlayerState(life=20, creatures=[g1, g2]),
         }
     )
-    decide_simple_blocks([titan, small], [g1, g2], game_state=state)
+    decide_simple_blocks(game_state=state)
     simple = [blk.blocking for blk in (g1, g2)]
 
     atk2 = [
@@ -226,7 +216,7 @@ def test_simple_vs_optimal_indestructible() -> None:
             "B": PlayerState(life=20, creatures=blk2),
         }
     )
-    decide_optimal_blocks(atk2, blk2, game_state=state2)
+    decide_optimal_blocks(game_state=state2)
     optimal = [blk.blocking for blk in blk2]
 
     assert [b.name if b else None for b in simple] == ["Warrior", None]
@@ -245,7 +235,7 @@ def test_simple_ai_single_blocks_when_double_is_better():
             "B": PlayerState(life=20, creatures=[blk1, blk2]),
         }
     )
-    decide_simple_blocks([big_atk, small_atk], [blk1, blk2], game_state=state)
+    decide_simple_blocks(game_state=state)
     assert blk1.blocking is small_atk and blk2.blocking is None
 
     for atk in (big_atk, small_atk):
@@ -253,7 +243,7 @@ def test_simple_ai_single_blocks_when_double_is_better():
     blk1.blocking = None
     blk2.blocking = None
 
-    decide_optimal_blocks([big_atk, small_atk], [blk1, blk2], game_state=state)
+    decide_optimal_blocks(game_state=state)
     assert blk1.blocking is big_atk and blk2.blocking is big_atk
 
 
@@ -269,7 +259,7 @@ def test_simple_ai_leaves_both_attackers_unblocked():
             "B": PlayerState(life=20, creatures=[blk1, blk2]),
         }
     )
-    decide_simple_blocks([atk1, atk2], [blk1, blk2], game_state=state)
+    decide_simple_blocks(game_state=state)
     assert blk1.blocking is None and blk2.blocking is None
 
     for atk in (atk1, atk2):
@@ -277,5 +267,5 @@ def test_simple_ai_leaves_both_attackers_unblocked():
     blk1.blocking = None
     blk2.blocking = None
 
-    decide_optimal_blocks([atk1, atk2], [blk1, blk2], game_state=state)
+    decide_optimal_blocks(game_state=state)
     assert blk1.blocking is atk1 and blk2.blocking is atk1

--- a/tests/combat/test_snapshot_blocks.py
+++ b/tests/combat/test_snapshot_blocks.py
@@ -38,8 +38,6 @@ def test_optimal_blocks_snapshots() -> None:
         provoke_map = decode_provoke(snap["provoke_map"], attackers, blockers)
         mentor_map = decode_mentor(snap["mentor_map"], attackers)
         decide_optimal_blocks(
-            attackers,
-            blockers,
             game_state=state,
             provoke_map=provoke_map,
         )

--- a/tests/core/test_block_utils.py
+++ b/tests/core/test_block_utils.py
@@ -14,8 +14,6 @@ def test_evaluate_block_assignment_simple():
             "B": PlayerState(life=20, creatures=[blk]),
         }
     )
-    score, new_state = evaluate_block_assignment(
-        [atk], [blk], [0], state, IterationCounter(10)
-    )
+    score, new_state = evaluate_block_assignment([0], state, IterationCounter(10))
     assert score == (0, 0.0, 0, 0, 0, 0, (0,))
     assert new_state is not None

--- a/tests/llm/test_llm_prompt.py
+++ b/tests/llm/test_llm_prompt.py
@@ -58,7 +58,7 @@ def test_create_prompt_contents():
             "B": PlayerState(life=20, creatures=[blk]),
         }
     )
-    prompt = create_llm_prompt(state, [atk], [blk])
+    prompt = create_llm_prompt(state)
     assert "The attackers are:" in prompt
     assert "Goblin" in prompt
     assert "The blockers are:" in prompt
@@ -74,7 +74,7 @@ def test_prompt_includes_mana_cost():
             "B": PlayerState(life=20, creatures=[blk]),
         }
     )
-    prompt = create_llm_prompt(state, [atk], [blk])
+    prompt = create_llm_prompt(state)
     assert "{2}{B}" in prompt
     assert "{1}{W}" in prompt
 
@@ -89,7 +89,7 @@ def test_prompt_includes_colors_when_relevant():
             "B": PlayerState(life=20, creatures=[blk]),
         }
     )
-    prompt = create_llm_prompt(state, [atk], [blk])
+    prompt = create_llm_prompt(state)
     assert "[Green]" in prompt
     assert "[Blue]" in prompt
 


### PR DESCRIPTION
## Summary
- remove redundant attacker and blocker lists from AI helpers
- compute combatants from the game state in `blocking_ai` and `create_llm_prompt`
- adjust scripts and tests for the new signatures

## Testing
- `isort --profile black $(git ls-files '*.py')`
- `black $(git ls-files '*.py')`
- `autoflake --in-place --remove-unused-variables --remove-all-unused-imports $(git ls-files '*.py')`
- `flake8 $(git ls-files '*.py')`
- `pycodestyle --max-line-length=88 --ignore=E203,W503,E226 $(git ls-files '*.py')`
- `pylint $(git ls-files '*.py')`
- `mypy`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862282b5e74832a91861d49e668434c