### PR TITLE
Add retry handling for LLM output parsing

### DIFF
--- a/llms/llm.py
+++ b/llms/llm.py
@@ -32,7 +32,11 @@ class LanguageModelName(Enum):
 
 def get_default_temperature(model: LanguageModelName) -> float:
     """Return the default temperature for the given model."""
-    if model in {LanguageModelName.O3_PRO, LanguageModelName.O3, LanguageModelName.O4_MINI}:
+    if model in {
+        LanguageModelName.O3_PRO,
+        LanguageModelName.O3,
+        LanguageModelName.O4_MINI,
+    }:
         return 1.0
     return 0.2
 
@@ -218,7 +222,7 @@ async def call_anthropic_model_single_prompt(
             temperature=temperature,
             max_tokens=1024,
         )
-        return "".join(block.text for block in response.content).strip()
+        return "".join(getattr(block, "text", "") for block in response.content).strip()
 
     return await _call_model_cached(
         prompt,

--- a/scripts/evaluate_llm_accuracy.py
+++ b/scripts/evaluate_llm_accuracy.py
@@ -82,14 +82,48 @@ async def evaluate_dataset(
         return 0.0 if not return_item_results else []
 
     results: list[bool] = []
-    for item, response in zip(items, responses):
+    for idx, (item, response) in enumerate(zip(items, responses)):
         ref_data = cast(dict[str, str], item["answer"])
         ref = ReferenceAnswer.model_validate(ref_data)
         blk_names = ref.blocks.keys()
         atk_names = ref.blocks.values()
-        try:
-            parsed, _ = parse_block_assignments(response, blk_names, atk_names)
-        except UnparsableLLMOutputError:
+
+        attempts = 0
+        max_attempts = 3
+        while True:
+            try:
+                parsed, _ = parse_block_assignments(response, blk_names, atk_names)
+                break
+            except UnparsableLLMOutputError:
+                attempts += 1
+                if attempts >= max_attempts:
+                    print(
+                        "Warning: unparseable response for item "
+                        f"{idx}; giving up after {max_attempts} attempts"
+                    )
+                    parsed = None
+                    break
+                print(
+                    "Warning: unparseable response for item "
+                    f"{idx}; retrying with new seed"
+                )
+                try:
+                    response = (
+                        await call(
+                            [prompts[idx]],
+                            model=model,
+                            temperature=temperature,
+                            seed=seed + attempts,
+                            cache=cache,
+                            concurrency=concurrency,
+                        )
+                    )[0]
+                except Exception as e:
+                    print(f"Error calling model {model}: {e}")
+                    parsed = None
+                    break
+
+        if parsed is None:
             results.append(False)
             continue
         pred = ReferenceAnswer(blocks=parsed)

--- a/tests/llm/test_llm_accuracy.py
+++ b/tests/llm/test_llm_accuracy.py
@@ -100,7 +100,7 @@ def test_evaluate_dataset_unparsable(monkeypatch, tmp_path):
         for item in items:
             fh.write(json.dumps(item) + "\n")
 
-    responses = ["- B -> A", "gibberish"]
+    responses = ["- B -> A", "gibberish", "None"]
     monkeypatch.setattr("openai.AsyncOpenAI", lambda: DummyClient(responses))
     cache = MockLLMCache()
     acc = asyncio.run(
@@ -108,4 +108,4 @@ def test_evaluate_dataset_unparsable(monkeypatch, tmp_path):
             str(data_path), model=LanguageModelName.TEST_M, concurrency=2, cache=cache
         )
     )
-    assert acc == 0.5
+    assert acc == 1.0


### PR DESCRIPTION
## Summary
- retry unparseable responses in `evaluate_dataset`
- handle Anthropic block content safely
- update tests for retry behavior

## Testing
- `pytest -q`
- `pytest tests/test_style.py::test_pycodestyle -q`
- `pytest tests/test_style.py::test_mypy -q`


------
https://chatgpt.com/codex/tasks/task_e_68676b464f68832aa4398ad1014cd096