### PR TITLE
Fix anthropic dependency issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ require the ``openai`` package, which is installed when running ``pip install
 -r requirements.txt``.  Before using these scripts you must set the
 ``OPENAI_API_KEY`` environment variable so that the client can authenticate.
 Support for the Anthropic API is also available.  Install the ``anthropic``
-package and set ``ANTHROPIC_API_KEY`` to use models such as
+package (version ``0.57.1`` or newer) and set ``ANTHROPIC_API_KEY`` to use models such as
 ``claude-3-sonnet-20240229`` or ``claude-3-opus-20240229``.
 
 ``scripts/evaluate_random_combat_scenarios.py`` contacts the model to

--- a/llms/llm.py
+++ b/llms/llm.py
@@ -51,7 +51,9 @@ async def _call_model_cached(
     cached = cache.get(prompt, model.value, seed, temperature) if cache else None
     if cached is not None:
         short = prompt.splitlines()[0][:30]
-        print(f"Using cached LLM response for: {short}, {model.value}, seed={seed}, temperature={temperature}")
+        print(
+            f"Using cached LLM response for: {short}, {model.value}, seed={seed}, temperature={temperature}"
+        )
         return cached
 
     async def _run() -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "requests==2.31.0",
     "numpy>=1.26,<2",
     "openai==1.79.0",
-    "anthropic==0.25.0",
+    "anthropic==0.57.1",
     "autoflake==2.1.1",
     "flake8==7.3.0",
     "flake8-import-order==0.19.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pytest==7.4.0
 requests==2.31.0
 numpy>=1.26,<2
 openai==1.79.0
-anthropic==0.25.0
+anthropic==0.57.1
 autoflake==2.1.1
 flake8==7.3.0
 flake8-import-order==0.19.2


### PR DESCRIPTION
## Summary
- bump `anthropic` to v0.57.1
- document minimum anthropic version in README
- format llm module with black

## Testing
- `isort --profile black .`
- `black .`
- `autoflake --check --recursive magic_combat scripts llms tests`
- `flake8 magic_combat llms scripts tests`
- `pycodestyle --max-line-length=88 --ignore=E203,W503,E226 --exclude=comprehensive_rules.py,tests,magic_combat/rules_text.py magic_combat scripts`
- `pylint magic_combat llms scripts tests`
- `mypy magic_combat llms scripts tests`
- `pyright magic_combat llms scripts tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68675e3e3a68832abbaec21eac335cd4