### PR TITLE
Replace prints with logging in random_scenario

### DIFF
--- a/magic_combat/random_scenario.py
+++ b/magic_combat/random_scenario.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import logging
 import os
 import random
 from typing import Any
@@ -263,14 +264,14 @@ def _determine_block_assignments(
         max_iterations=max_iterations,
     )
     if unique_optimal and opt_count != 1:
-        print("Invalid block scenario: multiple optimal blocks found")
+        logging.warning("Invalid block scenario: multiple optimal blocks found")
         raise InvalidBlockScenarioError("non unique optimal blocks")
 
     opt_map = {id(a): i for i, a in enumerate(attackers)}
     optimal_assignment = tuple(opt_map.get(id(b.blocking), None) for b in blockers)
 
     if simple_assignment is not None and simple_assignment == optimal_assignment:
-        print("Invalid block scenario: simple blocks equal optimal")
+        logging.warning("Invalid block scenario: simple blocks equal optimal")
         raise InvalidBlockScenarioError("simple blocks equal optimal")
 
     return simple_assignment, optimal_assignment


### PR DESCRIPTION
## Summary
- ensure invalid scenario messages use logging.warning
- replace print statements in `_determine_block_assignments`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686354f51d38832a8e906e121b141400