### PR TITLE
Add dataset creation script

### DIFF
--- a/magic_combat/__init__.py
+++ b/magic_combat/__init__.py
@@ -12,6 +12,7 @@ from .create_llm_prompt import parse_block_assignments
 from .creature import Color
 from .creature import CombatCreature
 from .damage import optimal_damage_order
+from .dataset import ReferenceAnswer
 from .exceptions import CardDataError
 from .exceptions import IllegalBlockError
 from .exceptions import InvalidBlockScenarioError
@@ -106,4 +107,5 @@ __all__ = [
     "decode_mapping",
     "decode_provoke",
     "decode_mentor",
+    "ReferenceAnswer",
 ]

--- a/magic_combat/dataset.py
+++ b/magic_combat/dataset.py
@@ -1,0 +1,33 @@
+"""Helpers for creating LLM training datasets."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from pydantic import BaseModel
+
+from .gamestate import GameState
+
+
+class ReferenceAnswer(BaseModel):
+    """Mapping of blocking creature to attacker."""
+
+    blocks: Dict[str, str]
+
+    model_config = {
+        "frozen": True,
+    }
+
+    @classmethod
+    def from_state(cls, mapping: Dict[str, str], state: GameState) -> "ReferenceAnswer":
+        """Validate ``mapping`` against ``state`` and return an instance."""
+
+        attacker_names = {c.name for c in state.players["A"].creatures}
+        blocker_names = {c.name for c in state.players["B"].creatures}
+
+        if not set(mapping).issubset(blocker_names):
+            raise ValueError("Unknown blocker name in mapping")
+        if not set(mapping.values()).issubset(attacker_names):
+            raise ValueError("Unknown attacker name in mapping")
+
+        return cls(blocks=dict(mapping))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "typing_extensions==4.13.1",
     "types-requests==2.28.11.17",
     "pyright==1.1.402",
+    "pydantic==2.7.1",
 ]
 
 [tool.setuptools.packages.find]

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ pycodestyle==2.14.0
 typing_extensions==4.13.1
 types-requests==2.28.11.17
 pyright==1.1.402
+pydantic==2.7.1

--- a/scripts/create_dataset.py
+++ b/scripts/create_dataset.py
@@ -1,0 +1,66 @@
+"""Generate a dataset of LLM prompts and reference answers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from pathlib import Path
+
+import numpy as np
+
+from magic_combat import build_value_map
+from magic_combat import compute_card_statistics
+from magic_combat import create_llm_prompt
+from magic_combat import generate_random_scenario
+from magic_combat import load_cards
+from magic_combat.dataset import ReferenceAnswer
+
+
+def _dump(path: Path, data: list[dict[str, object]]) -> None:
+    """Write ``data`` as JSONL to ``path``."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        for item in data:
+            json.dump(item, fh)
+            fh.write("\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Create training dataset")
+    parser.add_argument("-n", type=int, default=1, help="Number of scenarios")
+    parser.add_argument(
+        "--cards", default="tests/data/example_test_cards.json", help="Card data JSON"
+    )
+    parser.add_argument("--seed", type=int, default=0, help="Base random seed")
+    parser.add_argument("--output", required=True, help="Output JSONL file")
+    args = parser.parse_args()
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+
+    cards = load_cards(args.cards)
+    stats = compute_card_statistics(cards)
+    values = build_value_map(cards)
+
+    items: list[dict[str, object]] = []
+    for i in range(args.n):
+        state, _, _, opt_map, _ = generate_random_scenario(
+            cards, values, stats, seed=args.seed + i
+        )
+        prompt = create_llm_prompt(state)
+        attackers = list(state.players["A"].creatures)
+        blockers = list(state.players["B"].creatures)
+        mapping = {
+            blockers[idx].name: attackers[a_idx].name
+            for idx, a_idx in enumerate(opt_map)
+            if a_idx is not None
+        }
+        answer = ReferenceAnswer.from_state(mapping, state)
+        items.append({"prompt": prompt, "answer": answer.model_dump()})
+
+    _dump(Path(args.output), items)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/llm/test_dataset_script.py
+++ b/tests/llm/test_dataset_script.py
@@ -1,0 +1,54 @@
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from magic_combat.creature import CombatCreature
+from magic_combat.dataset import ReferenceAnswer
+from magic_combat.gamestate import GameState
+from magic_combat.gamestate import PlayerState
+from scripts import create_dataset
+
+DATA_PATH = Path(__file__).resolve().parents[1] / "data" / "example_test_cards.json"
+
+
+def test_reference_answer_validation() -> None:
+    atk = CombatCreature("Att", 2, 2, "A")
+    blk = CombatCreature("Blk", 1, 3, "B")
+    state = GameState(
+        players={"A": PlayerState(20, [atk]), "B": PlayerState(20, [blk])}
+    )
+    mapping = {blk.name: atk.name}
+    ans = ReferenceAnswer.from_state(mapping, state)
+    assert ans.blocks == mapping
+    with pytest.raises(ValueError):
+        ReferenceAnswer.from_state({"Foo": atk.name}, state)
+    with pytest.raises(ValueError):
+        ReferenceAnswer.from_state({blk.name: "Bar"}, state)
+
+
+def test_create_dataset_script(tmp_path: Path) -> None:
+    out = tmp_path / "data.jsonl"
+    with patch.object(
+        sys,
+        "argv",
+        [
+            "create_dataset.py",
+            "-n",
+            "1",
+            "--cards",
+            str(DATA_PATH),
+            "--output",
+            str(out),
+            "--seed",
+            "123",
+        ],
+    ):
+        create_dataset.main()
+    lines = out.read_text().splitlines()
+    assert len(lines) == 1
+    entry = json.loads(lines[0])
+    assert isinstance(entry.get("prompt"), str)
+    ReferenceAnswer.model_validate(entry.get("answer"))


### PR DESCRIPTION
## Summary
- implement `ReferenceAnswer` pydantic model
- add `create_dataset` script to generate prompts and optimal blocks
- expose `ReferenceAnswer` in package
- update dependencies for pydantic
- add tests for dataset generation

## Testing
- `isort --profile black magic_combat scripts tests`
- `black magic_combat scripts tests`
- `autoflake --check --recursive magic_combat scripts tests`
- `flake8 magic_combat scripts tests`
- `pycodestyle --max-line-length=88 --ignore=E203,W503,E226 --exclude=comprehensive_rules.py,tests,magic_combat/rules_text.py magic_combat scripts`
- `pylint magic_combat scripts tests --disable=R,C`
- `mypy magic_combat scripts tests`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865ffc4bc58832a90c432048ce3c772