### PR TITLE
Refactor snapshot decode utilities

### DIFF
--- a/magic_combat/__init__.py
+++ b/magic_combat/__init__.py
@@ -44,6 +44,7 @@ from .simulator import CombatResult
 from .simulator import CombatSimulator
 from .snapshot import creature_from_dict
 from .snapshot import creature_to_dict
+from .snapshot import decode_mapping
 from .snapshot import decode_mentor
 from .snapshot import decode_provoke
 from .snapshot import encode_map
@@ -104,6 +105,7 @@ __all__ = [
     "state_to_dict",
     "state_from_dict",
     "encode_map",
+    "decode_mapping",
     "decode_provoke",
     "decode_mentor",
 ]

--- a/magic_combat/snapshot.py
+++ b/magic_combat/snapshot.py
@@ -70,13 +70,22 @@ def encode_map(
     return {str(atk.index(a)): blk.index(b) for a, b in mapping.items()}
 
 
+def decode_mapping(
+    data: Dict[str, int],
+    src: List[CombatCreature],
+    dst: List[CombatCreature],
+) -> Dict[CombatCreature, CombatCreature]:
+    """Decode an index mapping into a creature mapping."""
+    return {src[int(k)]: dst[v] for k, v in data.items()}
+
+
 def decode_provoke(
     data: Dict[str, int],
     atk: List[CombatCreature],
     blk: List[CombatCreature],
 ) -> Dict[CombatCreature, CombatCreature]:
     """Decode an encoded provoke mapping."""
-    return {atk[int(k)]: blk[v] for k, v in data.items()}
+    return decode_mapping(data, atk, blk)
 
 
 def decode_mentor(
@@ -84,4 +93,4 @@ def decode_mentor(
     atk: List[CombatCreature],
 ) -> Dict[CombatCreature, CombatCreature]:
     """Decode an encoded mentor mapping."""
-    return {atk[int(k)]: atk[v] for k, v in data.items()}
+    return decode_mapping(data, atk, atk)

--- a/scripts/generate_blocking_snapshots.py
+++ b/scripts/generate_blocking_snapshots.py
@@ -10,12 +10,12 @@ from typing import List
 import numpy as np
 
 from magic_combat import build_value_map
-from magic_combat import creature_to_dict
-from magic_combat import encode_map
 from magic_combat import generate_random_scenario
 from magic_combat import load_cards
-from magic_combat import state_to_dict
 from magic_combat.constants import SNAPSHOT_VERSION
+from magic_combat.snapshot import creature_to_dict
+from magic_combat.snapshot import encode_map
+from magic_combat.snapshot import state_to_dict
 
 
 def _dump_snapshot(data: List[dict[str, object]], path: Path) -> None:

--- a/tests/combat/test_snapshot_blocks.py
+++ b/tests/combat/test_snapshot_blocks.py
@@ -3,12 +3,12 @@ from pathlib import Path
 from typing import List
 from typing import Optional
 
-from magic_combat import creature_from_dict
-from magic_combat import decode_mentor
-from magic_combat import decode_provoke
-from magic_combat import state_from_dict
 from magic_combat.blocking_ai import decide_optimal_blocks
 from magic_combat.constants import SNAPSHOT_VERSION
+from magic_combat.snapshot import creature_from_dict
+from magic_combat.snapshot import decode_mentor
+from magic_combat.snapshot import decode_provoke
+from magic_combat.snapshot import state_from_dict
 
 DATA_PATH = Path(__file__).resolve().parents[1] / "data"
 SNAP_PATH = DATA_PATH / "blocking_snapshots.json"


### PR DESCRIPTION
## Summary
- add `decode_mapping` helper in `snapshot.py`
- refactor `decode_provoke` and `decode_mentor` to use the new function
- export `decode_mapping` from the package
- update imports in tests and snapshot generation script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68656093e5e0832aaeeede1780499dff