### PR TITLE
Add Grok API integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ require the ``openai`` package, which is installed when running ``pip install
 Support for the Anthropic API is also available.  Install the ``anthropic``
 package (version ``0.57.1`` or newer) and set ``ANTHROPIC_API_KEY`` to use models such as
 ``claude-3-sonnet-20240229`` or ``claude-3-opus-20240229``.
+Support for xAI Grok models is available as well. Install the ``xai-sdk``
+package and set ``XAI_API_KEY`` to authenticate when using models like
+``grok-3``.
 
 ``scripts/evaluate_random_combat_scenarios.py`` contacts the model to
 evaluate blocking assignments for randomly generated combat scenarios.  A

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "pydantic==2.7.1",
     "google-genai==1.24.0",
     "together==1.5.17",
+    "xai-sdk==1.0.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ pytest==7.4.0
 requests==2.31.0
 tabulate==0.9.0
 together==1.5.17
+xai-sdk==1.0.0
 types-requests==2.28.11.17
 types-tabulate==0.9.0.20241207
 typing_extensions==4.13.1

--- a/tests/llm/test_llm_models.py
+++ b/tests/llm/test_llm_models.py
@@ -6,6 +6,7 @@ from llms.llm import LanguageModelName
 from llms.llm import MockLanguageModel
 from llms.llm import OpenAILanguageModel
 from llms.llm import TogetherLanguageModel
+from llms.llm import XAILanguageModel
 from llms.llm import build_language_model
 from llms.llm_cache import MockLLMCache
 
@@ -36,6 +37,7 @@ def test_build_language_model_types(monkeypatch):
     monkeypatch.setattr("anthropic.AsyncAnthropic", lambda: object())
     monkeypatch.setattr("google.genai.Client", lambda: object())
     monkeypatch.setattr("together.AsyncTogether", lambda: object())
+    monkeypatch.setattr("llms.llm.XAIClient", lambda: object())
     assert isinstance(
         build_language_model(LanguageModelName.GPT_4O), OpenAILanguageModel
     )
@@ -48,3 +50,4 @@ def test_build_language_model_types(monkeypatch):
     assert isinstance(
         build_language_model(LanguageModelName.DEEPSEEK_R1), TogetherLanguageModel
     )
+    assert isinstance(build_language_model(LanguageModelName.GROK_3), XAILanguageModel)


### PR DESCRIPTION
## Summary
- add xai-sdk dependency
- document using Grok with XAI_API_KEY
- support Grok models in llm module
- test Grok build

## Testing
- `pycodestyle --max-line-length=88 --ignore=E203,W503,E226 --exclude=comprehensive_rules.py,tests,magic_combat/rules_text.py magic_combat scripts`
- `flake8 magic_combat scripts tests`
- `pylint magic_combat scripts tests >/tmp/pylint.log 2>&1 && tail -n 20 /tmp/pylint.log`
- `mypy magic_combat scripts tests >/tmp/mypy.log && tail -n 20 /tmp/mypy.log`
- `pyright magic_combat scripts tests >/tmp/pyright.log && tail -n 20 /tmp/pyright.log`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868d80d79f0832a850b5386fe994d0e