### PR TITLE
Handle unparsable outputs in evaluation script

### DIFF
--- a/scripts/evaluate_llm_accuracy.py
+++ b/scripts/evaluate_llm_accuracy.py
@@ -12,6 +12,7 @@ from llms.llm import call_anthropic_model
 from llms.llm import call_openai_model
 from llms.llm_cache import LLMCache
 from magic_combat.dataset import ReferenceAnswer
+from magic_combat.exceptions import UnparsableLLMOutputError
 
 
 async def evaluate_dataset(
@@ -49,7 +50,10 @@ async def evaluate_dataset(
         ref = ReferenceAnswer.model_validate(ref_data)
         blk_names = ref.blocks.keys()
         atk_names = ref.blocks.values()
-        parsed, _ = parse_block_assignments(response, blk_names, atk_names)
+        try:
+            parsed, _ = parse_block_assignments(response, blk_names, atk_names)
+        except UnparsableLLMOutputError:
+            continue
         pred = ReferenceAnswer(blocks=parsed)
         if pred == ref:
             correct += 1

--- a/tests/llm/test_llm_accuracy.py
+++ b/tests/llm/test_llm_accuracy.py
@@ -63,3 +63,21 @@ def test_evaluate_dataset(monkeypatch, tmp_path):
     )
     assert acc == 1.0
     assert len(cache.entries) == 2
+
+
+def test_evaluate_dataset_unparsable(monkeypatch, tmp_path):
+    data_path = tmp_path / "data.jsonl"
+    items = [
+        {"prompt": "p1", "answer": {"blocks": {"B": "A"}}},
+        {"prompt": "p2", "answer": {"blocks": {}}},
+    ]
+    with data_path.open("w", encoding="utf8") as fh:
+        for item in items:
+            fh.write(json.dumps(item) + "\n")
+    responses = ["- B -> A", "gibberish"]
+    monkeypatch.setattr("openai.AsyncOpenAI", lambda: DummyClient(responses))
+    cache = MockLLMCache()
+    acc = asyncio.run(
+        evaluate_dataset(str(data_path), model="m", concurrency=2, cache=cache)
+    )
+    assert acc == 0.5


### PR DESCRIPTION
## Summary
- avoid crashing on unparsable LLM answers in `evaluate_dataset`
- test accuracy evaluation when the model response can't be parsed

## Testing
- `pytest tests/llm/test_llm_accuracy.py::test_evaluate_dataset_unparsable -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686745ca0d5c832aafacd8733afea6cf