### PR TITLE
Add responses stub to DummyOpenAIClient

### DIFF
--- a/tests/llm/test_llm_models.py
+++ b/tests/llm/test_llm_models.py
@@ -46,6 +46,13 @@ class DummyOpenAIClient:
                 "create": self._completion_create,
             },
         )()
+        self.responses = type(
+            "Responses",
+            (),
+            {
+                "create": self._response_create,
+            },
+        )()
 
     async def _chat_create(
         self, model: str, messages: list[dict[str, str]], temperature: float = 0.0
@@ -62,6 +69,14 @@ class DummyOpenAIClient:
         self.calls += 1
         return type(
             "R", (), {"choices": [DummyOpenAICompletionChoice(f"response to {prompt}")]}
+        )()
+
+    async def _response_create(self, model: str, input: str, temperature: float = 0.0):
+        self.calls += 1
+        return type(
+            "R",
+            (),
+            {"output_text": f"response to {input}"},
         )()
 
     async def close(self) -> None:


### PR DESCRIPTION
## Summary
- extend `DummyOpenAIClient` with a `responses.create` method

## Testing
- `black tests/llm/test_llm_models.py`
- `isort tests/llm/test_llm_models.py`
- `flake8 tests/llm/test_llm_models.py`
- `pycodestyle tests/llm/test_llm_models.py`
- `autoflake -i tests/llm/test_llm_models.py`
- `pylint tests/llm/test_llm_models.py`
- `mypy`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867f7208420832aa9ab33d8917a126e