### PR TITLE
Add GameState block assignment helper

### DIFF
--- a/magic_combat/blocking_ai.py
+++ b/magic_combat/blocking_ai.py
@@ -216,12 +216,7 @@ def decide_optimal_blocks(
         return [], optimal_count
 
     _, best_assignment = top[0]
-    for blk_idx, choice in enumerate(best_assignment):
-        if choice is not None:
-            blk = blockers[blk_idx]
-            atk = attackers[choice]
-            blk.blocking = atk
-            atk.blocked_by.append(blk)
+    game_state.apply_block_assignment(best_assignment, attackers, blockers)
 
     return top, optimal_count
 
@@ -252,7 +247,9 @@ def decide_simple_blocks(
 
     minimal_assignments = [a for a in all_assignments if _valid_minimal(a, attackers)]
     print(
-        f"Found {len(minimal_assignments)} minimal assignments out of {len(all_assignments)} total assignments."
+        "Found "
+        f"{len(minimal_assignments)} minimal assignments out of "
+        f"{len(all_assignments)} total assignments."
     )
     for assignment in minimal_assignments:
         print("Assignment:", assignment)
@@ -290,14 +287,6 @@ def decide_simple_blocks(
     print(final_assignment)
 
     reset_block_assignments(game_state)
-    for blk_idx, choice in enumerate(final_assignment):
-        print(f"Blocker {blk_idx} assigned to attacker {choice}")
-        if choice is not None:
-            blk = blockers[blk_idx]
-            atk = attackers[choice]
-            blk.blocking = atk
-            atk.blocked_by.append(blk)
-            print(
-                f"{blk.name} ({blk.power}/{blk.toughness}) blocks "
-                f"{atk.name} ({atk.power}/{atk.toughness})"
-            )
+    game_state.apply_block_assignment(
+        final_assignment, attackers, blockers, verbose=True
+    )

--- a/magic_combat/gamestate.py
+++ b/magic_combat/gamestate.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from dataclasses import field
+from typing import Optional
+from typing import Sequence
 
 from magic_combat.constants import POISON_LOSS_THRESHOLD
 
@@ -50,6 +52,38 @@ class GameState:
             for line in str(state).splitlines():
                 lines.append(f"  {line}")
         return "\n".join(lines)
+
+    def apply_block_assignment(
+        self,
+        assignment: Sequence[Optional[int]],
+        attackers: Sequence[CombatCreature],
+        blockers: Sequence[CombatCreature],
+        *,
+        verbose: bool = False,
+    ) -> None:
+        """Apply a blocking assignment to the game state.
+
+        Args:
+            assignment: Sequence mapping each blocker index to an attacker index
+                or ``None`` if the blocker is not assigned.
+            attackers: Ordered list of attacking creatures.
+            blockers: Ordered list of blocking creatures.
+            verbose: If ``True``, print the chosen assignments.
+        """
+
+        for blk_idx, choice in enumerate(assignment):
+            if verbose:
+                print(f"Blocker {blk_idx} assigned to attacker {choice}")
+            if choice is not None:
+                blk = blockers[blk_idx]
+                atk = attackers[choice]
+                blk.blocking = atk
+                atk.blocked_by.append(blk)
+                if verbose:
+                    print(
+                        f"{blk.name} ({blk.power}/{blk.toughness}) blocks "
+                        f"{atk.name} ({atk.power}/{atk.toughness})"
+                    )
 
 
 def has_player_lost(state: GameState, player: str) -> bool:

--- a/scripts/experiment_with_simple_ai.py
+++ b/scripts/experiment_with_simple_ai.py
@@ -58,10 +58,11 @@ def main() -> None:
     )
     for blk in blockers:
         if blk.blocking:
-            print(
-                f"{blk.name} ({blk.power}/{blk.toughness}) "
-                f"blocks {blk.blocking.name} ({blk.blocking.power}/{blk.blocking.toughness})"
+            msg = (
+                f"{blk.name} ({blk.power}/{blk.toughness}) blocks "
+                f"{blk.blocking.name} ({blk.blocking.power}/{blk.blocking.toughness})"
             )
+            print(msg)
         else:
             print(f"{blk.name} does not block")
     result = CombatSimulator(attackers, blockers, game_state=state).simulate()
@@ -128,10 +129,11 @@ def generate_scenario():
     )
     for blk in blockers:
         if blk.blocking:
-            print(
-                f"{blk.name} ({blk.power}/{blk.toughness}) "
-                f"blocks {blk.blocking.name} ({blk.blocking.power}/{blk.blocking.toughness})"
+            msg = (
+                f"{blk.name} ({blk.power}/{blk.toughness}) blocks "
+                f"{blk.blocking.name} ({blk.blocking.power}/{blk.blocking.toughness})"
             )
+            print(msg)
         else:
             print(f"{blk.name} does not block")
 


### PR DESCRIPTION
## Summary
- create `GameState.apply_block_assignment` helper
- use the helper in `decide_optimal_blocks` and `decide_simple_blocks`
- break long lines in simple AI script for style compliance

## Testing
- `isort --profile black .`
- `autoflake --in-place --remove-unused-variables --remove-all-unused-imports -r magic_combat scripts`
- `black .`
- `flake8`
- `pycodestyle --max-line-length=88 --ignore=E203,W503,E226 --exclude=comprehensive_rules.py,tests,magic_combat/rules_text.py magic_combat scripts`
- `autoflake --check --recursive magic_combat scripts`
- `pylint magic_combat scripts`
- `mypy magic_combat scripts` *(fails: Argument type errors)*
- `pyright magic_combat scripts tests` *(fails: Unknown attribute errors)*
- `pytest -q` *(fails: mypy and pyright issues)*

------
https://chatgpt.com/codex/tasks/task_e_6864c0030078832a961c5807d8580a33