### PR TITLE
Add Anthropic model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
 # Magic Combat
+from llms.llm import call_anthropic_model
+from magic_combat import CombatCreature
+from magic_combat import CombatSimulator
+from magic_combat import compute_card_statistics
+from magic_combat import fetch_french_vanilla_cards
+from magic_combat import generate_random_creature
+from magic_combat import load_cards
+from magic_combat import save_cards
 
 This project provides a small combat simulator inspired by trading card games
 such as *Magic: The Gathering*.
@@ -52,7 +60,6 @@ implemented correctly.
 ## Usage
 
 ```python
-from magic_combat import CombatCreature, CombatSimulator
 
 attacker = CombatCreature("Knight", 2, 2, "A")
 blocker = CombatCreature("Goblin", 1, 1, "B")
@@ -73,7 +80,6 @@ resulting data can be stored locally using :func:`save_cards` and later
 loaded with :func:`load_cards`.
 
 ```python
-from magic_combat import fetch_french_vanilla_cards, save_cards
 
 cards = fetch_french_vanilla_cards()  # optional ``timeout`` parameter
 save_cards(cards, "data/cards.json")
@@ -97,7 +103,6 @@ Once you have downloaded card data, you can build statistics for the real
 creature distribution and sample new creatures from it:
 
 ```python
-from magic_combat import load_cards, compute_card_statistics, generate_random_creature
 
 cards = load_cards("data/cards.json")
 stats = compute_card_statistics(cards)
@@ -135,3 +140,17 @@ OPENAI_API_KEY=<your-key> \
 
 The script will generate scenarios, send them to the model and print the
 results to the console.
+
+## Using Anthropic models
+
+Support for Anthropic's Claude models is also provided.  Before using these
+functions you must install the ``anthropic`` package (already included in
+``requirements.txt``) and set the ``ANTHROPIC_API_KEY`` environment variable.
+The :func:`llms.llm.call_anthropic_model` helper mirrors
+``call_openai_model`` but queries the Anthropic API instead.  Example:
+
+```bash
+ANTHROPIC_API_KEY=<your-key> python - <<'EOF'
+print(asyncio.run(call_anthropic_model(["Hello"], model="claude-3-sonnet-20240229")))
+EOF
+```

--- a/llms/__init__.py
+++ b/llms/__init__.py
@@ -1,0 +1,6 @@
+"""Simple interface for language models."""
+
+from .llm import call_anthropic_model
+from .llm import call_openai_model
+
+__all__ = ["call_openai_model", "call_anthropic_model"]

--- a/llms/llm.py
+++ b/llms/llm.py
@@ -1,6 +1,7 @@
 import asyncio
 from typing import Optional
 
+import anthropic
 import openai
 
 from .llm_cache import LLMCache
@@ -60,6 +61,88 @@ async def call_openai_model(
         semaphore = asyncio.Semaphore(concurrency) if concurrency else None
         tasks = [
             call_openai_model_single_prompt(
+                prompt,
+                client,
+                model=model,
+                temperature=temperature,
+                seed=seed,
+                cache=cache,
+                semaphore=semaphore,
+            )
+            for prompt in prompts
+        ]
+        responses = await asyncio.gather(*tasks)
+        return list(responses)
+    finally:
+        await client.close()
+
+
+async def _anthropic_extract_text(response: anthropic.types.Message) -> str:
+    """Return a simple text string from the API ``response``."""
+    parts = []
+    for block in response.content:
+        text = getattr(block, "text", None)
+        if isinstance(text, str):
+            parts.append(text)
+    return "".join(parts).strip()
+
+
+async def call_anthropic_model_single_prompt(
+    prompt: str,
+    client: anthropic.AsyncAnthropic,
+    *,
+    model: str = "claude-3-sonnet-20240229",
+    temperature: float = 0.2,
+    seed: int = 0,
+    cache: Optional[LLMCache] = None,
+    semaphore: Optional[asyncio.Semaphore] = None,
+) -> str:
+    """Return ``prompt`` response from Anthropic, optionally using ``cache``."""
+    cached = None
+    if cache is not None:
+        cached = cache.get(prompt, model, seed, temperature)
+    if cached is not None:
+        short = prompt.splitlines()[0][:30]
+        print(f"Using cached LLM response for: {short}...")
+        return cached
+
+    if semaphore is None:
+        response = await client.messages.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=1024,
+            temperature=temperature,
+        )
+    else:
+        async with semaphore:
+            response = await client.messages.create(
+                model=model,
+                messages=[{"role": "user", "content": prompt}],
+                max_tokens=1024,
+                temperature=temperature,
+            )
+
+    text = await _anthropic_extract_text(response)
+    if cache is not None:
+        cache.add(prompt, model, seed, temperature, text)
+    return text
+
+
+async def call_anthropic_model(
+    prompts: list[str],
+    *,
+    model: str = "claude-3-sonnet-20240229",
+    temperature: float = 0.2,
+    seed: int = 0,
+    cache: Optional[LLMCache] = None,
+    concurrency: int | None = None,
+) -> list[str]:
+    """Return responses for ``prompts`` from Anthropic."""
+    client = anthropic.AsyncAnthropic()
+    try:
+        semaphore = asyncio.Semaphore(concurrency) if concurrency else None
+        tasks = [
+            call_anthropic_model_single_prompt(
                 prompt,
                 client,
                 model=model,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "types-requests==2.28.11.17",
     "pyright==1.1.402",
     "pydantic==2.7.1",
+    "anthropic==0.57.1",
 ]
 
 [tool.setuptools.packages.find]

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ typing_extensions==4.13.1
 types-requests==2.28.11.17
 pyright==1.1.402
 pydantic==2.7.1
+anthropic==0.57.1

--- a/tests/llm/test_llm_prompt.py
+++ b/tests/llm/test_llm_prompt.py
@@ -2,6 +2,7 @@ import asyncio
 
 from llms.create_llm_prompt import create_llm_prompt
 from llms.create_llm_prompt import parse_block_assignments
+from llms.llm import call_anthropic_model
 from llms.llm import call_openai_model
 from llms.llm_cache import LLMCache
 from llms.llm_cache import MockLLMCache
@@ -44,6 +45,34 @@ class DummyChat:
 class DummyClient:
     def __init__(self):
         self.chat = DummyChat()
+
+    async def close(self):
+        pass
+
+
+class DummyBlock:
+    def __init__(self, text):
+        self.text = text
+
+
+class DummyMessages:
+    def __init__(self):
+        self.calls = 0
+
+    async def create(self, model, messages, max_tokens=0, temperature=0.0):
+        self.calls += 1
+        prompt = messages[0]["content"]
+        return DummyAnthropicResponse(f"response to {prompt}")
+
+
+class DummyAnthropicResponse:
+    def __init__(self, content):
+        self.content = [DummyBlock(content)]
+
+
+class DummyAnthropicClient:
+    def __init__(self):
+        self.messages = DummyMessages()
 
     async def close(self):
         pass
@@ -173,3 +202,61 @@ def test_llm_cache_file_hit(monkeypatch, tmp_path):
     )
     assert res1 == res2
     assert dummy.chat.completions.calls == 1
+
+
+def test_call_anthropic_model(monkeypatch):
+    monkeypatch.setattr("anthropic.AsyncAnthropic", lambda: DummyAnthropicClient())
+    res = asyncio.run(call_anthropic_model(["p1", "p2"]))
+    assert res == ["response to p1", "response to p2"]
+
+
+def test_anthropic_cache_hit(monkeypatch):
+    monkeypatch.setattr("anthropic.AsyncAnthropic", lambda: DummyAnthropicClient())
+    cache = MockLLMCache()
+    res1 = asyncio.run(
+        call_anthropic_model(["p1"], model="m", temperature=0.3, seed=1, cache=cache)
+    )
+    res2 = asyncio.run(
+        call_anthropic_model(["p1"], model="m", temperature=0.3, seed=1, cache=cache)
+    )
+    assert res1 == res2
+    assert cache.entries[0]["response"] == res1[0]
+    assert len(cache.entries) == 1
+
+
+def test_anthropic_cache_miss(monkeypatch):
+    monkeypatch.setattr("anthropic.AsyncAnthropic", lambda: DummyAnthropicClient())
+    cache = MockLLMCache()
+    res1 = asyncio.run(
+        call_anthropic_model(["p1"], model="m", temperature=0.3, seed=1, cache=cache)
+    )
+    res2 = asyncio.run(
+        call_anthropic_model(["p1"], model="m2", temperature=0.3, seed=1, cache=cache)
+    )
+    res3 = asyncio.run(
+        call_anthropic_model(["p1"], model="m", temperature=0.4, seed=1, cache=cache)
+    )
+    res4 = asyncio.run(
+        call_anthropic_model(["p1"], model="m", temperature=0.3, seed=2, cache=cache)
+    )
+    assert res1[0] != ""
+    assert res2[0] != ""
+    assert res3[0] != ""
+    assert res4[0] != ""
+    assert len(cache.entries) == 4
+
+
+def test_anthropic_cache_file_hit(monkeypatch, tmp_path):
+    dummy = DummyAnthropicClient()
+    monkeypatch.setattr("anthropic.AsyncAnthropic", lambda: dummy)
+    cache_path = tmp_path / "cache.jsonl"
+    cache = LLMCache(str(cache_path))
+    res1 = asyncio.run(
+        call_anthropic_model(["p1"], model="m", temperature=0.3, seed=1, cache=cache)
+    )
+    cache2 = LLMCache(str(cache_path))
+    res2 = asyncio.run(
+        call_anthropic_model(["p1"], model="m", temperature=0.3, seed=1, cache=cache2)
+    )
+    assert res1 == res2
+    assert dummy.messages.calls == 1


### PR DESCRIPTION
## Summary
- support Anthropic models in llms module
- expose new helper in `llms.__init__`
- add Anthropic dependency
- document Anthropic usage in README
- test Anthropic helpers

## Testing
- `autoflake --check --recursive llms tests`
- `flake8 llms tests`
- `pycodestyle --max-line-length=88 --ignore=E203,W503,E226 --exclude=comprehensive_rules.py,tests,magic_combat/rules_text.py magic_combat scripts llms`
- `pylint llms tests`
- `mypy llms tests`
- `pyright llms tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866d1726838832ab7914bbc14dcfe42