### PR TITLE
Fix mentor map propagation in blocking logic

### DIFF
--- a/magic_combat/block_utils.py
+++ b/magic_combat/block_utils.py
@@ -22,9 +22,14 @@ def evaluate_block_assignment(
     state: GameState,
     counter: IterationCounter,
     provoke_map: Optional[Dict[CombatCreature, CombatCreature]] = None,
+    mentor_map: Optional[Dict[CombatCreature, CombatCreature]] = None,
     damage_order: Optional[dict[CombatCreature, tuple[CombatCreature, ...]]] = None,
 ) -> Tuple[Optional[CombatResult], Optional[GameState]]:
-    """Simulate combat for ``assignment`` and return the result and new state."""
+    """Simulate combat for ``assignment`` and return the result and new state.
+
+    ``provoke_map`` and ``mentor_map`` are used to validate special attacker
+    interactions during simulation.
+    """
     orig_atks = list(state.players["A"].creatures)
     orig_blks = list(state.players["B"].creatures)
     state_copy = deepcopy(state)
@@ -44,6 +49,12 @@ def evaluate_block_assignment(
         for atk, blk in provoke_map.items():
             if atk in atk_map and blk in blk_map:
                 prov_copies[atk_map[atk]] = blk_map[blk]
+
+    mentor_copies: Dict[CombatCreature, CombatCreature] = {}
+    if mentor_map:
+        for mentor, target in mentor_map.items():
+            if mentor in atk_map and target in atk_map:
+                mentor_copies[atk_map[mentor]] = atk_map[target]
 
     order_map: dict[CombatCreature, tuple[CombatCreature, ...]] | None = None
     if damage_order:
@@ -67,6 +78,7 @@ def evaluate_block_assignment(
         game_state=state_copy,
         damage_order_map=order_map,
         provoke_map=prov_copies or None,
+        mentor_map=mentor_copies or None,
     )
     try:
         counter.increment()

--- a/magic_combat/blocking_ai.py
+++ b/magic_combat/blocking_ai.py
@@ -138,11 +138,16 @@ def _minimax_assignments(
     game_state: GameState,
     counter: IterationCounter,
     provoke_map: Optional[dict[CombatCreature, CombatCreature]],
+    mentor_map: Optional[dict[CombatCreature, CombatCreature]],
     *,
     include_loss: bool,
     k: int,
 ) -> Tuple[list[tuple[ScoreVector, tuple[Optional[int], ...]]], int]:
-    """Evaluate a collection of predetermined blocking assignments."""
+    """Evaluate a collection of predetermined blocking assignments.
+
+    ``provoke_map`` and ``mentor_map`` ensure special interactions are
+    enforced when simulating each assignment.
+    """
 
     attackers = list(game_state.players["A"].creatures)
     blockers = list(game_state.players["B"].creatures)
@@ -162,8 +167,9 @@ def _minimax_assignments(
                 block_dict,
                 game_state,
                 counter,
-                provoke_map,
-                damage_order,
+                provoke_map=provoke_map,
+                mentor_map=mentor_map,
+                damage_order=damage_order,
             )
             if result is not None:
                 score = result.score("A", "B", include_loss=include_loss) + (key,)
@@ -189,10 +195,15 @@ def decide_optimal_blocks(
     game_state: GameState,
     *,
     provoke_map: Optional[dict[CombatCreature, CombatCreature]] = None,
+    mentor_map: Optional[dict[CombatCreature, CombatCreature]] = None,
     max_iterations: int = int(1e4),
     k: int = 1,
 ) -> Tuple[list[tuple[ScoreVector, tuple[Optional[int], ...]]], int,]:
-    """Assign blockers to attackers using a minimax search over block assignments."""
+    """Assign blockers to attackers using a minimax search.
+
+    ``provoke_map`` and ``mentor_map`` describe forced blocks and mentor
+    targets that must be respected when evaluating assignments.
+    """
 
     check_non_negative(k, "k")
 
@@ -214,6 +225,7 @@ def decide_optimal_blocks(
         game_state,
         counter,
         provoke_map,
+        mentor_map,
         include_loss=True,
         k=k,
     )
@@ -237,9 +249,14 @@ def decide_optimal_blocks(
 def decide_simple_blocks(
     game_state: GameState,
     provoke_map: Optional[dict[CombatCreature, CombatCreature]] = None,
+    mentor_map: Optional[dict[CombatCreature, CombatCreature]] = None,
     max_iterations: int = int(1e4),
 ) -> tuple[ScoreVector, tuple[Optional[int], ...]]:
-    """Assign blocks using a small two-stage minimax search."""
+    """Assign blocks using a small two-stage minimax search.
+
+    ``provoke_map`` and ``mentor_map`` function the same as in
+    :func:`decide_optimal_blocks`.
+    """
 
     attackers = list(game_state.players["A"].creatures)
     blockers = list(game_state.players["B"].creatures)
@@ -261,6 +278,7 @@ def decide_simple_blocks(
         game_state,
         counter,
         provoke_map,
+        mentor_map,
         include_loss=False,
         k=5,
     )
@@ -276,6 +294,7 @@ def decide_simple_blocks(
         game_state,
         counter,
         provoke_map,
+        mentor_map,
         include_loss=True,
         k=1,
     )

--- a/magic_combat/random_scenario.py
+++ b/magic_combat/random_scenario.py
@@ -34,7 +34,6 @@ from .scryfall_loader import cards_to_creatures
 from .scryfall_loader import fetch_french_vanilla_cards
 from .scryfall_loader import load_cards
 from .scryfall_loader import save_cards
-from .simulator import CombatSimulator
 
 __all__ = [
     "ensure_cards",
@@ -266,6 +265,7 @@ def _attempt_random_scenario(
     top, opt_count = decide_optimal_blocks(
         game_state=optimal_state,
         provoke_map=provoke_map,
+        mentor_map=mentor_map,
         max_iterations=max_iterations,
         k=1,
     )
@@ -273,14 +273,15 @@ def _attempt_random_scenario(
         logging.warning("Invalid block scenario: multiple optimal blocks found")
         raise InvalidBlockScenarioError("non unique optimal blocks")
 
-    optimal_score, optimal_assignment = top[0]
-    simple_score, simple_assignment = decide_simple_blocks(
+    _, optimal_assignment = top[0]
+    _, simple_assignment = decide_simple_blocks(
         game_state=simple_state,
         provoke_map=provoke_map,
+        mentor_map=mentor_map,
         max_iterations=max_iterations,
     )
 
-    if simple_assignment is not None and simple_assignment == optimal_assignment:
+    if simple_assignment == optimal_assignment:
         logging.warning("Invalid block scenario: simple blocks equal optimal")
         raise InvalidBlockScenarioError("simple blocks equal optimal")
     print(simple_assignment, optimal_assignment, original_state)

--- a/scripts/generate_blocking_snapshots.py
+++ b/scripts/generate_blocking_snapshots.py
@@ -58,7 +58,6 @@ def main() -> None:
             mentor_map,
             opt_map,
             simple_map,
-            combat_value,
         ) = generate_random_scenario(cards, values, seed=seed)
         attackers = list(state.players["A"].creatures)
         blockers = list(state.players["B"].creatures)
@@ -73,7 +72,6 @@ def main() -> None:
             "mentor_map": encode_map(mentor_map, attackers, attackers),
             "optimal_assignment": list(opt_map),
             "simple_assignment": list(simple_map) if simple_map is not None else None,
-            "combat_value": list(combat_value),
         }
         snapshots.append(snapshot)
         print(snapshot)

--- a/tests/combat/test_snapshot_blocks.py
+++ b/tests/combat/test_snapshot_blocks.py
@@ -39,6 +39,7 @@ def test_optimal_blocks_snapshots() -> None:
         decide_optimal_blocks(
             game_state=state,
             provoke_map=provoke_map,
+            mentor_map=mentor_map,
         )
         chosen: List[Optional[int]] = [
             attackers.index(b.blocking) if b.blocking is not None else None


### PR DESCRIPTION
## Summary
- pass `mentor_map` through evaluation helpers
- expose `mentor_map` in `decide_optimal_blocks` and `decide_simple_blocks`
- include mentor targets when generating scenarios
- update snapshot tests accordingly

## Testing
- `flake8`
- `mypy > /tmp/mypy.log`
- `pyright > /tmp/pyright.log`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864d5bfb680832aaed31c0221e21286