### PR TITLE
Refactor utilities and improve docs

### DIFF
--- a/magic_combat/blocking_ai.py
+++ b/magic_combat/blocking_ai.py
@@ -158,12 +158,12 @@ def _best_survival_assignment(
     base_list = list(base_assignment)
 
     for combo in product(*options):
-        ass = base_list[:]
+        candidate_assignment = base_list[:]
         for idx, choice in zip(remain_indices, combo):
-            ass[idx] = choice
+            candidate_assignment[idx] = choice
 
         counts: dict[int, int] = {}
-        for choice in ass:
+        for choice in candidate_assignment:
             if choice is not None:
                 counts[choice] = counts.get(choice, 0) + 1
         valid = True
@@ -181,7 +181,7 @@ def _best_survival_assignment(
 
         try:
             result, _dead_atk, _dead_blk, score = _simulate_assignment(
-                ass,
+                candidate_assignment,
                 game_state,
                 provoke_map,
                 counter,
@@ -200,7 +200,7 @@ def _best_survival_assignment(
 
         if (def_val, def_cnt) < best_score:
             best_score = (def_val, def_cnt)
-            best_assignment = tuple(ass)
+            best_assignment = tuple(candidate_assignment)
             best_numeric = score
 
     return best_assignment, best_numeric

--- a/magic_combat/random_creature.py
+++ b/magic_combat/random_creature.py
@@ -20,15 +20,15 @@ from .creature import CombatCreature
 from .scryfall_loader import cards_to_creatures
 
 # Probability thresholds for assigning +1/+1 or -1/-1 counters
-PLUS1_PROB = 0.1
-MINUS1_PROB = 0.2
+PLUS_ONE_PROB = 0.1
+MINUS_ONE_PROB = 0.2
 
 # Default probability used when randomly tapping creatures
 DEFAULT_TAP_PROB = 0.3
 
 __all__ = [
-    "PLUS1_PROB",
-    "MINUS1_PROB",
+    "PLUS_ONE_PROB",
+    "MINUS_ONE_PROB",
     "DEFAULT_TAP_PROB",
     "compute_card_statistics",
     "generate_random_creature",
@@ -151,9 +151,9 @@ def assign_random_counters(
     rng = rng if rng is not None else random.Random()
     for cr in creatures:
         roll = rng.random()
-        if roll < PLUS1_PROB:
+        if roll < PLUS_ONE_PROB:
             cr.plus1_counters = rng.randint(1, 2)
-        elif roll < MINUS1_PROB:
+        elif roll < MINUS_ONE_PROB:
             max_minus = min(2, cr.toughness)
             if max_minus > 0:
                 cr.minus1_counters = rng.randint(1, max_minus)
@@ -163,9 +163,18 @@ def assign_random_tapped(
     creatures: Iterable[CombatCreature],
     *,
     rng: random.Random | None = None,
-    prob: float = DEFAULT_TAP_PROB,
+    tap_probability: float = DEFAULT_TAP_PROB,
 ) -> None:
     """Randomly tap creatures without vigilance.
+
+    Parameters
+    ----------
+    creatures:
+        The creatures that may become tapped.
+    rng:
+        Optional random number generator for reproducible tests.
+    tap_probability:
+        Chance for a non-vigilant creature to start tapped.
 
     CR 302.2 states that tapped creatures can't attack or block. Vigilance
     (CR 702.21b) keeps a creature from tapping when it attacks, so vigilant
@@ -176,5 +185,5 @@ def assign_random_tapped(
     for cr in creatures:
         if cr.vigilance:
             cr.tapped = False
-        elif rng.random() < prob:
+        elif rng.random() < tap_probability:
             cr.tapped = True

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,12 @@
+# Scripts
+
+This directory contains helper scripts for interacting with the combat simulator.
+
+* `download_cards.py` — Download sample card data from Scryfall.
+* `generate_blocking_snapshots.py` — Create snapshot data for unit tests.
+* `evaluate_random_combat_scenarios.py` — Use an LLM to assess blocking decisions.
+* `experiment_with_simple_ai.py` — Run a simple heuristic blocking AI.
+* `random_combat.py` — Quickly generate and simulate random combats.
+
+Most scripts can be run directly with `python <script> --help` to see available
+options.

--- a/tests/random/test_random_tapped.py
+++ b/tests/random/test_random_tapped.py
@@ -12,7 +12,7 @@ def test_assign_random_tapped_respects_vigilance():
         CombatCreature("B", 2, 2, "B", vigilance=True),
         CombatCreature("C", 2, 2, "B"),
     ]
-    assign_random_tapped(creatures, rng=rng, prob=1.0)
+    assign_random_tapped(creatures, rng=rng, tap_probability=1.0)
     assert creatures[0].tapped
     assert not creatures[1].tapped
     assert creatures[2].tapped


### PR DESCRIPTION
## Summary
- rename `PLUS1_PROB`/`MINUS1_PROB` to clearer `PLUS_ONE_PROB`/`MINUS_ONE_PROB`
- rename `prob` parameter in `assign_random_tapped` to `tap_probability`
- clarify tapping helper docstring
- rename confusing local `ass` variable to `candidate_assignment`
- document helper scripts
- update affected test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686389ca2ec4832a87863c80fc8d1fe9