### PR TITLE
Improve leaderboard formatting

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,5 @@ types-requests==2.28.11.17
 pyright==1.1.402
 pydantic==2.7.1
 google-genai==1.24.0
+tabulate==0.9.0
+types-tabulate==0.9.0.20241207

--- a/tests/llm/test_leaderboard.py
+++ b/tests/llm/test_leaderboard.py
@@ -5,6 +5,8 @@ import asyncio
 from llms.llm import LanguageModelName
 from scripts.leaderboard import count_items
 from scripts.leaderboard import evaluate_models
+from scripts.leaderboard import format_accuracy_table
+from scripts.leaderboard import format_pvalue_table
 from scripts.leaderboard import standard_error
 from scripts.leaderboard import two_proportion_p_value
 
@@ -47,3 +49,21 @@ def test_evaluate_models(monkeypatch):
         LanguageModelName.TEST_M1: [True, False],
         LanguageModelName.TEST_M2: [True, True],
     }
+
+
+def test_format_accuracy_table():
+    res = {
+        LanguageModelName.TEST_M1: [True, False],
+        LanguageModelName.TEST_M2: [True, True],
+    }
+    table = format_accuracy_table(res, 2)
+    assert "Model" in table and "Accuracy" in table
+
+
+def test_format_pvalue_table():
+    res = {
+        LanguageModelName.TEST_M1: [True, False],
+        LanguageModelName.TEST_M2: [True, True],
+    }
+    table = format_pvalue_table(res)
+    assert LanguageModelName.TEST_M1.value in table


### PR DESCRIPTION
## Summary
- make leaderboard output easier to read with `tabulate`
- expose helper functions for formatted accuracy and p-value tables
- test new helper functions
- add `tabulate` and `types-tabulate` to requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68675e5f1b64832a8641e462f0294c06