### PR TITLE
Fix shadow blocking rule

### DIFF
--- a/magic_combat/utils.py
+++ b/magic_combat/utils.py
@@ -161,6 +161,8 @@ def can_block(attacker: "CombatCreature", blocker: "CombatCreature") -> bool:
         return False
     if attacker.shadow and not blocker.shadow:
         return False
+    if blocker.shadow and not attacker.shadow:
+        return False
     if attacker.horsemanship and not blocker.horsemanship:
         return False
     if attacker.skulk and blocker.effective_power() > attacker.effective_power():

--- a/tests/abilities/test_shadow.py
+++ b/tests/abilities/test_shadow.py
@@ -5,14 +5,14 @@ from magic_combat import CombatSimulator
 from tests.conftest import link_block
 
 
-def test_shadow_blocker_can_block_nonshadow_attacker():
-    """CR 702.27b: A creature with shadow can block or be blocked only by creatures with shadow."""
+def test_shadow_blocker_cant_block_nonshadow_attacker():
+    """CR 702.27b: A shadow creature can't block a non-shadow creature."""
     attacker = CombatCreature("Goblin", 2, 2, "A")
     blocker = CombatCreature("Shade", 2, 2, "B", shadow=True)
     link_block(attacker, blocker)
     sim = CombatSimulator([attacker], [blocker])
-    # Simulator currently allows this block
-    sim.validate_blocking()
+    with pytest.raises(ValueError):
+        sim.validate_blocking()
 
 
 def test_shadow_attacker_blocked_by_nonshadow_illegal():


### PR DESCRIPTION
## Summary
- enforce symmetrical shadow restriction in `can_block`
- update shadow ability tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68647d6f4ef8832aa3a0db5707aaf413