### PR TITLE
Add has_player_lost method on GameState

### DIFF
--- a/magic_combat/__init__.py
+++ b/magic_combat/__init__.py
@@ -21,7 +21,6 @@ from .exceptions import ScenarioGenerationError
 from .exceptions import UnparsableLLMOutputError
 from .gamestate import GameState
 from .gamestate import PlayerState
-from .gamestate import has_player_lost
 from .llm_cache import LLMCache
 from .llm_cache import MockLLMCache
 from .random_creature import assign_random_counters
@@ -63,7 +62,6 @@ __all__ = [
     "decide_simple_blocks",
     "GameState",
     "PlayerState",
-    "has_player_lost",
     "calculate_mana_value",
     "fetch_french_vanilla_cards",
     "load_cards",

--- a/magic_combat/gamestate.py
+++ b/magic_combat/gamestate.py
@@ -51,10 +51,9 @@ class GameState:
                 lines.append(f"  {line}")
         return "\n".join(lines)
 
-
-def has_player_lost(state: GameState, player: str) -> bool:
-    """Return ``True`` if ``player`` has lost the game."""
-    ps = state.players.get(player)
-    if ps is None:
-        return False
-    return ps.life <= 0 or ps.poison >= POISON_LOSS_THRESHOLD
+    def has_player_lost(self, player: str) -> bool:
+        """Return ``True`` if ``player`` has lost the game."""
+        ps = self.players.get(player)
+        if ps is None:
+            return False
+        return ps.life <= 0 or ps.poison >= POISON_LOSS_THRESHOLD

--- a/magic_combat/simulator.py
+++ b/magic_combat/simulator.py
@@ -13,7 +13,6 @@ from .creature import CombatCreature
 from .damage import optimal_damage_order
 from .exceptions import IllegalBlockError
 from .gamestate import GameState
-from .gamestate import has_player_lost
 from .utils import can_block
 from .utils import ensure_player_state
 
@@ -255,7 +254,7 @@ class CombatSimulator:
         if self.game_state is not None:
             for player in self.game_state.players:
                 if (
-                    has_player_lost(self.game_state, player)
+                    self.game_state.has_player_lost(player)
                     and player not in self.players_lost
                 ):
                     self.players_lost.append(player)

--- a/tests/abilities/test_poison.py
+++ b/tests/abilities/test_poison.py
@@ -2,7 +2,6 @@ from magic_combat import CombatCreature
 from magic_combat import CombatSimulator
 from magic_combat import GameState
 from magic_combat import PlayerState
-from magic_combat import has_player_lost
 from magic_combat.constants import DEFAULT_STARTING_LIFE
 from magic_combat.constants import POISON_LOSS_THRESHOLD
 from tests.conftest import link_block
@@ -136,7 +135,7 @@ def test_player_loses_at_ten_poison():
     sim = CombatSimulator([atk], [defender], game_state=state)
     sim.simulate()
     assert state.players["B"].poison == POISON_LOSS_THRESHOLD
-    assert has_player_lost(state, "B")
+    assert state.has_player_lost("B")
     assert "B" in sim.players_lost
 
 

--- a/tests/combat/test_game_loss_scenarios.py
+++ b/tests/combat/test_game_loss_scenarios.py
@@ -2,7 +2,6 @@ from magic_combat import CombatCreature
 from magic_combat import CombatSimulator
 from magic_combat import GameState
 from magic_combat import PlayerState
-from magic_combat import has_player_lost
 from magic_combat.constants import DEFAULT_STARTING_LIFE
 from magic_combat.constants import POISON_LOSS_THRESHOLD
 from tests.conftest import link_block
@@ -22,7 +21,7 @@ def test_afflict_lethal_when_blocked():
     sim = CombatSimulator([atk], [blk], game_state=state)
     sim.simulate()
     assert state.players["B"].life == 0
-    assert has_player_lost(state, "B")
+    assert state.has_player_lost("B")
     assert "B" in sim.players_lost
 
 
@@ -40,7 +39,7 @@ def test_afflict_and_trample_combined_lethal():
     sim = CombatSimulator([atk], [blk], game_state=state)
     sim.simulate()
     assert state.players["B"].life == 0
-    assert has_player_lost(state, "B")
+    assert state.has_player_lost("B")
     assert "B" in sim.players_lost
 
 
@@ -59,7 +58,7 @@ def test_toxic_three_poison_counters_causes_loss():
     sim = CombatSimulator([atk], [defender], game_state=state)
     sim.simulate()
     assert state.players["B"].poison == 11
-    assert has_player_lost(state, "B")
+    assert state.has_player_lost("B")
     assert "B" in sim.players_lost
 
 
@@ -78,7 +77,7 @@ def test_infect_and_toxic_exactly_ten_poison():
     sim = CombatSimulator([atk], [defender], game_state=state)
     sim.simulate()
     assert state.players["B"].poison == POISON_LOSS_THRESHOLD
-    assert has_player_lost(state, "B")
+    assert state.has_player_lost("B")
     assert "B" in sim.players_lost
 
 
@@ -97,7 +96,7 @@ def test_double_strike_infect_first_step_loss():
     sim = CombatSimulator([atk], [defender], game_state=state)
     sim.simulate()
     assert state.players["B"].poison == 11
-    assert has_player_lost(state, "B")
+    assert state.has_player_lost("B")
     assert "B" in sim.players_lost
 
 
@@ -115,7 +114,7 @@ def test_double_strike_trample_overkill():
     sim = CombatSimulator([atk], [blk], game_state=state)
     sim.simulate()
     assert state.players["B"].life == -2
-    assert has_player_lost(state, "B")
+    assert state.has_player_lost("B")
     assert "B" in sim.players_lost
 
 
@@ -133,7 +132,7 @@ def test_first_strike_blocker_barely_survives():
     sim = CombatSimulator([atk], [blk], game_state=state)
     sim.simulate()
     assert state.players["B"].life == 1
-    assert not has_player_lost(state, "B")
+    assert not state.has_player_lost("B")
     assert "B" not in sim.players_lost
 
 
@@ -152,7 +151,7 @@ def test_trample_lifelink_kills_player():
     sim.simulate()
     assert state.players["B"].life == 0
     assert state.players["A"].life == 14
-    assert has_player_lost(state, "B")
+    assert state.has_player_lost("B")
     assert "B" in sim.players_lost
 
 
@@ -172,7 +171,7 @@ def test_lifelink_cannot_prevent_poison_loss():
     sim.simulate()
     assert state.players["A"].life == 6
     assert state.players["B"].poison == POISON_LOSS_THRESHOLD
-    assert has_player_lost(state, "B")
+    assert state.has_player_lost("B")
     assert "B" in sim.players_lost
 
 

--- a/tests/combat/test_gamestate.py
+++ b/tests/combat/test_gamestate.py
@@ -2,7 +2,6 @@ from magic_combat import CombatCreature
 from magic_combat import CombatSimulator
 from magic_combat import GameState
 from magic_combat import PlayerState
-from magic_combat import has_player_lost
 from magic_combat.constants import DEFAULT_STARTING_LIFE
 from magic_combat.constants import POISON_LOSS_THRESHOLD
 from tests.conftest import link_block
@@ -21,7 +20,7 @@ def test_player_loses_when_life_zero():
     sim = CombatSimulator([atk], [defender], game_state=state)
     sim.simulate()
     assert state.players["B"].life == 0
-    assert has_player_lost(state, "B")
+    assert state.has_player_lost("B")
     assert "B" in sim.players_lost
 
 
@@ -40,7 +39,7 @@ def test_player_loses_from_poison():
     sim = CombatSimulator([atk], [defender], game_state=state)
     sim.simulate()
     assert state.players["B"].poison == 11
-    assert has_player_lost(state, "B")
+    assert state.has_player_lost("B")
     assert "B" in sim.players_lost
 
 
@@ -151,6 +150,6 @@ def test_double_strike_infect_can_cause_loss():
     sim = CombatSimulator([atk], [defender], game_state=state)
     result = sim.simulate()
     assert state.players["B"].poison == POISON_LOSS_THRESHOLD
-    assert has_player_lost(state, "B")
+    assert state.has_player_lost("B")
     assert "B" in sim.players_lost
     assert result.poison_counters["B"] == 2

--- a/tests/combat/test_life_poison.py
+++ b/tests/combat/test_life_poison.py
@@ -2,7 +2,6 @@ from magic_combat import CombatCreature
 from magic_combat import CombatSimulator
 from magic_combat import GameState
 from magic_combat import PlayerState
-from magic_combat import has_player_lost
 from magic_combat.constants import DEFAULT_STARTING_LIFE
 from magic_combat.constants import POISON_LOSS_THRESHOLD
 from tests.conftest import link_block
@@ -25,7 +24,7 @@ def test_infect_lifelink_poison_lethal():
     assert state.players["B"].life == 20
     assert state.players["B"].poison == POISON_LOSS_THRESHOLD
     assert result.lifegain["A"] == 2
-    assert has_player_lost(state, "B")
+    assert state.has_player_lost("B")
     assert "B" in sim.players_lost
 
 
@@ -43,7 +42,7 @@ def test_double_strike_lifelink_player_lethal():
     result = sim.simulate()
     assert state.players["B"].life == -1
     assert result.lifegain["A"] == 4
-    assert has_player_lost(state, "B")
+    assert state.has_player_lost("B")
     assert "B" in sim.players_lost
 
 
@@ -65,7 +64,7 @@ def test_infect_double_strike_lifelink_poison_lethal():
     result = sim.simulate()
     assert state.players["B"].poison == 11
     assert result.lifegain["A"] == 2
-    assert has_player_lost(state, "B")
+    assert state.has_player_lost("B")
     assert "B" in sim.players_lost
 
 
@@ -98,5 +97,5 @@ def test_trample_deathtouch_lifelink_lethal():
     result = sim.simulate()
     assert state.players["B"].life == 0
     assert result.lifegain["A"] == 3
-    assert has_player_lost(state, "B")
+    assert state.has_player_lost("B")
     assert "B" in sim.players_lost

--- a/tests/combat/test_result_state_diff.py
+++ b/tests/combat/test_result_state_diff.py
@@ -5,7 +5,6 @@ from magic_combat import CombatSimulator
 from magic_combat import GameState
 from magic_combat import PlayerState
 from magic_combat.block_utils import evaluate_block_assignment
-from magic_combat.gamestate import has_player_lost
 from magic_combat.limits import IterationCounter
 from tests.conftest import link_block
 
@@ -14,7 +13,7 @@ def _score_from_states(
     start: GameState, end: GameState | None, attacker: str, defender: str
 ) -> tuple[int, float, int, int, int, int]:
     assert end is not None
-    lost = 1 if has_player_lost(end, defender) else 0
+    lost = 1 if end.has_player_lost(defender) else 0
     start_att = start.players[attacker].creatures
     start_def = start.players[defender].creatures
     end_att_names = {c.name for c in end.players[attacker].creatures}


### PR DESCRIPTION
## Summary
- move has_player_lost to GameState as a method
- update simulator to use the new method
- drop old function from __init__ and tests
- call GameState.has_player_lost in tests

## Testing
- `isort --profile black .`
- `autoflake -i -r magic_combat tests`
- `black .`
- `flake8`
- `pycodestyle .`
- `pylint magic_combat tests`
- `mypy`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864e130d3ec832a9845745decc3132b