### PR TITLE
Add Anthropic model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ The ``scripts`` directory includes tools that rely on the OpenAI API.  These
 require the ``openai`` package, which is installed when running ``pip install
 -r requirements.txt``.  Before using these scripts you must set the
 ``OPENAI_API_KEY`` environment variable so that the client can authenticate.
+Support for the Anthropic API is also available.  Install the ``anthropic``
+package and set ``ANTHROPIC_API_KEY`` to use models such as
+``claude-3-sonnet-20240229`` or ``claude-3-opus-20240229``.
 
 ``scripts/evaluate_random_combat_scenarios.py`` contacts the model to
 evaluate blocking assignments for randomly generated combat scenarios.  A
@@ -131,6 +134,16 @@ typical invocation looks like this:
 OPENAI_API_KEY=<your-key> \
     python scripts/evaluate_random_combat_scenarios.py -n 3 \
     --cards data/cards.json
+```
+
+To use an Anthropic model instead, set ``ANTHROPIC_API_KEY`` and pass the
+``--model`` option.  For example:
+
+```bash
+ANTHROPIC_API_KEY=<your-key> \
+    python scripts/evaluate_random_combat_scenarios.py -n 3 \
+    --cards data/cards.json \
+    --model claude-3-sonnet-20240229
 ```
 
 The script will generate scenarios, send them to the model and print the

--- a/llms/llm.py
+++ b/llms/llm.py
@@ -1,6 +1,7 @@
 import asyncio
 from typing import Optional
 
+import anthropic
 import openai
 
 from .llm_cache import LLMCache
@@ -60,6 +61,76 @@ async def call_openai_model(
         semaphore = asyncio.Semaphore(concurrency) if concurrency else None
         tasks = [
             call_openai_model_single_prompt(
+                prompt,
+                client,
+                model=model,
+                temperature=temperature,
+                seed=seed,
+                cache=cache,
+                semaphore=semaphore,
+            )
+            for prompt in prompts
+        ]
+        responses = await asyncio.gather(*tasks)
+        return list(responses)
+    finally:
+        await client.close()
+
+
+async def call_anthropic_model_single_prompt(
+    prompt: str,
+    client: anthropic.AsyncAnthropic,
+    *,
+    model: str = "claude-3-sonnet-20240229",
+    temperature: float = 0.2,
+    seed: int = 0,
+    cache: Optional[LLMCache] = None,
+    semaphore: Optional[asyncio.Semaphore] = None,
+) -> str:
+    """Return ``prompt`` response from Anthropic, optionally using ``cache``."""
+    cached = None
+    if cache is not None:
+        cached = cache.get(prompt, model, seed, temperature)
+    if cached is not None:
+        short = prompt.splitlines()[0][:30]
+        print(f"Using cached LLM response for: {short}...")
+        return cached
+
+    async def _create():
+        return await client.messages.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=temperature,
+            max_tokens=1024,
+        )
+
+    if semaphore is None:
+        response = await _create()
+    else:
+        async with semaphore:
+            response = await _create()
+
+    text = "".join(block.text for block in response.content).strip()
+    if cache is not None:
+        cache.add(prompt, model, seed, temperature, text)
+    return text
+
+
+async def call_anthropic_model(
+    prompts: list[str],
+    *,
+    model: str = "claude-3-sonnet-20240229",
+    temperature: float = 0.2,
+    seed: int = 0,
+    cache: Optional[LLMCache] = None,
+    concurrency: int | None = None,
+) -> list[str]:
+    """Return responses for ``prompts`` using Anthropic models."""
+    client = anthropic.AsyncAnthropic()
+    try:
+        semaphore = asyncio.Semaphore(concurrency) if concurrency else None
+        tasks = [
+            call_anthropic_model_single_prompt(
                 prompt,
                 client,
                 model=model,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "requests==2.31.0",
     "numpy>=1.26,<2",
     "openai==1.79.0",
+    "anthropic==0.25.0",
     "autoflake==2.1.1",
     "flake8==7.3.0",
     "flake8-import-order==0.19.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ pytest==7.4.0
 requests==2.31.0
 numpy>=1.26,<2
 openai==1.79.0
+anthropic==0.25.0
 autoflake==2.1.1
 flake8==7.3.0
 flake8-import-order==0.19.2

--- a/scripts/evaluate_llm_accuracy.py
+++ b/scripts/evaluate_llm_accuracy.py
@@ -8,6 +8,7 @@ from typing import Optional
 from typing import cast
 
 from llms.create_llm_prompt import parse_block_assignments
+from llms.llm import call_anthropic_model
 from llms.llm import call_openai_model
 from llms.llm_cache import LLMCache
 from magic_combat.dataset import ReferenceAnswer
@@ -32,7 +33,8 @@ async def evaluate_dataset(
             items.append(json.loads(line))
 
     prompts = [cast(str, item["prompt"]) for item in items]
-    responses = await call_openai_model(
+    call = call_anthropic_model if model.startswith("claude") else call_openai_model
+    responses = await call(
         prompts,
         model=model,
         temperature=temperature,

--- a/tests/llm/test_anthropic_llm.py
+++ b/tests/llm/test_anthropic_llm.py
@@ -1,0 +1,89 @@
+"""Tests for the Anthropic LLM helper functions."""
+
+import asyncio
+
+from llms.llm import call_anthropic_model
+from llms.llm_cache import LLMCache
+from llms.llm_cache import MockLLMCache
+
+
+class DummyBlock:
+    def __init__(self, text: str):
+        self.text = text
+
+
+class DummyResponse:
+    def __init__(self, content: str):
+        self.content = [DummyBlock(content)]
+
+
+class DummyMessages:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def create(self, model, messages, temperature=0.0, max_tokens=0):
+        self.calls += 1
+        prompt = messages[0]["content"]
+        return DummyResponse(f"response to {prompt}")
+
+
+class DummyClient:
+    def __init__(self) -> None:
+        self.messages = DummyMessages()
+
+    async def close(self) -> None:
+        pass
+
+
+def test_call_anthropic_model(monkeypatch):
+    monkeypatch.setattr("anthropic.AsyncAnthropic", lambda: DummyClient())
+    res = asyncio.run(call_anthropic_model(["p1", "p2"]))
+    assert res == ["response to p1", "response to p2"]
+
+
+def test_anthropic_cache_hit(monkeypatch):
+    monkeypatch.setattr("anthropic.AsyncAnthropic", lambda: DummyClient())
+    cache = MockLLMCache()
+    res1 = asyncio.run(
+        call_anthropic_model(["p1"], model="m", temperature=0.3, seed=1, cache=cache)
+    )
+    res2 = asyncio.run(
+        call_anthropic_model(["p1"], model="m", temperature=0.3, seed=1, cache=cache)
+    )
+    assert res1 == res2
+    assert cache.entries[0]["response"] == res1[0]
+    assert len(cache.entries) == 1
+
+
+def test_anthropic_cache_miss(monkeypatch):
+    monkeypatch.setattr("anthropic.AsyncAnthropic", lambda: DummyClient())
+    cache = MockLLMCache()
+    asyncio.run(
+        call_anthropic_model(["p1"], model="m", temperature=0.3, seed=1, cache=cache)
+    )
+    asyncio.run(
+        call_anthropic_model(["p1"], model="m2", temperature=0.3, seed=1, cache=cache)
+    )
+    asyncio.run(
+        call_anthropic_model(["p1"], model="m", temperature=0.4, seed=1, cache=cache)
+    )
+    asyncio.run(
+        call_anthropic_model(["p1"], model="m", temperature=0.3, seed=2, cache=cache)
+    )
+    assert len(cache.entries) == 4
+
+
+def test_anthropic_cache_file_hit(monkeypatch, tmp_path):
+    dummy = DummyClient()
+    monkeypatch.setattr("anthropic.AsyncAnthropic", lambda: dummy)
+    cache_path = tmp_path / "cache.jsonl"
+    cache = LLMCache(str(cache_path))
+    res1 = asyncio.run(
+        call_anthropic_model(["p1"], model="m", temperature=0.3, seed=1, cache=cache)
+    )
+    cache2 = LLMCache(str(cache_path))
+    res2 = asyncio.run(
+        call_anthropic_model(["p1"], model="m", temperature=0.3, seed=1, cache=cache2)
+    )
+    assert res1 == res2
+    assert dummy.messages.calls == 1


### PR DESCRIPTION
## Summary
- support Anthropic models in the LLM helpers
- allow the evaluation scripts to call Anthropic or OpenAI based on the model name
- document Anthropic usage in the README
- add tests for the Anthropic LLM helper
- include `anthropic` library in dependencies

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866d1726838832ab7914bbc14dcfe42