### PR TITLE
Add Gemini model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,17 @@ OPENAI_API_KEY=<your-key> \
 
 The script will generate scenarios, send them to the model and print the
 results to the console.
+
+## Using Gemini models
+
+The :mod:`llms.llm` module also supports Google's Gemini family of models.
+Install the ``google-genai`` package and set the ``GOOGLE_API_KEY``
+environment variable before querying a Gemini model.
+
+```bash
+GOOGLE_API_KEY=<your-key> python - <<'PY'
+import asyncio
+from llms.llm import call_gemini_model
+print(asyncio.run(call_gemini_model(["hello"])))
+PY
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "types-requests==2.28.11.17",
     "pyright==1.1.402",
     "pydantic==2.7.1",
+    "google-genai==1.24.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ typing_extensions==4.13.1
 types-requests==2.28.11.17
 pyright==1.1.402
 pydantic==2.7.1
+google-genai==1.24.0


### PR DESCRIPTION
## Summary
- integrate `google-genai` and implement `call_gemini_model`
- document Gemini usage in README
- update dependencies for Gemini
- extend tests to cover Gemini LLM

## Testing
- `isort --profile black --check-only magic_combat scripts tests llms`
- `black --check magic_combat scripts tests llms`
- `flake8 magic_combat scripts tests`
- `pycodestyle --max-line-length=88 --ignore=E203,W503,E226 --exclude=comprehensive_rules.py,tests,magic_combat/rules_text.py magic_combat scripts`
- `autoflake --check --recursive magic_combat scripts tests llms`
- `pylint magic_combat scripts tests llms` (no output)
- `mypy magic_combat scripts tests llms`
- `pyright magic_combat scripts tests llms` (with warnings only)
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866d1885cd0832aa2f16a736f755276