### PR TITLE
Add Gemini model support

### DIFF
--- a/llms/llm.py
+++ b/llms/llm.py
@@ -3,6 +3,8 @@ from typing import Optional
 
 import anthropic
 import openai
+from google import genai
+from google.genai import types as genai_types
 
 from .llm_cache import LLMCache
 
@@ -75,6 +77,71 @@ async def call_openai_model(
         return list(responses)
     finally:
         await client.close()
+
+
+async def call_gemini_model_single_prompt(
+    prompt: str,
+    *,
+    model: str = "gemini-pro",
+    temperature: float = 0.2,
+    seed: int = 0,
+    cache: Optional[LLMCache] = None,
+    semaphore: Optional[asyncio.Semaphore] = None,
+) -> str:
+    """Return ``prompt`` response from Gemini, optionally using ``cache``."""
+    cached = None
+    if cache is not None:
+        cached = cache.get(prompt, model, seed, temperature)
+    if cached is not None:
+        short = prompt.splitlines()[0][:30]
+        print(f"Using cached LLM response for: {short}...")
+        return cached
+
+    client = genai.Client()
+    generation_config = genai_types.GenerateContentConfig(
+        temperature=temperature, seed=seed
+    )
+
+    async def _call() -> str:
+        response = await client.aio.models.generate_content(
+            model=model, contents=prompt, config=generation_config
+        )
+        return (response.text or "").strip()
+
+    if semaphore is None:
+        text = await _call()
+    else:
+        async with semaphore:
+            text = await _call()
+    if cache is not None:
+        cache.add(prompt, model, seed, temperature, text)
+    return text
+
+
+async def call_gemini_model(
+    prompts: list[str],
+    *,
+    model: str = "gemini-pro",
+    temperature: float = 0.2,
+    seed: int = 0,
+    cache: Optional[LLMCache] = None,
+    concurrency: int | None = None,
+) -> list[str]:
+    """Return responses for ``prompts`` using Gemini."""
+    semaphore = asyncio.Semaphore(concurrency) if concurrency else None
+    tasks = [
+        call_gemini_model_single_prompt(
+            prompt,
+            model=model,
+            temperature=temperature,
+            seed=seed,
+            cache=cache,
+            semaphore=semaphore,
+        )
+        for prompt in prompts
+    ]
+    responses = await asyncio.gather(*tasks)
+    return list(responses)
 
 
 async def call_anthropic_model_single_prompt(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "types-requests==2.28.11.17",
     "pyright==1.1.402",
     "pydantic==2.7.1",
+    "google-genai==1.24.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ typing_extensions==4.13.1
 types-requests==2.28.11.17
 pyright==1.1.402
 pydantic==2.7.1
+google-genai==1.24.0

--- a/scripts/evaluate_llm_accuracy.py
+++ b/scripts/evaluate_llm_accuracy.py
@@ -84,6 +84,7 @@ async def evaluate_dataset(
         try:
             parsed, _ = parse_block_assignments(response, blk_names, atk_names)
         except UnparsableLLMOutputError:
+            results.append(False)
             continue
         pred = ReferenceAnswer(blocks=parsed)
         results.append(pred == ref)

--- a/tests/llm/test_gemini_llm.py
+++ b/tests/llm/test_gemini_llm.py
@@ -1,0 +1,83 @@
+import asyncio
+
+from llms.llm import call_gemini_model
+from llms.llm_cache import LLMCache
+from llms.llm_cache import MockLLMCache
+
+
+class DummyResponse:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+class DummyModels:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def generate_content(self, model, contents, config=None):
+        self.calls += 1
+        return DummyResponse(f"response to {contents}")
+
+
+class DummyAio:
+    def __init__(self) -> None:
+        self.models = DummyModels()
+
+
+class DummyClient:
+    def __init__(self) -> None:
+        self.aio = DummyAio()
+
+
+def test_call_gemini_model(monkeypatch):
+    monkeypatch.setattr("google.genai.Client", lambda: DummyClient())
+    res = asyncio.run(call_gemini_model(["p1", "p2"]))
+    assert res == ["response to p1", "response to p2"]
+
+
+def test_gemini_cache_hit(monkeypatch):
+    monkeypatch.setattr("google.genai.Client", lambda: DummyClient())
+    cache = MockLLMCache()
+    res1 = asyncio.run(
+        call_gemini_model(["p1"], model="m", temperature=0.3, seed=1, cache=cache)
+    )
+    res2 = asyncio.run(
+        call_gemini_model(["p1"], model="m", temperature=0.3, seed=1, cache=cache)
+    )
+    assert res1 == res2
+    assert cache.entries[0]["response"] == res1[0]
+    assert len(cache.entries) == 1
+
+
+def test_gemini_cache_miss(monkeypatch):
+    monkeypatch.setattr("google.genai.Client", lambda: DummyClient())
+    cache = MockLLMCache()
+    asyncio.run(
+        call_gemini_model(["p1"], model="m", temperature=0.3, seed=1, cache=cache)
+    )
+    asyncio.run(
+        call_gemini_model(["p1"], model="m2", temperature=0.3, seed=1, cache=cache)
+    )
+    asyncio.run(
+        call_gemini_model(["p1"], model="m", temperature=0.4, seed=1, cache=cache)
+    )
+    asyncio.run(
+        call_gemini_model(["p1"], model="m", temperature=0.3, seed=2, cache=cache)
+    )
+    assert len(cache.entries) == 4
+
+
+def test_gemini_cache_file_hit(monkeypatch, tmp_path):
+    dummy = DummyClient()
+    monkeypatch.setattr("google.genai.Client", lambda: dummy)
+    cache_path = tmp_path / "cache.jsonl"
+    cache = LLMCache(str(cache_path))
+    res1 = asyncio.run(
+        call_gemini_model(["p1"], model="m", temperature=0.3, seed=1, cache=cache)
+    )
+    cache2 = LLMCache(str(cache_path))
+    res2 = asyncio.run(
+        call_gemini_model(["p1"], model="m", temperature=0.3, seed=1, cache=cache2)
+    )
+    assert res1 == res2
+    assert dummy.aio.models.calls == 1

--- a/tests/llm/test_llm_accuracy.py
+++ b/tests/llm/test_llm_accuracy.py
@@ -64,6 +64,7 @@ def test_evaluate_dataset(monkeypatch, tmp_path):
     assert acc == 1.0
     assert len(cache.entries) == 2
 
+
 def test_evaluate_dataset_return_results(monkeypatch, tmp_path):
     data_path = tmp_path / "data.jsonl"
     items = [
@@ -84,6 +85,7 @@ def test_evaluate_dataset_return_results(monkeypatch, tmp_path):
         )
     )
     assert results == [True, True]
+
 
 def test_evaluate_dataset_unparsable(monkeypatch, tmp_path):
     data_path = tmp_path / "data.jsonl"


### PR DESCRIPTION
## Summary
- implement Gemini model helpers via google.genai
- support unparsable dataset results in accuracy script
- add google-genai to dependencies
- test Gemini LLM caching behavior
- fix formatting in existing tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68674c50ecfc832a90a506d444c7111c