### PR TITLE
Add score tracking to dataset and leaderboard

### DIFF
--- a/llms/llm.py
+++ b/llms/llm.py
@@ -1,4 +1,3 @@
-import os
 from abc import ABC
 from abc import abstractmethod
 from enum import Enum
@@ -206,7 +205,10 @@ class AnthropicLanguageModel(LanguageModel):
             messages=[{"role": "user", "content": prompt}],
             temperature=temperature,
             max_tokens=max_tokens,
-            thinking={"type": thinking_type, "budget_tokens": int(max_tokens / 2)},
+            thinking={
+                "type": thinking_type,
+                "budget_tokens": int(max_tokens / 2),
+            },  # pyright: ignore[reportArgumentType]
         )
         return "".join(getattr(b, "text", "") for b in response.content).strip()
 

--- a/magic_combat/__init__.py
+++ b/magic_combat/__init__.py
@@ -32,6 +32,8 @@ from .random_scenario import generate_random_scenario
 from .random_scenario import sample_balanced
 from .rules_text import RULES_TEXT
 from .rules_text import get_relevant_rules_text
+from .scoring import AGGREGATE_WEIGHTS
+from .scoring import compute_aggregate_score
 from .scryfall_loader import card_to_creature
 from .scryfall_loader import cards_to_creatures
 from .scryfall_loader import fetch_french_vanilla_cards
@@ -101,4 +103,6 @@ __all__ = [
     "decode_provoke",
     "decode_mentor",
     "ReferenceAnswer",
+    "compute_aggregate_score",
+    "AGGREGATE_WEIGHTS",
 ]

--- a/magic_combat/scoring.py
+++ b/magic_combat/scoring.py
@@ -1,0 +1,28 @@
+"""Helpers for computing aggregate combat scores."""
+
+from __future__ import annotations
+
+from typing import Iterable
+from typing import Tuple
+
+AGGREGATE_WEIGHTS: Tuple[float, float, float, float, float, float] = (
+    20.0,  # losing the game outweighs everything else
+    1.0,  # creature value difference
+    2.0,  # creature count difference
+    1.0,  # mana value difference
+    0.5,  # life total difference (up to ~20)
+    2.0,  # poison counter difference (up to 10)
+)
+
+
+def compute_aggregate_score(
+    score_vec: Iterable[float | int],
+    best_score: Iterable[float | int],
+    weights: Iterable[float] = AGGREGATE_WEIGHTS,
+) -> float:
+    """Return weighted aggregate difference between ``score_vec`` and ``best_score``."""
+
+    diff = [
+        w * abs(float(s) - float(b)) for s, b, w in zip(score_vec, best_score, weights)
+    ]
+    return -sum(diff)

--- a/scripts/create_dataset.py
+++ b/scripts/create_dataset.py
@@ -24,6 +24,7 @@ from magic_combat.blocking_ai import (
 )
 from magic_combat.dataset import ReferenceAnswer
 from magic_combat.limits import IterationCounter
+from magic_combat.scoring import compute_aggregate_score
 from magic_combat.text_utils import summarize_creature
 
 
@@ -130,10 +131,7 @@ def main() -> None:
                     int(sc["life_diff"]),
                     int(sc["poison_diff"]),
                 )
-                aggregate = -sum(
-                    abs(float(s) - float(b)) for s, b in zip(score_vec, best_score)
-                )
-                data["aggregate"] = aggregate
+                data["aggregate"] = compute_aggregate_score(score_vec, best_score)
 
         items.append(
             {

--- a/tests/core/test_scoring.py
+++ b/tests/core/test_scoring.py
@@ -1,0 +1,67 @@
+from magic_combat import CombatCreature
+from magic_combat import GameState
+from magic_combat import PlayerState
+from magic_combat import decide_optimal_blocks
+from magic_combat.block_utils import evaluate_block_assignment
+from magic_combat.blocking_ai import _get_all_assignments
+from magic_combat.blocking_ai import _get_block_options
+from magic_combat.limits import IterationCounter
+from magic_combat.scoring import AGGREGATE_WEIGHTS
+from magic_combat.scoring import compute_aggregate_score
+
+
+def test_compute_aggregate_score_vector():
+    best = (0, 0.0, 0, 0, 0, 0)
+    vec = (0, 5.0, 1, 2, 10, 3)
+    expected = -sum(
+        w * abs(float(s) - float(b)) for w, s, b in zip(AGGREGATE_WEIGHTS, vec, best)
+    )
+    assert compute_aggregate_score(vec, best) == expected
+
+
+def test_optimal_assignment_zero_aggregate():
+    """CR 509.1a: The defending player chooses how creatures block."""
+    atk1 = CombatCreature("A1", 3, 3, "A")
+    atk2 = CombatCreature("A2", 2, 2, "A")
+    blk = CombatCreature("B", 3, 3, "B")
+    state = GameState(
+        players={
+            "A": PlayerState(life=20, creatures=[atk1, atk2]),
+            "B": PlayerState(life=20, creatures=[blk]),
+        }
+    )
+
+    attackers = list(state.players["A"].creatures)
+    blockers = list(state.players["B"].creatures)
+    options = _get_block_options(state, None)
+    assignments = _get_all_assignments(options)
+
+    score_map = {}
+    best_vec = None
+    for ass in assignments:
+        blk_map = {
+            blockers[i]: attackers[a] for i, a in enumerate(ass) if a is not None
+        }
+        result, _ = evaluate_block_assignment(blk_map, state, IterationCounter(10))
+        if result is None:
+            continue
+        vec = result.score("A", "B")
+        score_map[ass] = vec
+        if best_vec is None or vec < best_vec:
+            best_vec = vec
+
+    assert best_vec is not None
+
+    # compute aggregates
+    aggregates = {
+        ass: compute_aggregate_score(vec, best_vec) for ass, vec in score_map.items()
+    }
+
+    # Optimal AI assignment should have zero aggregate
+    top, _ = decide_optimal_blocks(game_state=state)
+    ai_assignment = top[0][1]
+    assert aggregates[ai_assignment] == 0
+    # All other assignments must be negative
+    for ass, agg in aggregates.items():
+        if ass != ai_assignment:
+            assert agg < 0

--- a/tests/llm/test_llm_accuracy.py
+++ b/tests/llm/test_llm_accuracy.py
@@ -47,7 +47,7 @@ def test_evaluate_dataset_return_results(monkeypatch, tmp_path):
             fh.write(json.dumps(item) + "\n")
 
     _patch_build(monkeypatch, ["- B -> A", "None"])
-    results = asyncio.run(
+    results, losses = asyncio.run(
         evaluate_dataset(
             str(data_path),
             model=LanguageModelName.GPT_4O,
@@ -56,6 +56,7 @@ def test_evaluate_dataset_return_results(monkeypatch, tmp_path):
         )
     )
     assert results == [True, True]
+    assert losses == [0.0, 0.0]
 
 
 def test_evaluate_dataset_unparsable(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- enrich dataset creation with full block assignment scoring
- compute value lost when evaluating LLM output
- display value lost column in leaderboard
- adjust tests for new API

## Testing
- `isort --profile black **/*.py`
- `black **/*.py`
- `autoflake --in-place --remove-unused-variables --remove-all-unused-imports -r .`
- `flake8`
- `pycodestyle --max-line-length=88 --ignore=E203,W503,E226 --exclude=comprehensive_rules.py,tests,magic_combat/rules_text.py magic_combat scripts`
- `pylint magic_combat scripts`
- `mypy`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ad687c1b4832a9507a5bd12b4636a