### PR TITLE
Implement GameState.reset_block_assignments

### DIFF
--- a/magic_combat/block_utils.py
+++ b/magic_combat/block_utils.py
@@ -108,12 +108,3 @@ def should_force_provoke(
         if not eligible:
             return False
     return True
-
-
-def reset_block_assignments(game_state: GameState) -> None:
-    """Clear ``blocked_by`` and ``blocking`` fields on all combatants."""
-
-    for atk in game_state.players["A"].creatures:
-        atk.blocked_by.clear()
-    for blk in game_state.players["B"].creatures:
-        blk.blocking = None

--- a/magic_combat/blocking_ai.py
+++ b/magic_combat/blocking_ai.py
@@ -12,7 +12,6 @@ from typing import Tuple
 from typing import TypeAlias
 
 from .block_utils import evaluate_block_assignment
-from .block_utils import reset_block_assignments
 from .block_utils import should_force_provoke
 from .creature import CombatCreature
 from .gamestate import GameState
@@ -231,7 +230,7 @@ def decide_optimal_blocks(
     )
 
     # Apply the chosen assignment to the real objects
-    reset_block_assignments(game_state)
+    game_state.reset_block_assignments()
     if len(top) == 0:
         return [], optimal_count
 
@@ -262,7 +261,7 @@ def decide_simple_blocks(
     blockers = list(game_state.players["B"].creatures)
     counter = IterationCounter(max_iterations)
 
-    reset_block_assignments(game_state)
+    game_state.reset_block_assignments()
 
     block_options = _get_block_options(
         game_state,
@@ -301,7 +300,7 @@ def decide_simple_blocks(
 
     final_score, final_assignment = top[0]
 
-    reset_block_assignments(game_state)
+    game_state.reset_block_assignments()
     for blk_idx, choice in enumerate(final_assignment):
         if choice is not None:
             blk = blockers[blk_idx]

--- a/magic_combat/gamestate.py
+++ b/magic_combat/gamestate.py
@@ -51,6 +51,14 @@ class GameState:
                 lines.append(f"  {line}")
         return "\n".join(lines)
 
+    def reset_block_assignments(self) -> None:
+        """Clear ``blocked_by`` and ``blocking`` fields on all combatants."""
+
+        for attacker in self.players["A"].creatures:
+            attacker.blocked_by.clear()
+        for blocker in self.players["B"].creatures:
+            blocker.blocking = None
+
 
 def has_player_lost(state: GameState, player: str) -> bool:
     """Return ``True`` if ``player`` has lost the game."""


### PR DESCRIPTION
## Summary
- move `reset_block_assignments` into `GameState`
- use the new method in `blocking_ai`
- remove old helper function from `block_utils`

## Testing
- `pytest -q`
- `pytest tests/test_style.py::test_flake8 -q`


------
https://chatgpt.com/codex/tasks/task_e_6864e1336acc832a84f4149246c3240b