### PR TITLE
Refactor leaderboard to evaluate models concurrently

### DIFF
--- a/scripts/evaluate_llm_accuracy.py
+++ b/scripts/evaluate_llm_accuracy.py
@@ -69,7 +69,9 @@ async def evaluate_dataset(
 
     temperature = get_default_temperature(model)
     semaphore = asyncio.Semaphore(concurrency)
-    llm = build_language_model(model, cache=cache, verbose=verbose)
+    llm = build_language_model(
+        model, cache=cache, verbose=verbose, api_concurrency=concurrency
+    )
 
     results: List[Tuple[bool, float]] = await asyncio.gather(
         *[
@@ -115,6 +117,7 @@ async def evaluate_single_item(
     blk_names = ref.blocks.keys()
     atk_names = ref.blocks.values()
     parsed = None
+    response = ""
     for attempt in range(max_attempts):
         try:
             async with semaphore:

--- a/tests/llm/test_llm_accuracy.py
+++ b/tests/llm/test_llm_accuracy.py
@@ -13,7 +13,7 @@ def _patch_build(monkeypatch, responses):
     llm = MockLanguageModel(responses, cache=MockLLMCache())
     monkeypatch.setattr(
         "scripts.evaluate_llm_accuracy.build_language_model",
-        lambda model, cache=None, verbose=False: llm,
+        lambda model, cache=None, verbose=False, api_concurrency=50: llm,
     )
     return llm
 


### PR DESCRIPTION
## Summary
- allow building language models with a shared API semaphore
- cap concurrent API calls per provider using shared semaphore
- evaluate multiple models concurrently in leaderboard generation
- update tests for new build_language_model signature
- fix potential unbound variable warning in LLM evaluation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b5ca14e68832a82ff702cedcbcb1c