### PR TITLE
Fix LLM tests with test model enums

### DIFF
--- a/llms/llm.py
+++ b/llms/llm.py
@@ -24,6 +24,9 @@ class LanguageModelName(Enum):
     CLAUDE_3_7_OPUS = "claude-3-opus-20240229"
     CLAUDE_4_SONNET = "claude-3-sonnet-20240229"
     CLAUDE_4_OPUS = "claude-4-opus-20240229"
+    TEST_M = "m"
+    TEST_M1 = "m1"
+    TEST_M2 = "m2"
 
 
 def get_default_temperature(model: LanguageModelName) -> float:
@@ -154,7 +157,7 @@ async def call_gemini_model_single_prompt(
 
     async def _call() -> str:
         response = await client.aio.models.generate_content(
-            model=model, contents=prompt, config=generation_config
+            model=model.value, contents=prompt, config=generation_config
         )
         return (response.text or "").strip()
 
@@ -207,7 +210,7 @@ async def call_anthropic_model_single_prompt(
 
     async def _create() -> str:
         response = await client.messages.create(
-            model=model,
+            model=model.value,
             messages=[{"role": "user", "content": prompt}],
             temperature=temperature,
             max_tokens=1024,
@@ -266,4 +269,7 @@ CALL_METHOD_BY_MODEL = {
     LanguageModelName.CLAUDE_3_7_OPUS: call_anthropic_model,
     LanguageModelName.CLAUDE_4_SONNET: call_anthropic_model,
     LanguageModelName.CLAUDE_4_OPUS: call_anthropic_model,
+    LanguageModelName.TEST_M: call_openai_model,
+    LanguageModelName.TEST_M1: call_openai_model,
+    LanguageModelName.TEST_M2: call_openai_model,
 }

--- a/scripts/leaderboard.py
+++ b/scripts/leaderboard.py
@@ -7,7 +7,6 @@ import argparse
 import asyncio
 import math
 from pathlib import Path
-from typing import Iterable
 from typing import Optional
 from typing import Sequence
 
@@ -54,14 +53,17 @@ def two_proportion_p_value(results1: Sequence[bool], results2: Sequence[bool]) -
 
 async def evaluate_models(
     dataset: str,
+    models: Sequence[LanguageModelName] | None = None,
     *,
     seed: int = 0,
     concurrency: int = 20,
     cache: Optional[LLMCache] = None,
 ) -> dict[LanguageModelName, list[bool]]:
     """Return per-item correctness for each model in ``models``."""
+    if models is None:
+        models = list(LanguageModelName)
     results: dict[LanguageModelName, list[bool]] = {}
-    for model in LanguageModelName:
+    for model in models:
         item_results = await evaluate_dataset(
             dataset,
             model=model,
@@ -98,7 +100,7 @@ async def run_leaderboard(args: argparse.Namespace) -> None:
     print("\nPairwise p-values:")
     print("\t" + "\t".join(m.value for m in models))
     for m1 in models:
-        row = [m1]
+        row = [m1.value]
         for m2 in models:
             if m1 == m2:
                 row.append("-")

--- a/tests/llm/test_leaderboard.py
+++ b/tests/llm/test_leaderboard.py
@@ -2,6 +2,7 @@
 
 import asyncio
 
+from llms.llm import LanguageModelName
 from scripts.leaderboard import count_items
 from scripts.leaderboard import evaluate_models
 from scripts.leaderboard import standard_error
@@ -25,11 +26,24 @@ def test_two_proportion_p_value():
     assert p < 0.05
 
 
-async def dummy_evaluate_dataset(path: str, *, model: str = "", **kwargs) -> list[bool]:
-    return {"m1": [True, False], "m2": [True, True]}[model]
+async def dummy_evaluate_dataset(
+    path: str, *, model: LanguageModelName = LanguageModelName.TEST_M1, **kwargs
+) -> list[bool]:
+    return {
+        LanguageModelName.TEST_M1: [True, False],
+        LanguageModelName.TEST_M2: [True, True],
+    }[model]
 
 
 def test_evaluate_models(monkeypatch):
     monkeypatch.setattr("scripts.leaderboard.evaluate_dataset", dummy_evaluate_dataset)
-    res = asyncio.run(evaluate_models("d.jsonl", ["m1", "m2"]))
-    assert res == {"m1": [True, False], "m2": [True, True]}
+    res = asyncio.run(
+        evaluate_models(
+            "d.jsonl",
+            [LanguageModelName.TEST_M1, LanguageModelName.TEST_M2],
+        )
+    )
+    assert res == {
+        LanguageModelName.TEST_M1: [True, False],
+        LanguageModelName.TEST_M2: [True, True],
+    }

--- a/tests/llm/test_llm_accuracy.py
+++ b/tests/llm/test_llm_accuracy.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 
+from llms.llm import LanguageModelName
 from llms.llm_cache import MockLLMCache
 from scripts.evaluate_llm_accuracy import evaluate_dataset
 
@@ -59,7 +60,9 @@ def test_evaluate_dataset(monkeypatch, tmp_path):
     monkeypatch.setattr("openai.AsyncOpenAI", lambda: DummyClient(responses))
     cache = MockLLMCache()
     acc = asyncio.run(
-        evaluate_dataset(str(data_path), model="m", concurrency=2, cache=cache)
+        evaluate_dataset(
+            str(data_path), model=LanguageModelName.TEST_M, concurrency=2, cache=cache
+        )
     )
     assert acc == 1.0
     assert len(cache.entries) == 2
@@ -79,7 +82,7 @@ def test_evaluate_dataset_return_results(monkeypatch, tmp_path):
     results = asyncio.run(
         evaluate_dataset(
             str(data_path),
-            model="m",
+            model=LanguageModelName.TEST_M,
             concurrency=2,
             return_item_results=True,
         )
@@ -101,6 +104,8 @@ def test_evaluate_dataset_unparsable(monkeypatch, tmp_path):
     monkeypatch.setattr("openai.AsyncOpenAI", lambda: DummyClient(responses))
     cache = MockLLMCache()
     acc = asyncio.run(
-        evaluate_dataset(str(data_path), model="m", concurrency=2, cache=cache)
+        evaluate_dataset(
+            str(data_path), model=LanguageModelName.TEST_M, concurrency=2, cache=cache
+        )
     )
     assert acc == 0.5

--- a/tests/llm/test_llm_models.py
+++ b/tests/llm/test_llm_models.py
@@ -3,6 +3,7 @@ from typing import Callable
 
 import pytest
 
+from llms.llm import LanguageModelName
 from llms.llm import call_anthropic_model
 from llms.llm import call_gemini_model
 from llms.llm import call_openai_model
@@ -137,8 +138,16 @@ def test_llm_cache_hit(
     dummy = client_cls()
     monkeypatch.setattr(patch_target, lambda: dummy)
     cache = MockLLMCache()
-    res1 = asyncio.run(call_fn(["p1"], model="m", temperature=0.3, seed=1, cache=cache))
-    res2 = asyncio.run(call_fn(["p1"], model="m", temperature=0.3, seed=1, cache=cache))
+    res1 = asyncio.run(
+        call_fn(
+            ["p1"], model=LanguageModelName.TEST_M, temperature=0.3, seed=1, cache=cache
+        )
+    )
+    res2 = asyncio.run(
+        call_fn(
+            ["p1"], model=LanguageModelName.TEST_M, temperature=0.3, seed=1, cache=cache
+        )
+    )
     assert res1 == res2
     assert dummy.calls == 1
     assert len(cache.entries) == 1
@@ -158,10 +167,30 @@ def test_llm_cache_miss(
     dummy = client_cls()
     monkeypatch.setattr(patch_target, lambda: dummy)
     cache = MockLLMCache()
-    asyncio.run(call_fn(["p1"], model="m", temperature=0.3, seed=1, cache=cache))
-    asyncio.run(call_fn(["p1"], model="m2", temperature=0.3, seed=1, cache=cache))
-    asyncio.run(call_fn(["p1"], model="m", temperature=0.4, seed=1, cache=cache))
-    asyncio.run(call_fn(["p1"], model="m", temperature=0.3, seed=2, cache=cache))
+    asyncio.run(
+        call_fn(
+            ["p1"], model=LanguageModelName.TEST_M, temperature=0.3, seed=1, cache=cache
+        )
+    )
+    asyncio.run(
+        call_fn(
+            ["p1"],
+            model=LanguageModelName.TEST_M2,
+            temperature=0.3,
+            seed=1,
+            cache=cache,
+        )
+    )
+    asyncio.run(
+        call_fn(
+            ["p1"], model=LanguageModelName.TEST_M, temperature=0.4, seed=1, cache=cache
+        )
+    )
+    asyncio.run(
+        call_fn(
+            ["p1"], model=LanguageModelName.TEST_M, temperature=0.3, seed=2, cache=cache
+        )
+    )
     assert dummy.calls == 4
     assert len(cache.entries) == 4
 
@@ -181,10 +210,20 @@ def test_llm_cache_file_hit(
     monkeypatch.setattr(patch_target, lambda: dummy)
     cache_path = tmp_path / "cache.jsonl"
     cache = LLMCache(str(cache_path))
-    res1 = asyncio.run(call_fn(["p1"], model="m", temperature=0.3, seed=1, cache=cache))
+    res1 = asyncio.run(
+        call_fn(
+            ["p1"], model=LanguageModelName.TEST_M, temperature=0.3, seed=1, cache=cache
+        )
+    )
     cache2 = LLMCache(str(cache_path))
     res2 = asyncio.run(
-        call_fn(["p1"], model="m", temperature=0.3, seed=1, cache=cache2)
+        call_fn(
+            ["p1"],
+            model=LanguageModelName.TEST_M,
+            temperature=0.3,
+            seed=1,
+            cache=cache2,
+        )
     )
     assert res1 == res2
     assert dummy.calls == 1


### PR DESCRIPTION
## Summary
- add `TEST_M`, `TEST_M1` and `TEST_M2` options to `LanguageModelName`
- map the new enum values in `CALL_METHOD_BY_MODEL`
- fix gemini and anthropic calls to pass `model.value`
- update leaderboard helper to accept an optional list of models
- remove unused imports and print enums correctly in leaderboard
- update LLM tests to use the new enum values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686759224500832ab379250e52b6ed3a