### PR TITLE
Implement write_json utility

### DIFF
--- a/magic_combat/scryfall_loader.py
+++ b/magic_combat/scryfall_loader.py
@@ -16,6 +16,7 @@ from .creature import CombatCreature
 from .keywords import ALLOWED_KEYWORDS
 from .parsing import apply_keyword_attributes
 from .parsing import parse_colors as _parse_colors
+from .utils import write_json
 
 SCRYFALL_API = "https://api.scryfall.com/cards/search"
 QUERY = "is:frenchvanilla t:creature"
@@ -67,8 +68,7 @@ def fetch_french_vanilla_cards(timeout: float = 10.0) -> List[Dict[str, Any]]:
 
 def save_cards(cards: List[Dict[str, Any]], path: str) -> None:
     """Save ``cards`` to ``path`` as JSON."""
-    with open(path, "w", encoding="utf8") as fh:
-        json.dump(cards, fh, indent=2, ensure_ascii=False)
+    write_json(cards, path)
 
 
 def load_cards(path: str) -> List[Dict[str, Any]]:

--- a/magic_combat/utils.py
+++ b/magic_combat/utils.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 import re
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -208,3 +210,12 @@ def apply_blocker_bushido(blocker: "CombatCreature") -> None:
     if blocker.blocking is not None and blocker.bushido:
         blocker.temp_power += blocker.bushido
         blocker.temp_toughness += blocker.bushido
+
+
+def write_json(obj: object, path: str | Path) -> None:
+    """Write ``obj`` to ``path`` in JSON format."""
+
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("w", encoding="utf-8") as fh:
+        json.dump(obj, fh, indent=2, ensure_ascii=False)

--- a/scripts/generate_blocking_snapshots.py
+++ b/scripts/generate_blocking_snapshots.py
@@ -2,7 +2,6 @@
 """Generate snapshot scenarios for optimal blocking tests."""
 
 import argparse
-import json
 import random
 from pathlib import Path
 from typing import List
@@ -16,13 +15,12 @@ from magic_combat import generate_random_scenario
 from magic_combat import load_cards
 from magic_combat import state_to_dict
 from magic_combat.constants import SNAPSHOT_VERSION
+from magic_combat.utils import write_json
 
 
 def _dump_snapshot(data: List[dict[str, object]], path: Path) -> None:
     """Write snapshot data to ``path`` in JSON format."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", encoding="utf-8") as fh:
-        json.dump(data, fh, indent=2)
+    write_json(data, path)
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- add `utils.write_json` for saving JSON with indentation and UTF‑8
- use `write_json` in `save_cards`
- use `write_json` when dumping snapshot data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865607f60fc832a8e09af301a61f60b