### PR TITLE
Implement GameState.ensure_player_state

### DIFF
--- a/magic_combat/combat_utils.py
+++ b/magic_combat/combat_utils.py
@@ -12,7 +12,6 @@ from typing import Optional
 
 from .creature import CombatCreature
 from .gamestate import GameState
-from .utils import ensure_player_state
 
 __all__ = ["damage_creature", "damage_player"]
 
@@ -52,15 +51,15 @@ def damage_player(
     if source.infect:
         poison_counters[player] = poison_counters.get(player, 0) + amount
         if game_state is not None:
-            ps = ensure_player_state(game_state, player)
+            ps = game_state.ensure_player_state(player)
             ps.poison += amount
     else:
         damage_to_players[player] = damage_to_players.get(player, 0) + amount
         if game_state is not None:
-            ps = ensure_player_state(game_state, player)
+            ps = game_state.ensure_player_state(player)
             ps.life -= amount
     if source.toxic:
         poison_counters[player] = poison_counters.get(player, 0) + source.toxic
         if game_state is not None:
-            ps = ensure_player_state(game_state, player)
+            ps = game_state.ensure_player_state(player)
             ps.poison += source.toxic

--- a/magic_combat/gamestate.py
+++ b/magic_combat/gamestate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from dataclasses import field
 
+from magic_combat.constants import DEFAULT_STARTING_LIFE
 from magic_combat.constants import POISON_LOSS_THRESHOLD
 
 from .creature import CombatCreature
@@ -50,6 +51,14 @@ class GameState:
             for line in str(state).splitlines():
                 lines.append(f"  {line}")
         return "\n".join(lines)
+
+    def ensure_player_state(self, player: str) -> PlayerState:
+        """Return existing :class:`PlayerState` for ``player`` or create one."""
+
+        return self.players.setdefault(
+            player,
+            PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[], poison=0),
+        )
 
 
 def has_player_lost(state: GameState, player: str) -> bool:

--- a/magic_combat/simulator.py
+++ b/magic_combat/simulator.py
@@ -15,7 +15,6 @@ from .exceptions import IllegalBlockError
 from .gamestate import GameState
 from .gamestate import has_player_lost
 from .utils import can_block
-from .utils import ensure_player_state
 
 
 @dataclass
@@ -446,7 +445,7 @@ class CombatSimulator:
             return
         max_life = max(ps.life for ps in self.game_state.players.values())
         defender = self._get_defending_player()
-        defender_life = ensure_player_state(self.game_state, defender).life
+        defender_life = self.game_state.ensure_player_state(defender).life
         for atk in self.attackers:
             if atk.dethrone and defender_life >= max_life:
                 atk.plus1_counters += 1
@@ -462,7 +461,7 @@ class CombatSimulator:
                     self.player_damage.get(defender, 0) + atk.afflict
                 )
                 if self.game_state is not None:
-                    ps = ensure_player_state(self.game_state, defender)
+                    ps = self.game_state.ensure_player_state(defender)
                     ps.life -= atk.afflict
 
     def _handle_bushido_rampage_flanking(self) -> None:
@@ -645,7 +644,7 @@ class CombatSimulator:
                 already = self._lifegain_applied.get(player, 0)
                 diff = gain - already
                 if diff:
-                    ps = ensure_player_state(self.game_state, player)
+                    ps = self.game_state.ensure_player_state(player)
                     ps.life += diff
                     self._lifegain_applied[player] = gain
         # lifegain remains tracked for CombatResult

--- a/magic_combat/utils.py
+++ b/magic_combat/utils.py
@@ -7,8 +7,6 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .creature import CombatCreature
-    from .gamestate import GameState
-    from .gamestate import PlayerState
 
 
 def check_non_negative(value: int, name: str) -> None:
@@ -34,19 +32,6 @@ def check_positive(value: int, name: str) -> None:
     """Validate that ``value`` is strictly positive."""
     if value <= 0:
         raise ValueError(f"{name} must be positive")
-
-
-def ensure_player_state(state: "GameState", player: str) -> "PlayerState":
-    """Return existing :class:`PlayerState` for ``player`` or create one."""
-
-    # Import inside the function to avoid circular imports at module load time.
-    from magic_combat.constants import DEFAULT_STARTING_LIFE
-
-    from .gamestate import PlayerState
-
-    return state.players.setdefault(
-        player, PlayerState(life=DEFAULT_STARTING_LIFE, creatures=[], poison=0)
-    )
 
 
 def _evaluate_mana_symbol(symbol: str, x_value: int) -> int:


### PR DESCRIPTION
## Summary
- add `ensure_player_state` method to `GameState`
- update combat utilities and simulator to call the new method
- remove standalone `ensure_player_state` helper

## Testing
- `autoflake --check --recursive magic_combat scripts tests`
- `pycodestyle --max-line-length=88 --ignore=E203,W503,E226 --exclude=comprehensive_rules.py,tests,magic_combat/rules_text.py magic_combat scripts`
- `flake8 magic_combat scripts tests`
- `pylint magic_combat scripts tests`
- `mypy magic_combat scripts tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864e1326c1c832ab13cb4388654c91c