### PR TITLE
Add serialization helpers to GameState

### DIFF
--- a/magic_combat/__init__.py
+++ b/magic_combat/__init__.py
@@ -47,8 +47,6 @@ from .snapshot import creature_to_dict
 from .snapshot import decode_mentor
 from .snapshot import decode_provoke
 from .snapshot import encode_map
-from .snapshot import state_from_dict
-from .snapshot import state_to_dict
 from .utils import apply_attacker_blocking_bonuses
 from .utils import apply_blocker_bushido
 from .utils import calculate_mana_value
@@ -101,8 +99,6 @@ __all__ = [
     "SNAPSHOT_VERSION",
     "creature_to_dict",
     "creature_from_dict",
-    "state_to_dict",
-    "state_from_dict",
     "encode_map",
     "decode_provoke",
     "decode_mentor",

--- a/magic_combat/gamestate.py
+++ b/magic_combat/gamestate.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from dataclasses import field
+from typing import Any
 
 from magic_combat.constants import POISON_LOSS_THRESHOLD
 
@@ -50,6 +51,35 @@ class GameState:
             for line in str(state).splitlines():
                 lines.append(f"  {line}")
         return "\n".join(lines)
+
+    def to_dict(self) -> dict[str, dict[str, int]]:
+        """Return life totals and poison counters for this state."""
+        life = {p: ps.life for p, ps in self.players.items()}
+        poison = {p: ps.poison for p, ps in self.players.items()}
+        return {"life": life, "poison": poison}
+
+    @classmethod
+    def from_dict(
+        cls,
+        data: dict[str, Any],
+        attackers: list[CombatCreature],
+        blockers: list[CombatCreature],
+    ) -> "GameState":
+        """Create a ``GameState`` from raw ``data`` and creature lists."""
+        return cls(
+            players={
+                "A": PlayerState(
+                    life=int(data["life"]["A"]),
+                    poison=int(data["poison"]["A"]),
+                    creatures=attackers,
+                ),
+                "B": PlayerState(
+                    life=int(data["life"]["B"]),
+                    poison=int(data["poison"]["B"]),
+                    creatures=blockers,
+                ),
+            }
+        )
 
 
 def has_player_lost(state: GameState, player: str) -> bool:

--- a/magic_combat/snapshot.py
+++ b/magic_combat/snapshot.py
@@ -10,10 +10,6 @@ from typing import List
 from .creature import Color
 from .creature import CombatCreature
 from .gamestate import GameState
-from .gamestate import PlayerState
-
-_DEFENDER = "B"
-_ATTACKER = "A"
 
 
 def creature_to_dict(creature: CombatCreature) -> Dict[str, Any]:
@@ -34,9 +30,7 @@ def creature_from_dict(data: Dict[str, Any]) -> CombatCreature:
 
 def state_to_dict(state: GameState) -> Dict[str, Any]:
     """Return life totals and poison counters for ``state``."""
-    life = {p: ps.life for p, ps in state.players.items()}
-    poison = {p: ps.poison for p, ps in state.players.items()}
-    return {"life": life, "poison": poison}
+    return state.to_dict()
 
 
 def state_from_dict(
@@ -45,20 +39,7 @@ def state_from_dict(
     blockers: List[CombatCreature],
 ) -> GameState:
     """Create a :class:`GameState` from ``data`` and creature lists."""
-    return GameState(
-        players={
-            _ATTACKER: PlayerState(
-                life=int(data["life"][_ATTACKER]),
-                poison=int(data["poison"][_ATTACKER]),
-                creatures=attackers,
-            ),
-            _DEFENDER: PlayerState(
-                life=int(data["life"][_DEFENDER]),
-                poison=int(data["poison"][_DEFENDER]),
-                creatures=blockers,
-            ),
-        }
-    )
+    return GameState.from_dict(data, attackers, blockers)
 
 
 def encode_map(

--- a/scripts/generate_blocking_snapshots.py
+++ b/scripts/generate_blocking_snapshots.py
@@ -14,7 +14,6 @@ from magic_combat import creature_to_dict
 from magic_combat import encode_map
 from magic_combat import generate_random_scenario
 from magic_combat import load_cards
-from magic_combat import state_to_dict
 from magic_combat.constants import SNAPSHOT_VERSION
 
 
@@ -67,7 +66,7 @@ def main() -> None:
             "seed": seed,
             "attackers": [creature_to_dict(c) for c in attackers],
             "blockers": [creature_to_dict(c) for c in blockers],
-            "state": state_to_dict(state),
+            "state": state.to_dict(),
             "provoke_map": encode_map(provoke_map, attackers, blockers),
             "mentor_map": encode_map(mentor_map, attackers, attackers),
             "optimal_assignment": list(opt_map),

--- a/tests/combat/test_snapshot_blocks.py
+++ b/tests/combat/test_snapshot_blocks.py
@@ -3,10 +3,10 @@ from pathlib import Path
 from typing import List
 from typing import Optional
 
+from magic_combat import GameState
 from magic_combat import creature_from_dict
 from magic_combat import decode_mentor
 from magic_combat import decode_provoke
-from magic_combat import state_from_dict
 from magic_combat.blocking_ai import decide_optimal_blocks
 from magic_combat.constants import SNAPSHOT_VERSION
 
@@ -33,7 +33,7 @@ def test_optimal_blocks_snapshots() -> None:
             continue
         attackers = [creature_from_dict(d) for d in snap["attackers"]]
         blockers = [creature_from_dict(d) for d in snap["blockers"]]
-        state = state_from_dict(snap["state"], attackers, blockers)
+        state = GameState.from_dict(snap["state"], attackers, blockers)
         provoke_map = decode_provoke(snap["provoke_map"], attackers, blockers)
         mentor_map = decode_mentor(snap["mentor_map"], attackers)
         decide_optimal_blocks(


### PR DESCRIPTION
## Summary
- implement `GameState.to_dict` and `GameState.from_dict`
- delegate snapshot helpers to new methods
- update scripts and tests
- drop legacy snapshot helpers from package exports

## Testing
- `isort --profile black **/*.py`
- `black **/*.py`
- `autoflake --in-place --remove-unused-variables --remove-all-unused-imports -r magic_combat scripts tests`
- `flake8`
- `pycodestyle --max-line-length=88 --ignore=E203,W503,E226 --exclude=comprehensive_rules.py,tests,magic_combat/rules_text.py magic_combat scripts`
- `pylint magic_combat scripts tests`
- `mypy`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864e134a25c832a98e1fdaff7dc77d2