### PR TITLE
Refactor block assignment evaluation

### DIFF
--- a/magic_combat/block_utils.py
+++ b/magic_combat/block_utils.py
@@ -13,6 +13,7 @@ from .damage import optimal_damage_order
 from .exceptions import IllegalBlockError
 from .gamestate import GameState
 from .limits import IterationCounter
+from .simulator import CombatResult
 from .simulator import CombatSimulator
 
 
@@ -22,11 +23,8 @@ def evaluate_block_assignment(
     counter: IterationCounter,
     provoke_map: Optional[Dict[CombatCreature, CombatCreature]] = None,
     damage_order: Optional[dict[CombatCreature, tuple[CombatCreature, ...]]] = None,
-) -> Tuple[
-    Tuple[int, float, int, int, int, int, Tuple[Optional[int], ...]],
-    Optional[GameState],
-]:
-    """Simulate combat for ``assignment`` and return the score and new state."""
+) -> Tuple[Optional[CombatResult], Optional[GameState]]:
+    """Simulate combat for ``assignment`` and return the result and new state."""
     orig_atks = list(state.players["A"].creatures)
     orig_blks = list(state.players["B"].creatures)
     state_copy = deepcopy(state)
@@ -74,21 +72,6 @@ def evaluate_block_assignment(
         counter.increment()
         result = sim.simulate()
     except IllegalBlockError:
-        ass_key = tuple(
-            len(atks) if choice is None else choice for choice in assignment
-        )
-        return (
-            1,
-            float("inf"),
-            -len(atks) - len(blks),
-            -(10**9),
-            10**9,
-            10**9,
-            ass_key,
-        ), None
+        return None, None
 
-    defender = "B"
-    attacker_player = "A"
-    ass_key = tuple(len(atks) if choice is None else choice for choice in assignment)
-    score = result.score(attacker_player, defender) + (ass_key,)
-    return score, sim.game_state
+    return result, sim.game_state

--- a/magic_combat/blocking_ai.py
+++ b/magic_combat/blocking_ai.py
@@ -333,13 +333,30 @@ def _minimax_blocks(
         order_iter = product(*order_options) if order_options else [tuple()]
         for orders in order_iter:
             damage_order = {atk_keys[i]: orders[i] for i in range(len(orders))}
-            score, _ = evaluate_block_assignment(
+            result, _ = evaluate_block_assignment(
                 assignment,
                 game_state,
                 counter,
                 provoke_map,
                 damage_order,
             )
+            ass_key = tuple(len(attackers) if c is None else c for c in assignment)
+            if result is None:
+                score = (
+                    1,
+                    float("inf"),
+                    -len(attackers) - len(blockers),
+                    -(10**9),
+                    10**9,
+                    10**9,
+                    ass_key,
+                )
+            else:
+                score = result.score(
+                    attackers[0].controller if attackers else "A",
+                    blockers[0].controller if blockers else "B",
+                ) + (ass_key,)
+
             numeric = score[:-1]
             if worst_for_defender is None or numeric > worst_for_defender[:-1]:
                 worst_for_defender = score

--- a/scripts/experiment_with_simple_ai.py
+++ b/scripts/experiment_with_simple_ai.py
@@ -38,11 +38,13 @@ def main():
     )
     assignment = [attackers.index(b.blocking) if b.blocking else None for b in blockers]
     iteration_counter = IterationCounter(max_iterations=1000)
-    score, _ = evaluate_block_assignment(
+    result, _ = evaluate_block_assignment(
         assignment=assignment,
         state=game_state,
         counter=iteration_counter,  # No iteration counter needed for this example
     )
+    assert result is not None
+    score = result.score("A", "B") + (tuple(assignment),)
     for attacker in attackers:
         print("----")
         print("attacker:", summarize_creature(attacker))

--- a/tests/combat/test_block_damage_extra.py
+++ b/tests/combat/test_block_damage_extra.py
@@ -58,7 +58,12 @@ def _compute_best_assignment(atk, blk, state):
     best = None
     best_score = None
     for ass in product(*options):
-        score, _ = evaluate_block_assignment(ass, state, counter)
+        result, _ = evaluate_block_assignment(ass, state, counter)
+        if result is None:
+            continue
+        score = result.score("A", "B") + (
+            tuple(len(atk) if choice is None else choice for choice in ass),
+        )
         if best_score is None or score < best_score:
             best_score = score
             best = ass

--- a/tests/combat/test_random_card_blocks.py
+++ b/tests/combat/test_random_card_blocks.py
@@ -26,7 +26,12 @@ def _compute_best_assignment(atk, blk, state):
     best = None
     best_score = None
     for ass in product(*options):
-        score, _ = evaluate_block_assignment(ass, state, counter)
+        result, _ = evaluate_block_assignment(ass, state, counter)
+        if result is None:
+            continue
+        score = result.score("A", "B") + (
+            tuple(len(atk) if choice is None else choice for choice in ass),
+        )
         if best_score is None or score < best_score:
             best_score = score
             best = ass

--- a/tests/combat/test_result_state_diff.py
+++ b/tests/combat/test_result_state_diff.py
@@ -53,14 +53,16 @@ def test_persist_undying_state_value():
         [state_for_sim.players["B"].creatures[0]],
         game_state=state_for_sim,
     )
-    result = sim.simulate()
+    sim_result = sim.simulate()
     expected = _score_from_states(start, state_for_sim, "A", "B")
-    assert result.score("A", "B") == expected
+    assert sim_result.score("A", "B") == expected
     # Reset blocking on the original objects before evaluation
     atk.blocked_by.clear()
     blk.blocking = None
-    score, end_state = evaluate_block_assignment([0], start, IterationCounter(10))
+    eval_result, end_state = evaluate_block_assignment([0], start, IterationCounter(10))
+    assert eval_result is not None
     assert _score_from_states(start, end_state, "A", "B") == expected
+    score = eval_result.score("A", "B") + ((0,),)
     assert score == expected + ((0,),)
     assert end_state is not None
     p_creature = end_state.players["A"].creatures[0]
@@ -88,9 +90,13 @@ def test_lifelink_infect_state_changes():
         [state_for_sim.players["B"].creatures[0]],
         game_state=state_for_sim,
     )
-    result = sim.simulate()
+    sim_result = sim.simulate()
     expected = _score_from_states(start, state_for_sim, "A", "B")
-    assert result.score("A", "B") == expected
-    score, end_state = evaluate_block_assignment([None], start, IterationCounter(10))
+    assert sim_result.score("A", "B") == expected
+    eval_result, end_state = evaluate_block_assignment(
+        [None], start, IterationCounter(10)
+    )
+    assert eval_result is not None
     assert _score_from_states(start, end_state, "A", "B") == expected
+    score = eval_result.score("A", "B") + ((1,),)
     assert score == expected + ((1,),)

--- a/tests/core/test_block_utils.py
+++ b/tests/core/test_block_utils.py
@@ -14,6 +14,8 @@ def test_evaluate_block_assignment_simple():
             "B": PlayerState(life=20, creatures=[blk]),
         }
     )
-    score, new_state = evaluate_block_assignment([0], state, IterationCounter(10))
+    result, new_state = evaluate_block_assignment([0], state, IterationCounter(10))
+    assert result is not None
+    score = result.score("A", "B") + ((0,),)
     assert score == (0, 0.0, 0, 0, 0, 0, (0,))
     assert new_state is not None


### PR DESCRIPTION
## Summary
- refactor `evaluate_block_assignment` to return `CombatResult`
- compute score after calling `evaluate_block_assignment`
- update AI logic and example script for new return type
- adjust unit tests for the API change

## Testing
- `black magic_combat scripts tests --check`
- `isort --profile black magic_combat scripts tests --check-only`
- `flake8 magic_combat scripts tests`
- `pycodestyle --max-line-length=88 --ignore=E203,W503,E226 --exclude=comprehensive_rules.py,tests,magic_combat/rules_text.py magic_combat scripts`
- `autoflake --check --recursive magic_combat scripts tests`
- `pylint magic_combat scripts tests`
- `mypy magic_combat scripts tests`
- `pyright magic_combat scripts tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686232a48d9c832aaaf164ea15b49b46