### PR TITLE
Add simple block snapshots

### DIFF
--- a/tests/combat/test_snapshot_blocks.py
+++ b/tests/combat/test_snapshot_blocks.py
@@ -4,6 +4,7 @@ from typing import List
 from typing import Optional
 
 from magic_combat.blocking_ai import decide_optimal_blocks
+from magic_combat.blocking_ai import decide_simple_blocks
 from magic_combat.constants import SNAPSHOT_VERSION
 from magic_combat.snapshot import creature_from_dict
 from magic_combat.snapshot import decode_mentor
@@ -46,3 +47,34 @@ def test_optimal_blocks_snapshots() -> None:
             for b in blockers
         ]
         assert chosen == snap["optimal_assignment"]
+
+
+def test_simple_blocks_snapshots() -> None:
+    """CR 509.1a: The defending player chooses how creatures block."""
+    snapshots = _load_snapshots()
+    for snap in snapshots:
+        if snap.get("version") != SNAPSHOT_VERSION:
+            print(
+                "Warning: snapshot version",
+                snap.get("version"),
+                "!=",
+                SNAPSHOT_VERSION,
+            )
+            continue
+        if snap.get("simple_assignment") is None:
+            continue
+        attackers = [creature_from_dict(d) for d in snap["attackers"]]
+        blockers = [creature_from_dict(d) for d in snap["blockers"]]
+        state = state_from_dict(snap["state"], attackers, blockers)
+        provoke_map = decode_provoke(snap["provoke_map"], attackers, blockers)
+        mentor_map = decode_mentor(snap["mentor_map"], attackers)
+        decide_simple_blocks(
+            game_state=state,
+            provoke_map=provoke_map,
+            mentor_map=mentor_map,
+        )
+        chosen: List[Optional[int]] = [
+            attackers.index(b.blocking) if b.blocking is not None else None
+            for b in blockers
+        ]
+        assert chosen == snap["simple_assignment"]

--- a/tests/data/blocking_snapshots.json
+++ b/tests/data/blocking_snapshots.json
@@ -318,8 +318,8 @@
       2
     ],
     "simple_assignment": [
-      null,
-      null
+      1,
+      2
     ],
     "combat_value": [
       3,
@@ -590,7 +590,7 @@
     ],
     "simple_assignment": [
       null,
-      null
+      1
     ],
     "combat_value": [
       2,
@@ -923,7 +923,7 @@
     ],
     "simple_assignment": [
       null,
-      null
+      0
     ],
     "combat_value": [
       4,
@@ -1193,7 +1193,7 @@
       null
     ],
     "simple_assignment": [
-      null,
+      1,
       null
     ],
     "combat_value": [
@@ -1524,8 +1524,8 @@
       null
     ],
     "simple_assignment": [
-      null,
-      null,
+      1,
+      1,
       null
     ],
     "combat_value": [
@@ -1738,7 +1738,7 @@
       1
     ],
     "simple_assignment": [
-      null
+      1
     ],
     "combat_value": [
       4,
@@ -1950,7 +1950,7 @@
     ],
     "simple_assignment": [
       null,
-      null
+      0
     ],
     "combat_value": [
       0,
@@ -2160,7 +2160,7 @@
       0
     ],
     "simple_assignment": [
-      null
+      0
     ],
     "combat_value": [
       2,
@@ -2669,9 +2669,9 @@
     ],
     "simple_assignment": [
       null,
-      null,
-      null,
-      null
+      1,
+      2,
+      1
     ],
     "combat_value": [
       7,
@@ -2881,7 +2881,7 @@
       0
     ],
     "simple_assignment": [
-      null
+      0
     ],
     "combat_value": [
       2,


### PR DESCRIPTION
## Summary
- verify simple block results against snapshot data
- embed new simple block assignments into snapshot JSON

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865ff04ef84832abad289e37ded7ee6