### PR TITLE
Add k parameter tests for decide_optimal_blocks

### DIFF
--- a/magic_combat/blocking_ai.py
+++ b/magic_combat/blocking_ai.py
@@ -20,6 +20,7 @@ from .gamestate import GameState
 from .limits import IterationCounter
 from .simulator import CombatResult
 from .simulator import CombatSimulator
+from .utils import check_non_negative
 
 ScoreVector: TypeAlias = tuple[int, float, int, int, int, int, tuple[int, ...]]
 
@@ -357,6 +358,8 @@ def decide_optimal_blocks(
     k: int = 1,
 ) -> Tuple[list[tuple[ScoreVector, tuple[Optional[int], ...]]], int,]:
     """Assign blockers to attackers using a minimax search over block assignments."""
+
+    check_non_negative(k, "k")
 
     attackers = list(game_state.players["A"].creatures)
     blockers = list(game_state.players["B"].creatures)

--- a/tests/combat/test_k_parameter.py
+++ b/tests/combat/test_k_parameter.py
@@ -1,0 +1,119 @@
+import pytest
+
+from magic_combat import CombatCreature
+from magic_combat import GameState
+from magic_combat import PlayerState
+from magic_combat import decide_optimal_blocks
+
+# Scenario helpers
+
+
+def _simple_state() -> GameState:
+    a1 = CombatCreature("A1", 2, 2, "A")
+    a2 = CombatCreature("A2", 3, 3, "A")
+    b1 = CombatCreature("B1", 2, 2, "B")
+    return GameState(
+        players={
+            "A": PlayerState(life=20, creatures=[a1, a2]),
+            "B": PlayerState(life=20, creatures=[b1]),
+        }
+    )
+
+
+def _tie_state() -> GameState:
+    a1 = CombatCreature("A1", 2, 2, "A")
+    a2 = CombatCreature("A2", 2, 2, "A")
+    b1 = CombatCreature("B1", 2, 2, "B")
+    b2 = CombatCreature("B2", 2, 2, "B")
+    return GameState(
+        players={
+            "A": PlayerState(life=20, creatures=[a1, a2]),
+            "B": PlayerState(life=20, creatures=[b1, b2]),
+        }
+    )
+
+
+def test_negative_k_raises_error():
+    """CR 509.1a: The defending player chooses how creatures block."""
+    state = _simple_state()
+    with pytest.raises(ValueError):
+        decide_optimal_blocks(game_state=state, k=-1)
+
+
+def test_result_length_not_exceed_k():
+    """CR 509.1a: The defending player chooses how creatures block."""
+    state = _simple_state()
+    assns, _ = decide_optimal_blocks(game_state=state, k=2)
+    assert len(assns) <= 2
+
+
+def test_assignments_sorted_by_score():
+    """CR 509.1a: The defending player chooses how creatures block."""
+    state = _simple_state()
+    assns, _ = decide_optimal_blocks(game_state=state, k=3)
+    scores = [score for score, _ in assns]
+    assert scores == sorted(scores)
+
+
+def test_large_k_returns_all_assignments():
+    """CR 509.1a: The defending player chooses how creatures block."""
+    state = _simple_state()
+    assns, _ = decide_optimal_blocks(game_state=state, k=10)
+    assert len(assns) == 3
+
+
+def test_best_assignment_applied_with_large_k():
+    """CR 509.1a: The defending player chooses how creatures block."""
+    state = _simple_state()
+    assns, _ = decide_optimal_blocks(game_state=state, k=3)
+    ((_, best),) = assns[:1]
+    attackers = list(state.players["A"].creatures)
+    blockers = list(state.players["B"].creatures)
+    if best[0] is None:
+        assert blockers[0].blocking is None
+    else:
+        assert blockers[0].blocking is attackers[best[0]]
+
+
+def test_same_best_assignment_for_k1_and_k3():
+    """CR 509.1a: The defending player chooses how creatures block."""
+    state1 = _simple_state()
+    assn1, _ = decide_optimal_blocks(game_state=state1, k=1)
+    best1 = assn1[0][1]
+
+    state2 = _simple_state()
+    assn3, _ = decide_optimal_blocks(game_state=state2, k=3)
+    best3 = assn3[0][1]
+
+    assert best1 == best3
+
+
+def test_optimal_count_independent_of_k():
+    """CR 509.1a: The defending player chooses how creatures block."""
+    state = _tie_state()
+    _, count1 = decide_optimal_blocks(game_state=state, k=1)
+    _, count2 = decide_optimal_blocks(game_state=_tie_state(), k=2)
+    assert count1 == 2
+    assert count1 == count2
+
+
+def test_tie_results_sorted():
+    """CR 509.1a: The defending player chooses how creatures block."""
+    state = _tie_state()
+    assns, _ = decide_optimal_blocks(game_state=state, k=2)
+    scores = [score for score, _ in assns]
+    assert scores == sorted(scores)
+
+
+def test_large_k_tie_no_error():
+    """CR 509.1a: The defending player chooses how creatures block."""
+    state = _tie_state()
+    assns, _ = decide_optimal_blocks(game_state=state, k=20)
+    assert len(assns) == 9
+
+
+def test_zero_k_returns_empty():
+    """CR 509.1a: The defending player chooses how creatures block."""
+    state = _simple_state()
+    assns, _ = decide_optimal_blocks(game_state=state, k=0)
+    assert assns == []


### PR DESCRIPTION
## Summary
- add non-negative check for `decide_optimal_blocks` parameter `k`
- add extensive tests validating `k` behaviour, including negative and large values

## Testing
- `flake8 magic_combat tests scripts`
- `pycodestyle --max-line-length=88 --ignore=E203,W503,E226 --exclude=comprehensive_rules.py,tests,magic_combat/rules_text.py magic_combat scripts`
- `autoflake --check --recursive magic_combat scripts tests`
- `pylint magic_combat scripts tests`
- `mypy magic_combat scripts tests`
- `pyright magic_combat scripts tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686381717488832abd8705eb25bf99ab