### PR TITLE
Refactor evaluate_block_assignment

### DIFF
--- a/magic_combat/block_utils.py
+++ b/magic_combat/block_utils.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Dict
 from typing import Optional
-from typing import Sequence
 from typing import Tuple
 
 from .creature import CombatCreature
@@ -18,7 +17,7 @@ from .simulator import CombatSimulator
 
 
 def evaluate_block_assignment(
-    assignment: Sequence[Optional[int]],
+    assignment: Dict[CombatCreature, CombatCreature],
     state: GameState,
     counter: IterationCounter,
     provoke_map: Optional[Dict[CombatCreature, CombatCreature]] = None,
@@ -32,10 +31,10 @@ def evaluate_block_assignment(
     blks = list(state_copy.players["B"].creatures)
     atk_map = {orig: copy for orig, copy in zip(orig_atks, atks)}
     blk_map = {orig: copy for orig, copy in zip(orig_blks, blks)}
-    for idx, choice in enumerate(assignment):
-        if choice is not None:
-            blk = blks[idx]
-            atk = atks[choice]
+    for blk_orig, atk_orig in assignment.items():
+        if blk_orig in blk_map and atk_orig in atk_map:
+            blk = blk_map[blk_orig]
+            atk = atk_map[atk_orig]
             blk.blocking = atk
             atk.blocked_by.append(blk)
 

--- a/magic_combat/blocking_ai.py
+++ b/magic_combat/blocking_ai.py
@@ -315,13 +315,16 @@ def _minimax_blocks(
         worst_for_defender: tuple[
             int, float, int, int, int, int, tuple[Optional[int], ...]
         ] | None = None
-        # Attacker chooses ordering to maximize the score
-        block_map: dict[CombatCreature, list[CombatCreature]] = {
-            atk: [] for atk in attackers
+        # Convert the tuple assignment into a mapping once
+        block_dict = {
+            blockers[blk_idx]: attackers[choice]
+            for blk_idx, choice in enumerate(assignment)
+            if choice is not None
         }
-        for blk_idx, choice in enumerate(assignment):
-            if choice is not None:
-                block_map[attackers[choice]].append(blockers[blk_idx])
+        # Attacker chooses ordering to maximize the score
+        block_map: dict[CombatCreature, list[CombatCreature]] = {}
+        for blk, atk in block_dict.items():
+            block_map.setdefault(atk, []).append(blk)
 
         order_options = []
         atk_keys = []
@@ -334,7 +337,7 @@ def _minimax_blocks(
         for orders in order_iter:
             damage_order = {atk_keys[i]: orders[i] for i in range(len(orders))}
             result, _ = evaluate_block_assignment(
-                assignment,
+                block_dict,
                 game_state,
                 counter,
                 provoke_map,

--- a/scripts/experiment_with_simple_ai.py
+++ b/scripts/experiment_with_simple_ai.py
@@ -36,15 +36,19 @@ def main():
         game_state=game_state,
         provoke_map={},
     )
-    assignment = [attackers.index(b.blocking) if b.blocking else None for b in blockers]
+    block_map = {blk: blk.blocking for blk in blockers if blk.blocking is not None}
     iteration_counter = IterationCounter(max_iterations=1000)
     result, _ = evaluate_block_assignment(
-        assignment=assignment,
+        assignment=block_map,
         state=game_state,
         counter=iteration_counter,  # No iteration counter needed for this example
     )
     assert result is not None
-    score = result.score("A", "B") + (tuple(assignment),)
+    assignment_tuple = tuple(
+        attackers.index(blk.blocking) if blk.blocking is not None else None
+        for blk in blockers
+    )
+    score = result.score("A", "B") + (assignment_tuple,)
     for attacker in attackers:
         print("----")
         print("attacker:", summarize_creature(attacker))

--- a/tests/combat/test_block_damage_extra.py
+++ b/tests/combat/test_block_damage_extra.py
@@ -58,7 +58,10 @@ def _compute_best_assignment(atk, blk, state):
     best = None
     best_score = None
     for ass in product(*options):
-        result, _ = evaluate_block_assignment(ass, state, counter)
+        block_map = {
+            blk[i]: atk[choice] for i, choice in enumerate(ass) if choice is not None
+        }
+        result, _ = evaluate_block_assignment(block_map, state, counter)
         if result is None:
             continue
         score = result.score("A", "B") + (

--- a/tests/combat/test_random_card_blocks.py
+++ b/tests/combat/test_random_card_blocks.py
@@ -26,7 +26,10 @@ def _compute_best_assignment(atk, blk, state):
     best = None
     best_score = None
     for ass in product(*options):
-        result, _ = evaluate_block_assignment(ass, state, counter)
+        block_map = {
+            blk[i]: atk[choice] for i, choice in enumerate(ass) if choice is not None
+        }
+        result, _ = evaluate_block_assignment(block_map, state, counter)
         if result is None:
             continue
         score = result.score("A", "B") + (

--- a/tests/combat/test_result_state_diff.py
+++ b/tests/combat/test_result_state_diff.py
@@ -59,7 +59,9 @@ def test_persist_undying_state_value():
     # Reset blocking on the original objects before evaluation
     atk.blocked_by.clear()
     blk.blocking = None
-    eval_result, end_state = evaluate_block_assignment([0], start, IterationCounter(10))
+    eval_result, end_state = evaluate_block_assignment(
+        {blk: atk}, start, IterationCounter(10)
+    )
     assert eval_result is not None
     assert _score_from_states(start, end_state, "A", "B") == expected
     score = eval_result.score("A", "B") + ((0,),)
@@ -93,9 +95,7 @@ def test_lifelink_infect_state_changes():
     sim_result = sim.simulate()
     expected = _score_from_states(start, state_for_sim, "A", "B")
     assert sim_result.score("A", "B") == expected
-    eval_result, end_state = evaluate_block_assignment(
-        [None], start, IterationCounter(10)
-    )
+    eval_result, end_state = evaluate_block_assignment({}, start, IterationCounter(10))
     assert eval_result is not None
     assert _score_from_states(start, end_state, "A", "B") == expected
     score = eval_result.score("A", "B") + ((1,),)

--- a/tests/core/test_block_utils.py
+++ b/tests/core/test_block_utils.py
@@ -14,7 +14,9 @@ def test_evaluate_block_assignment_simple():
             "B": PlayerState(life=20, creatures=[blk]),
         }
     )
-    result, new_state = evaluate_block_assignment([0], state, IterationCounter(10))
+    result, new_state = evaluate_block_assignment(
+        {blk: atk}, state, IterationCounter(10)
+    )
     assert result is not None
     score = result.score("A", "B") + ((0,),)
     assert score == (0, 0.0, 0, 0, 0, 0, (0,))


### PR DESCRIPTION
## Summary
- refactor block assignment to use a dictionary instead of a sequence
- update AI code and example script for new API
- adjust unit tests for dictionary-based assignment
- simplify minimax logic to avoid redundant maps

## Testing
- `black magic_combat scripts tests --exclude=magic_combat/rules_text.py`
- `isort --profile black magic_combat scripts tests`
- `autoflake -i -r magic_combat scripts tests --exclude magic_combat/rules_text.py`
- `flake8 magic_combat scripts tests`
- `pycodestyle --max-line-length=88 --ignore=E203,W503,E226 --exclude=comprehensive_rules.py,tests,magic_combat/rules_text.py magic_combat scripts`
- `pylint magic_combat`
- `mypy magic_combat scripts tests`
- `pyright magic_combat scripts tests` *(reported only warnings)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686238a6fc20832a9b93e12f56a58ea9