### PR TITLE
Return top-k block assignments

### DIFF
--- a/magic_combat/random_scenario.py
+++ b/magic_combat/random_scenario.py
@@ -261,6 +261,7 @@ def _determine_block_assignments(
         game_state=state,
         provoke_map=provoke_map,
         max_iterations=max_iterations,
+        k=1,
     )
     if unique_optimal and opt_count != 1:
         print("Invalid block scenario: multiple optimal blocks found")

--- a/scripts/experiment_with_simple_ai.py
+++ b/scripts/experiment_with_simple_ai.py
@@ -1,3 +1,5 @@
+import argparse
+
 from magic_combat import CombatCreature
 from magic_combat import GameState
 from magic_combat import PlayerState
@@ -7,7 +9,16 @@ from magic_combat.limits import IterationCounter
 from magic_combat.text_utils import summarize_creature
 
 
-def main():
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run simple blocking example")
+    parser.add_argument(
+        "--top-k",
+        type=int,
+        default=1,
+        help="Number of top blocking assignments to compute",
+    )
+    args = parser.parse_args()
+
     attackers = [
         CombatCreature(
             name="Attacker 1",
@@ -32,10 +43,12 @@ def main():
         }
     )
     print(game_state)
-    decide_optimal_blocks(
+    assignments, _ = decide_optimal_blocks(
         game_state=game_state,
         provoke_map={},
+        k=args.top_k,
     )
+    print("Top assignments:", assignments)
     block_map = {blk: blk.blocking for blk in blockers if blk.blocking is not None}
     iteration_counter = IterationCounter(max_iterations=1000)
     result, _ = evaluate_block_assignment(

--- a/tests/combat/test_block_ai.py
+++ b/tests/combat/test_block_ai.py
@@ -439,8 +439,9 @@ def test_ai_optimal_count_ignores_tiebreaker():
             "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[b1, b2]),
         }
     )
-    _, opt = decide_optimal_blocks(game_state=state)
+    assns, opt = decide_optimal_blocks(game_state=state, k=2)
     assert opt == 2
+    assert len(assns) >= 2
 
 
 def test_ai_ignores_tapped_blocker():


### PR DESCRIPTION
## Summary
- return a list of best blocking assignments from `decide_optimal_blocks`
- expose `--top-k` option in `experiment_with_simple_ai.py`
- update random scenario generator and unit tests
- use `heapq` to extract top-k results

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686343bf8e34832aaf94e389164949b2