### PR TITLE
Add comprehensive tests for LLM utilities

### DIFF
--- a/scripts/evaluate_llm_accuracy.py
+++ b/scripts/evaluate_llm_accuracy.py
@@ -89,10 +89,12 @@ async def evaluate_dataset(
                     )
                 parsed, _ = parse_block_assignments(response, blk_names, atk_names)
                 break
-            except UnparsableLLMOutputError as exc:
-                print(
-                    f"Unparseable response for model {model} on scenario {idx + 1}; retrying..."
+            except UnparsableLLMOutputError:
+                msg = (
+                    f"Unparseable response for model {model} "
+                    f"on scenario {idx + 1}; retrying..."
                 )
+                print(msg)
             except Exception as exc:  # pragma: no cover - network failure
                 print(f"Error calling model {model}: {exc}")
                 break

--- a/scripts/evaluate_random_combat_scenarios.py
+++ b/scripts/evaluate_random_combat_scenarios.py
@@ -104,9 +104,11 @@ async def _evaluate_single_scenario(
             if attempts > max_attempts:
                 print("Unparseable response; giving up")
                 break
-            print(
-                f"Unparseable response for model {model} on scenario {idx + 1}; retrying..."
+            msg = (
+                f"Unparseable response for model {model} "
+                f"on scenario {idx + 1}; retrying..."
             )
+            print(msg)
             continue
 
         if invalid:

--- a/tests/llm/test_block_parsing_bullets.py
+++ b/tests/llm/test_block_parsing_bullets.py
@@ -1,0 +1,36 @@
+from llms.create_llm_prompt import parse_block_assignments
+
+
+def test_dash_bullet_parsing():
+    text = "- Guard -> Goblin"
+    pairs, invalid = parse_block_assignments(text, ["Guard"], ["Goblin"])
+    assert pairs == {"Guard": "Goblin"}
+    assert not invalid
+
+
+def test_star_bullet_parsing():
+    text = "* Guard -> Goblin"
+    pairs, invalid = parse_block_assignments(text, ["Guard"], ["Goblin"])
+    assert pairs == {"Guard": "Goblin"}
+    assert not invalid
+
+
+def test_unicode_bullet_parsing():
+    text = "\u2022 Guard -> Goblin"
+    pairs, invalid = parse_block_assignments(text, ["Guard"], ["Goblin"])
+    assert pairs == {"Guard": "Goblin"}
+    assert not invalid
+
+
+def test_extra_spaces_handled():
+    text = " -  Guard  ->  Goblin  "
+    pairs, invalid = parse_block_assignments(text, ["Guard"], ["Goblin"])
+    assert pairs == {"Guard": "Goblin"}
+    assert not invalid
+
+
+def test_case_insensitive_no_blocks():
+    text = "No Blocks"
+    pairs, invalid = parse_block_assignments(text, ["Guard"], ["Goblin"])
+    assert pairs == {}
+    assert not invalid

--- a/tests/llm/test_block_parsing_errors.py
+++ b/tests/llm/test_block_parsing_errors.py
@@ -1,0 +1,30 @@
+import pytest
+
+from llms.create_llm_prompt import parse_block_assignments
+from magic_combat.exceptions import UnparsableLLMOutputError
+
+
+def test_no_assignment_lines_raises_error():
+    text = "Some random text\nAnother line"
+    with pytest.raises(UnparsableLLMOutputError):
+        parse_block_assignments(text, ["Guard"], ["Goblin"])
+
+
+def test_only_whitespace_raises_error():
+    text = "   \n \n"
+    with pytest.raises(UnparsableLLMOutputError):
+        parse_block_assignments(text, ["Guard"], ["Goblin"])
+
+
+def test_none_and_assignments_parsed():
+    text = "None\n- Guard -> Goblin"
+    pairs, invalid = parse_block_assignments(text, ["Guard"], ["Goblin"])
+    assert pairs == {"Guard": "Goblin"}
+    assert not invalid
+
+
+def test_extraneous_lines_ignored():
+    text = "Analysis\n- Guard -> Goblin"
+    pairs, invalid = parse_block_assignments(text, ["Guard"], ["Goblin"])
+    assert pairs == {"Guard": "Goblin"}
+    assert not invalid

--- a/tests/llm/test_block_parsing_invalid.py
+++ b/tests/llm/test_block_parsing_invalid.py
@@ -1,0 +1,31 @@
+from llms.create_llm_prompt import parse_block_assignments
+
+
+def test_duplicate_blocker_marked_invalid():
+    text = "- Guard -> Goblin\n- Guard -> Elf"
+    pairs, invalid = parse_block_assignments(
+        text, ["Guard", "Squire"], ["Goblin", "Elf"]
+    )
+    assert pairs == {"Guard": "Goblin"}
+    assert invalid
+
+
+def test_unknown_blocker_marked_invalid():
+    text = "- Foo -> Goblin"
+    pairs, invalid = parse_block_assignments(text, ["Guard"], ["Goblin"])
+    assert pairs == {}
+    assert invalid
+
+
+def test_unknown_attacker_marked_invalid():
+    text = "- Guard -> Foo"
+    pairs, invalid = parse_block_assignments(text, ["Guard"], ["Goblin"])
+    assert pairs == {}
+    assert invalid
+
+
+def test_case_mismatch_marked_invalid():
+    text = "- guard -> Goblin"
+    pairs, invalid = parse_block_assignments(text, ["Guard"], ["Goblin"])
+    assert pairs == {}
+    assert invalid

--- a/tests/llm/test_leaderboard_format.py
+++ b/tests/llm/test_leaderboard_format.py
@@ -1,0 +1,46 @@
+from llms.llm import LanguageModelName
+from scripts.leaderboard import count_items
+from scripts.leaderboard import format_accuracy_table
+from scripts.leaderboard import format_pvalue_table
+from scripts.leaderboard import standard_error
+from scripts.leaderboard import two_proportion_p_value
+
+
+def test_standard_error_zero_when_perfect():
+    assert standard_error(1.0, 10) == 0.0
+    assert standard_error(0.0, 10) == 0.0
+
+
+def test_format_accuracy_table_sorted():
+    res = {
+        LanguageModelName.GPT_4O: [True, True],
+        LanguageModelName.GPT_4_1: [True, False],
+    }
+    table = format_accuracy_table(res, 2)
+    first_line = table.splitlines()[2]
+    assert LanguageModelName.GPT_4O.value in first_line
+
+
+def test_two_proportion_p_value_symmetric():
+    r1 = [True, False, True]
+    r2 = [False, True, False]
+    p1 = two_proportion_p_value(r1, r2)
+    p2 = two_proportion_p_value(r2, r1)
+    assert abs(p1 - p2) < 1e-9
+
+
+def test_format_pvalue_table_diagonal():
+    res = {
+        LanguageModelName.GPT_4O: [True, False],
+        LanguageModelName.GPT_4_1: [False, True],
+    }
+    table = format_pvalue_table(res)
+    lines = table.splitlines()
+    cells = [c.strip() for c in lines[2].split("|") if c.strip()]
+    assert cells[1] == "-"
+
+
+def test_count_items_ignores_blank_lines(tmp_path):
+    path = tmp_path / "data.txt"
+    path.write_text("a\n\n\nb\n", encoding="utf8")
+    assert count_items(str(path)) == 2

--- a/tests/llm/test_leaderboard_run.py
+++ b/tests/llm/test_leaderboard_run.py
@@ -1,0 +1,108 @@
+import argparse
+import asyncio
+
+from llms.llm import LanguageModelName
+from llms.llm_cache import LLMCache
+from llms.llm_cache import MockLLMCache
+from scripts.leaderboard import evaluate_models
+from scripts.leaderboard import run_leaderboard
+
+
+def test_evaluate_models_default_models(monkeypatch):
+    calls = []
+
+    async def dummy(path: str, *, model: LanguageModelName, **kwargs):
+        calls.append(model)
+        return [True]
+
+    monkeypatch.setattr("scripts.leaderboard.evaluate_dataset", dummy)
+    results = asyncio.run(evaluate_models("d.jsonl"))
+    assert set(calls) == set(LanguageModelName)
+    assert set(results) == set(LanguageModelName)
+
+
+def test_evaluate_models_subset(monkeypatch):
+    calls = []
+
+    async def dummy(path: str, *, model: LanguageModelName, **kwargs):
+        calls.append(model)
+        return [True]
+
+    monkeypatch.setattr("scripts.leaderboard.evaluate_dataset", dummy)
+    models = [LanguageModelName.GPT_4O, LanguageModelName.GPT_4_1]
+    results = asyncio.run(evaluate_models("d.jsonl", models))
+    assert calls == models
+    assert set(results) == set(models)
+
+
+def test_run_leaderboard_prints_table(monkeypatch, capsys):
+    async def dummy_eval_models(*args, **kwargs):
+        return {LanguageModelName.GPT_4O: [True]}
+
+    monkeypatch.setattr("scripts.leaderboard.evaluate_models", dummy_eval_models)
+    monkeypatch.setattr("scripts.leaderboard.count_items", lambda x: 1)
+    monkeypatch.setattr(
+        "scripts.leaderboard.format_accuracy_table", lambda results, n: "TABLE"
+    )
+    args = argparse.Namespace(dataset="d.jsonl", seed=0, concurrency=1, cache=None)
+    asyncio.run(run_leaderboard(args))
+    captured = capsys.readouterr()
+    assert "TABLE" in captured.out
+
+
+def test_run_leaderboard_passes_args(monkeypatch):
+    passed = {}
+
+    async def dummy_eval_models(
+        dataset: str, *, seed: int, concurrency: int, cache=None, models=None
+    ):
+        passed.update(
+            {
+                "dataset": dataset,
+                "seed": seed,
+                "concurrency": concurrency,
+                "cache": cache,
+            }
+        )
+        return {LanguageModelName.GPT_4O: [True]}
+
+    monkeypatch.setattr("scripts.leaderboard.evaluate_models", dummy_eval_models)
+    monkeypatch.setattr("scripts.leaderboard.count_items", lambda x: 1)
+    monkeypatch.setattr(
+        "scripts.leaderboard.format_accuracy_table", lambda results, n: "TABLE"
+    )
+    args = argparse.Namespace(dataset="d.jsonl", seed=3, concurrency=7, cache="c")
+    asyncio.run(run_leaderboard(args))
+    assert passed["dataset"] == "d.jsonl"
+    assert passed["seed"] == 3
+    assert passed["concurrency"] == 7
+    assert isinstance(passed["cache"], LLMCache)
+
+
+def test_evaluate_models_passes_arguments(monkeypatch):
+    captured = {}
+
+    async def dummy(
+        path: str,
+        *,
+        model: LanguageModelName,
+        seed: int,
+        concurrency: int,
+        cache,
+        **kwargs,
+    ):
+        captured[model] = (seed, concurrency, cache)
+        return [True]
+
+    monkeypatch.setattr("scripts.leaderboard.evaluate_dataset", dummy)
+    cache = MockLLMCache()
+    asyncio.run(
+        evaluate_models(
+            "d.jsonl",
+            [LanguageModelName.GPT_4O],
+            seed=5,
+            concurrency=3,
+            cache=cache,
+        )
+    )
+    assert captured[LanguageModelName.GPT_4O] == (5, 3, cache)


### PR DESCRIPTION
## Summary
- add tests covering bullet variations and invalid cases in `parse_block_assignments`
- add tests for leaderboard formatting and argument propagation
- update evaluation scripts to split long lines for style compliance

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686829989798832aa3e541dfc4f60b3f