### PR TITLE
Add per-model max token settings

### DIFF
--- a/llms/llm.py
+++ b/llms/llm.py
@@ -1,4 +1,3 @@
-import os
 from abc import ABC
 from abc import abstractmethod
 from enum import Enum
@@ -206,7 +205,10 @@ class AnthropicLanguageModel(LanguageModel):
             messages=[{"role": "user", "content": prompt}],
             temperature=temperature,
             max_tokens=max_tokens,
-            thinking={"type": thinking_type, "budget_tokens": int(max_tokens / 2)},
+            thinking={
+                "type": thinking_type,
+                "budget_tokens": int(max_tokens / 2),
+            },  # pyright: ignore[reportArgumentType]
         )
         return "".join(getattr(b, "text", "") for b in response.content).strip()
 
@@ -308,6 +310,30 @@ class MockLanguageModel(LanguageModel):
         return response
 
 
+_MAX_TOKENS_BY_MODEL_NAME: dict[LanguageModelName, int] = {
+    LanguageModelName.GROK_3_MINI: 32768,
+    LanguageModelName.GEMINI_2_5_PRO: 8192,
+    LanguageModelName.GEMINI_2_5_FLASH: 8192,
+    LanguageModelName.GEMINI_2_0_FLASH: 8192,
+    LanguageModelName.GPT_4O: 8192,
+    LanguageModelName.GPT_4_1: 8192,
+    LanguageModelName.O4_MINI: 8192,
+    LanguageModelName.O3: 8192,
+    LanguageModelName.O3_PRO: 8192,
+    LanguageModelName.CLAUDE_3_7_SONNET: 8192,
+    LanguageModelName.CLAUDE_3_5_SONNET: 8192,
+    LanguageModelName.CLAUDE_4_SONNET: 8192,
+    LanguageModelName.CLAUDE_4_OPUS: 8192,
+    LanguageModelName.CLAUDE_4_SONNET_THINKING: 8192,
+    LanguageModelName.CLAUDE_4_OPUS_THINKING: 8192,
+    LanguageModelName.DEEPSEEK_R1: 8192,
+    LanguageModelName.LLAMA_4_MAVERICK: 8192,
+    LanguageModelName.LLAMA_4_SCOUT: 8192,
+    LanguageModelName.GROK_3: 8192,
+    LanguageModelName.QWEN_3_235B: 8192,
+}
+
+
 _MODEL_CLASS_BY_NAME: dict[LanguageModelName, type[LanguageModel]] = {
     LanguageModelName.GEMINI_2_5_PRO: GeminiLanguageModel,
     LanguageModelName.GEMINI_2_5_FLASH: GeminiLanguageModel,
@@ -342,4 +368,5 @@ def build_language_model(
     if model not in _MODEL_CLASS_BY_NAME:
         raise ValueError(f"Unsupported model: {model}")
     cls = _MODEL_CLASS_BY_NAME[model]
-    return cls(model, cache=cache, verbose=verbose)
+    max_tokens = _MAX_TOKENS_BY_MODEL_NAME.get(model, 8192)
+    return cls(model, cache=cache, verbose=verbose, max_tokens=max_tokens)

--- a/tests/llm/test_llm_models.py
+++ b/tests/llm/test_llm_models.py
@@ -51,3 +51,13 @@ def test_build_language_model_types(monkeypatch):
         build_language_model(LanguageModelName.DEEPSEEK_R1), TogetherLanguageModel
     )
     assert isinstance(build_language_model(LanguageModelName.GROK_3), XAILanguageModel)
+
+
+def test_build_language_model_max_tokens(monkeypatch):
+    monkeypatch.setattr("openai.AsyncOpenAI", lambda: object())
+    monkeypatch.setattr("anthropic.AsyncAnthropic", lambda: object())
+    monkeypatch.setattr("google.genai.Client", lambda: object())
+    monkeypatch.setattr("together.AsyncTogether", lambda: object())
+    monkeypatch.setattr("llms.llm.XAIClient", lambda: object())
+    llm = build_language_model(LanguageModelName.GROK_3_MINI)
+    assert llm.max_tokens == 32768


### PR DESCRIPTION
## Summary
- maintain token budgets in `_MAX_TOKENS_BY_MODEL_NAME`
- use that mapping when building a language model
- test that token budget is passed to the model

## Testing
- `isort --profile black .`
- `black .`
- `autoflake --in-place --remove-unused-variables --remove-all-unused-imports -r .`
- `flake8 .`
- `pycodestyle --max-line-length=88 --ignore=E203,W503,E226 --exclude=comprehensive_rules.py,tests,magic_combat/rules_text.py magic_combat scripts`
- `pylint llms tests`
- `mypy`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b437e4970832abe9bb9d13da71883