### PR TITLE
Add Elo rating scores to leaderboard

### DIFF
--- a/llms/llm.py
+++ b/llms/llm.py
@@ -199,12 +199,12 @@ class AnthropicLanguageModel(LanguageModel):
     ) -> str:
         thinking = self.model.value.endswith("-thinking")
         thinking_type = "enabled" if thinking else "disabled"
-        response = await self.client.messages.create(
+        response = await self.client.messages.create(  # type: ignore[call-overload]
             model=self.model.value.removesuffix("-thinking"),
             messages=[{"role": "user", "content": prompt}],
             temperature=temperature,
             max_tokens=max_tokens,
-            thinking={"type": thinking_type, "budget_tokens": int(max_tokens/2)},
+            thinking={"type": thinking_type, "budget_tokens": int(max_tokens / 2)},
         )
         return "".join(getattr(b, "text", "") for b in response.content).strip()
 

--- a/scripts/evaluate_llm_accuracy.py
+++ b/scripts/evaluate_llm_accuracy.py
@@ -10,7 +10,8 @@ from typing import cast
 from typing import overload
 
 from llms.create_llm_prompt import parse_block_assignments
-from llms.llm import LanguageModelName, LanguageModel
+from llms.llm import LanguageModel
+from llms.llm import LanguageModelName
 from llms.llm import build_language_model
 from llms.llm import get_default_temperature
 from llms.llm_cache import LLMCache
@@ -46,48 +47,6 @@ async def evaluate_dataset(
     ...
 
 
-async def evaluate_single_item(
-    idx: int,
-    item: dict[str, Any],
-    *,
-    model: LanguageModelName = LanguageModelName.GPT_4O,
-    seed: int = 0,
-    semaphore: asyncio.Semaphore,
-    llm: LanguageModel,
-    temperature: float = 1.0,
-    max_attempts=3
-):
-    prompt = cast(str, item["prompt"])
-    ref_data = cast(dict[str, str], item["answer"])
-    ref = ReferenceAnswer.model_validate(ref_data)
-    blk_names = ref.blocks.keys()
-    atk_names = ref.blocks.values()
-    parsed = None
-    for attempt in range(max_attempts):
-        try:
-            async with semaphore:
-                print(f"Calling model {model} for scenario {idx + 1} (attempt {attempt + 1})")
-                response = await llm.call(
-                    prompt,
-                    temperature=temperature,
-                    seed=seed + attempt,
-                )
-                print(f"Response for scenario {idx + 1}, attempt {attempt + 1}")
-
-            parsed, _ = parse_block_assignments(response, blk_names, atk_names)
-            break
-        except UnparsableLLMOutputError as exc:
-            print(
-                f"Unparseable response for model {model} on scenario {idx + 1}; retrying..."
-            )
-        except Exception as exc:  # pragma: no cover - network failure
-            print(f"Error calling model {model}: {exc}")
-            break
-    if parsed is None:
-        return False
-    pred = ReferenceAnswer(blocks=parsed)
-    return pred == ref
-
 async def evaluate_dataset(
     path: str,
     *,
@@ -111,25 +70,74 @@ async def evaluate_dataset(
     semaphore = asyncio.Semaphore(concurrency)
     llm = build_language_model(model, cache=cache, verbose=verbose)
 
-    results: List[bool] = await asyncio.gather(*[
-        evaluate_single_item(
-            idx,
-            item,
-            model=model,
-            seed=seed,
-            semaphore=semaphore,
-            llm=llm,
-            temperature=temperature,
-        )
-        for idx, item in enumerate(items)
-    ])
-
+    results: List[bool] = await asyncio.gather(
+        *[
+            evaluate_single_item(
+                idx,
+                item,
+                model=model,
+                seed=seed,
+                semaphore=semaphore,
+                llm=llm,
+                temperature=temperature,
+            )
+            for idx, item in enumerate(items)
+        ]
+    )
 
     if return_item_results:
         return results
 
     correct = sum(results)
     return correct / len(results) if results else 0.0
+
+
+async def evaluate_single_item(
+    idx: int,
+    item: dict[str, Any],
+    *,
+    model: LanguageModelName = LanguageModelName.GPT_4O,
+    seed: int = 0,
+    semaphore: asyncio.Semaphore,
+    llm: LanguageModel,
+    temperature: float = 1.0,
+    max_attempts=3,
+) -> bool:
+    """Return ``True`` if ``llm`` answers ``item`` correctly."""
+    prompt = cast(str, item["prompt"])
+    ref_data = cast(dict[str, str], item["answer"])
+    ref = ReferenceAnswer.model_validate(ref_data)
+    blk_names = ref.blocks.keys()
+    atk_names = ref.blocks.values()
+    parsed = None
+    for attempt in range(max_attempts):
+        try:
+            async with semaphore:
+                print(
+                    f"Calling model {model} for scenario {idx + 1} "
+                    f"(attempt {attempt + 1})"
+                )
+                response = await llm.call(
+                    prompt,
+                    temperature=temperature,
+                    seed=seed + attempt,
+                )
+                print(f"Response for scenario {idx + 1}, " f"attempt {attempt + 1}")
+
+            parsed, _ = parse_block_assignments(response, blk_names, atk_names)
+            break
+        except UnparsableLLMOutputError:
+            print(
+                f"Unparseable response for model {model} on scenario "
+                f"{idx + 1}; retrying..."
+            )
+        except Exception as exc:  # pragma: no cover - network failure
+            print(f"Error calling model {model}: {exc}")
+            break
+    if parsed is None:
+        return False
+    pred = ReferenceAnswer(blocks=parsed)
+    return pred == ref
 
 
 def main() -> None:

--- a/tests/llm/test_leaderboard.py
+++ b/tests/llm/test_leaderboard.py
@@ -1,9 +1,11 @@
 import asyncio
 
 from llms.llm import LanguageModelName
+from scripts.leaderboard import compute_elo_ratings
 from scripts.leaderboard import count_items
 from scripts.leaderboard import evaluate_models
 from scripts.leaderboard import format_accuracy_table
+from scripts.leaderboard import format_elo_table
 from scripts.leaderboard import format_pvalue_table
 from scripts.leaderboard import standard_error
 from scripts.leaderboard import two_proportion_p_value
@@ -65,3 +67,28 @@ def test_format_pvalue_table():
     }
     table = format_pvalue_table(res)
     assert LanguageModelName.GPT_4O.value in table
+
+
+def test_compute_elo_ratings():
+    res = {
+        LanguageModelName.GPT_4O: [True, True],
+        LanguageModelName.GPT_4_1: [True, False],
+        LanguageModelName.O3: [False, False],
+    }
+    ratings = compute_elo_ratings(res)
+    assert (
+        ratings[LanguageModelName.GPT_4O]
+        > ratings[LanguageModelName.GPT_4_1]
+        > ratings[LanguageModelName.O3]
+    )
+
+
+def test_format_elo_table():
+    res = {
+        LanguageModelName.GPT_4O: [True, True],
+        LanguageModelName.GPT_4_1: [True, False],
+        LanguageModelName.O3: [False, False],
+    }
+    ratings = compute_elo_ratings(res)
+    table = format_elo_table(ratings)
+    assert "Elo" in table and LanguageModelName.GPT_4O.value in table


### PR DESCRIPTION
## Summary
- implement `compute_elo_ratings` and `format_elo_table`
- extend leaderboard script to show Elo ratings
- fix mypy complaints and adjust helper location in evaluate_llm_accuracy
- test Elo rating functions

## Testing
- `isort --profile black magic_combat scripts tests`
- `black magic_combat scripts tests`
- `autoflake --check --recursive magic_combat scripts tests`
- `flake8 magic_combat scripts tests`
- `pycodestyle --max-line-length=88 --ignore=E203,W503,E226 --exclude=comprehensive_rules.py,tests,magic_combat/rules_text.py magic_combat scripts`
- `pylint magic_combat scripts tests`
- `mypy magic_combat scripts tests`
- `pyright magic_combat scripts tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869f7d4f590832a8968f9f46d97256d