### PR TITLE
Add value loss error bars on leaderboard

### DIFF
--- a/scripts/create_dataset.py
+++ b/scripts/create_dataset.py
@@ -11,7 +11,8 @@ from typing import cast
 import numpy as np
 
 from llms.create_llm_prompt import create_llm_prompt
-from magic_combat import build_value_map, IllegalBlockError
+from magic_combat import IllegalBlockError
+from magic_combat import build_value_map
 from magic_combat import compute_card_statistics
 from magic_combat import generate_random_scenario
 from magic_combat import load_cards

--- a/tests/llm/test_leaderboard.py
+++ b/tests/llm/test_leaderboard.py
@@ -9,6 +9,7 @@ from scripts.leaderboard import format_elo_table
 from scripts.leaderboard import format_leaderboard_table
 from scripts.leaderboard import format_pvalue_table
 from scripts.leaderboard import standard_error
+from scripts.leaderboard import standard_error_mean
 from scripts.leaderboard import two_proportion_p_value
 
 
@@ -61,8 +62,12 @@ def test_format_leaderboard_table():
     ratings = compute_elo_ratings(res)
     err = compute_elo_error_bars(res, reps=5, seed=0)
     loss = {LanguageModelName.GPT_4O: -0.5, LanguageModelName.GPT_4_1: 0.0}
-    table = format_leaderboard_table(res, 2, ratings, err, loss)
-    assert "Model" in table and "Elo" in table
+    loss_err = {
+        LanguageModelName.GPT_4O: standard_error_mean([0.0, -1.0]),
+        LanguageModelName.GPT_4_1: standard_error_mean([0.0, 0.0]),
+    }
+    table = format_leaderboard_table(res, 2, ratings, err, loss, loss_err)
+    assert "Model" in table and "Elo" in table and "±" in table
 
 
 def test_format_pvalue_table():

--- a/tests/llm/test_llm_models.py
+++ b/tests/llm/test_llm_models.py
@@ -60,4 +60,4 @@ def test_build_language_model_max_tokens(monkeypatch):
     monkeypatch.setattr("together.AsyncTogether", lambda: object())
     monkeypatch.setattr("llms.llm.XAIClient", lambda: object())
     llm = build_language_model(LanguageModelName.GROK_3_MINI)
-    assert llm.max_tokens == 32768
+    assert llm.max_tokens == 131072


### PR DESCRIPTION
## Summary
- compute standard error for the mean to display value loss error bars
- display ± error bars for value lost in leaderboard
- include value loss error bars when generating leaderboard
- fix expected max tokens for Grok-3 mini in tests
- style fixes from isort

## Testing
- `isort --profile black $(git ls-files '*.py')`
- `black $(git ls-files '*.py')`
- `autoflake --in-place --remove-unused-variables --remove-all-unused-imports $(git ls-files '*.py')`
- `flake8`
- `pycodestyle --max-line-length=88 --ignore=E203,W503,E226 --exclude=comprehensive_rules.py,tests,magic_combat/rules_text.py magic_combat scripts`
- `pylint scripts/leaderboard.py scripts/create_dataset.py tests/llm/test_leaderboard.py tests/llm/test_llm_models.py | tail -n 20`
- `mypy scripts/leaderboard.py scripts/create_dataset.py tests/llm/test_leaderboard.py tests/llm/test_llm_models.py`
- `pyright scripts/leaderboard.py scripts/create_dataset.py tests/llm/test_leaderboard.py tests/llm/test_llm_models.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b6d46d3d8832ab7e7f488cd4f7503