### PR TITLE
Fix evaluation accuracy for unparsable answers

### DIFF
--- a/scripts/evaluate_llm_accuracy.py
+++ b/scripts/evaluate_llm_accuracy.py
@@ -84,6 +84,7 @@ async def evaluate_dataset(
         try:
             parsed, _ = parse_block_assignments(response, blk_names, atk_names)
         except UnparsableLLMOutputError:
+            results.append(False)
             continue
         pred = ReferenceAnswer(blocks=parsed)
         results.append(pred == ref)

--- a/tests/llm/test_llm_accuracy.py
+++ b/tests/llm/test_llm_accuracy.py
@@ -64,6 +64,7 @@ def test_evaluate_dataset(monkeypatch, tmp_path):
     assert acc == 1.0
     assert len(cache.entries) == 2
 
+
 def test_evaluate_dataset_return_results(monkeypatch, tmp_path):
     data_path = tmp_path / "data.jsonl"
     items = [
@@ -84,6 +85,7 @@ def test_evaluate_dataset_return_results(monkeypatch, tmp_path):
         )
     )
     assert results == [True, True]
+
 
 def test_evaluate_dataset_unparsable(monkeypatch, tmp_path):
     data_path = tmp_path / "data.jsonl"


### PR DESCRIPTION
## Summary
- count unparsable model outputs as incorrect in accuracy evaluation
- keep test module formatting compliant with flake8

## Testing
- `flake8 magic_combat scripts tests`
- `pycodestyle --max-line-length=88 --ignore=E203,W503,E226 --exclude=comprehensive_rules.py,tests,magic_combat/rules_text.py magic_combat scripts`
- `autoflake --check --recursive magic_combat scripts tests`
- `pylint magic_combat scripts tests`
- `mypy magic_combat scripts tests`
- `pyright magic_combat scripts tests`
- `black --check magic_combat scripts tests`
- `isort --profile black --check-only magic_combat scripts tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68674c5ece20832ab9e1a943d6db3ebc