### PR TITLE
Add tests for persist & undying value with blocking AI

### DIFF
--- a/tests/abilities/test_undying_persist.py
+++ b/tests/abilities/test_undying_persist.py
@@ -59,3 +59,27 @@ def test_undying_returns_once(unused):
     result = sim.simulate()
     assert blk not in result.creatures_destroyed
     assert blk.plus1_counters == 1
+
+
+def test_persist_value_reduced_after_return():
+    """CR 702.77a: Persist returns with a -1/-1 counter reducing value."""
+    atk = CombatCreature("Bear", 3, 3, "A")
+    blk = CombatCreature("Ghost", 2, 2, "B", persist=True)
+    pre = blk.value()
+    link_block(atk, blk)
+    sim = CombatSimulator([atk], [blk])
+    sim.simulate()
+    assert blk.minus1_counters == 1
+    assert blk.value() < pre
+
+
+def test_undying_value_reduced_after_return():
+    """CR 702.92a: Undying returns with a +1/+1 counter reducing value."""
+    atk = CombatCreature("Bear", 3, 3, "A")
+    blk = CombatCreature("Phoenix", 2, 2, "B", undying=True)
+    pre = blk.value()
+    link_block(atk, blk)
+    sim = CombatSimulator([atk], [blk])
+    sim.simulate()
+    assert blk.plus1_counters == 1
+    assert blk.value() < pre

--- a/tests/combat/test_block_ai.py
+++ b/tests/combat/test_block_ai.py
@@ -456,3 +456,31 @@ def test_ai_ignores_tapped_blocker():
     )
     decide_optimal_blocks(game_state=state)
     assert blk.blocking is None
+
+
+def test_ai_blocks_persist_when_free():
+    """CR 702.77a & 509.1a: Optimal blocking kills a persist attacker if able."""
+    atk = CombatCreature("Spirit", 2, 2, "A", persist=True)
+    blk = CombatCreature("Giant", 3, 3, "B")
+    state = GameState(
+        players={
+            "A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]),
+            "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[blk]),
+        }
+    )
+    decide_optimal_blocks(game_state=state)
+    assert blk.blocking is atk
+
+
+def test_ai_blocks_undying_when_free():
+    """CR 702.92a & 509.1a: Optimal blocking kills an undying attacker if able."""
+    atk = CombatCreature("Phoenix", 2, 2, "A", undying=True)
+    blk = CombatCreature("Giant", 3, 3, "B")
+    state = GameState(
+        players={
+            "A": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[atk]),
+            "B": PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[blk]),
+        }
+    )
+    decide_optimal_blocks(game_state=state)
+    assert blk.blocking is atk


### PR DESCRIPTION
## Summary
- check that persist and undying creatures return with reduced value
- ensure optimal blocking AI kills those attackers when possible

## Testing
- `black . --check`
- `isort --profile black . --check-only`
- `flake8`
- `pycodestyle --max-line-length=88 --ignore=E203,W503,E226 --exclude=comprehensive_rules.py,tests,magic_combat/rules_text.py magic_combat scripts`
- `autoflake --check --recursive magic_combat scripts tests`
- `pylint magic_combat scripts tests`
- `mypy magic_combat scripts tests`
- `pyright magic_combat scripts tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68634327fe28832a842c23e4b7dcd78a